### PR TITLE
Runcommand Plugin: make the runcommand plugin more secure by default

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -21,7 +21,6 @@
         "--system-talk-name=org.freedesktop.UPower",
         "--talk-name=org.a11y.Bus",
         "--talk-name=org.freedesktop.DBus",
-        "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gnome.evolution.dataserver.AddressBook10",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
         "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",

--- a/src/plugins/runcommand/ca.andyholmes.valent.runcommand.gschema.xml
+++ b/src/plugins/runcommand/ca.andyholmes.valent.runcommand.gschema.xml
@@ -4,5 +4,10 @@
     <key name="commands" type="a{sv}">
       <default>{}</default>
     </key>
+    <key name="isolate-subprocesses" type="b">
+      <default>true</default>
+      <summary>Isolate Subprocesses</summary>
+      <description>Execute commands in a sandbox</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/plugins/runcommand/meson.build
+++ b/src/plugins/runcommand/meson.build
@@ -11,6 +11,7 @@ plugin_runcommand_sources = files([
   'valent-runcommand-plugin.c',
   'valent-runcommand-preferences.c',
   'valent-runcommand-editor.c',
+  'valent-runcommand-utils.c',
 ])
 
 plugin_runcommand_include_directories = [include_directories('.')]

--- a/src/plugins/runcommand/valent-runcommand-preferences.ui
+++ b/src/plugins/runcommand/valent-runcommand-preferences.ui
@@ -5,7 +5,7 @@
     <child>
       <object class="AdwPreferencesGroup" id="command_group">
         <property name="title" translatable="yes">Commands</property>
-        <property name="description" translatable="yes">Predefined commands that can be executed.</property>
+        <property name="description" translatable="yes">Define commands that can be executed by the remote device.</property>
         <child>
           <object class="GtkFrame">
             <child>
@@ -44,6 +44,26 @@
                     </child>
                   </object>
                 </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup" id="restrictions_group">
+        <property name="title" translatable="yes">Restrictions</property>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title">Isolate Subprocesses</property>
+            <property name="subtitle">Execute commands in a sandbox</property>
+            <child type="suffix">
+              <object class="GtkSwitch" id="isolate_subprocesses">
+                <property name="valign">center</property>
+                <signal name="state-set"
+                        handler="on_isolate_subprocesses_changed"
+                        object="ValentRuncommandPreferences"
+                        swapped="no"/>
               </object>
             </child>
           </object>

--- a/src/plugins/runcommand/valent-runcommand-utils.c
+++ b/src/plugins/runcommand/valent-runcommand-utils.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#define G_LOG_DOMAIN "valent-runcommand-utils"
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <libvalent-core.h>
+
+#include "valent-runcommand-utils.h"
+
+
+/**
+ * valent_runcommand_can_spawn_host:
+ *
+ * Check if subprocesses can be spawned on the host system.
+ *
+ * Returns: %TRUE if available, %FALSE otherwise.
+ */
+gboolean
+valent_runcommand_can_spawn_host (void)
+{
+  static int host = -1;
+
+  if (host != -1)
+    return host;
+
+  host = TRUE;
+
+  if (valent_in_flatpak ())
+    {
+      int status = 0;
+
+      g_spawn_command_line_sync ("flatpak-spawn --host echo",
+                                 NULL, NULL, &status, NULL);
+      host = g_spawn_check_exit_status (status, NULL);
+    }
+
+  return host;
+}
+
+/**
+ * valent_runcommand_can_spawn_sandbox:
+ *
+ * Check if `flatpak-spawn` can be found in `PATH`.
+ *
+ * Returns: %TRUE if available, %FALSE otherwise.
+ */
+gboolean
+valent_runcommand_can_spawn_sandbox (void)
+{
+  static int sandbox = -1;
+  g_autofree char *path = NULL;
+
+  if (sandbox != -1)
+    return sandbox;
+
+  if ((path = g_find_program_in_path ("flatpak-spawn")) == NULL)
+    sandbox = FALSE;
+  else
+    sandbox = TRUE;
+
+  return sandbox;
+}
+

--- a/src/plugins/runcommand/valent-runcommand-utils.h
+++ b/src/plugins/runcommand/valent-runcommand-utils.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+gboolean   valent_runcommand_can_spawn_host    (void);
+gboolean   valent_runcommand_can_spawn_sandbox (void);
+
+G_END_DECLS
+


### PR DESCRIPTION
Drop the `--talk=org.freedesktop.Flatpak` permission and default to
executing commands with `flatpak-spawn` when available.

Flatpak users will have to manually poke a hole in the sandbox to
execute commands on the host and all users will have to disable the
`isolate-subprocesses` setting, which comes with a warning.

This is more inconvenient for the common use-case of the plugin, which
typically involves running commands on the host, but it prevents user
plugins from arbitrarily executing commands on the host for flatpak
users.