### PR TITLE
tests: add basic smoke tests for plugin preferences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
                 -Dtests=true \
                 _build
           meson compile -C _build
+          xvfb-run -a -s "-screen 0 1024x768x24" \
           dbus-run-session -- \
           meson test -C _build \
                      --print-errorlogs \
@@ -52,6 +53,7 @@ jobs:
                 -Dtests=true \
                 _build
           meson compile -C _build
+          xvfb-run -a -s "-screen 0 1024x768x24" \
           dbus-run-session -- \
           meson test -C _build \
                      --print-errorlogs \

--- a/src/plugins/notification/valent-notification-preferences.c
+++ b/src/plugins/notification/valent-notification-preferences.c
@@ -97,7 +97,7 @@ add_application (ValentNotificationPreferences *self,
   g_autoptr (GVariant) iconv = NULL;
   g_autoptr (GIcon) icon = NULL;
 
-  if (!g_variant_lookup (app, "name", "s", &title))
+  if (!g_variant_lookup (app, "name", "&s", &title))
     return;
 
   row = g_object_new (ADW_TYPE_ACTION_ROW,

--- a/src/tests/extra/lsan.supp
+++ b/src/tests/extra/lsan.supp
@@ -13,3 +13,6 @@ leak:gst_gio_src_query
 # GStreamer?
 leak:g_quark_init
 
+# libpeas-loader-python3
+leak:libpython3.9
+

--- a/src/tests/fixtures/meson.build
+++ b/src/tests/fixtures/meson.build
@@ -63,6 +63,7 @@ libvalent_test_deps = [
   libvalent_mixer_dep,
   libvalent_notifications_dep,
   libvalent_power_dep,
+  libvalent_ui_dep,
 ]
 
 

--- a/src/tests/fixtures/valent-test-utils.c
+++ b/src/tests/fixtures/valent-test-utils.c
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
 
+#include <locale.h>
 #include <stdio.h>
+#include <gtk/gtk.h>
+#include <adwaita.h>
 #include <json-glib/json-glib.h>
 #include <libvalent-core.h>
+#include <libvalent-ui.h>
 
 #include "valent-test-channel.h"
 #include "valent-test-utils.h"
@@ -467,5 +471,37 @@ valent_test_upload (ValentChannel  *channel,
   g_main_loop_run (op->loop);
 
   return op->success;
+}
+
+/**
+ * valent_test_ui_init:
+ * @argcp: Address of the `argc` parameter of the
+ *        main() function. Changed if any arguments were handled.
+ * @argvp: (inout) (array length=argcp): Address of the
+ *        `argv` parameter of main().
+ *        Any parameters understood by g_test_init() or gtk_init() are
+ *        stripped before return.
+ * @...: currently unused
+ *
+ * This function is used to initialize a GUI test program.
+ *
+ * It calls g_test_init(), gtk_init() and adw_init() to initialize the testing
+ * framework and graphical toolkit for Valent. It’ll also set the program’s
+ * locale to “C”.
+ *
+ * Like gtk_init() and g_test_init(), any known arguments will be processed and
+ * stripped from @argc and @argv.
+ */
+void
+valent_test_ui_init(int    *argcp,
+                    char ***argvp,
+                    ...)
+{
+  g_test_init (argcp, argvp, NULL);
+  gtk_disable_setlocale ();
+  setlocale (LC_ALL, "en_US.UTF-8");
+
+  gtk_init ();
+  adw_init ();
 }
 

--- a/src/tests/fixtures/valent-test-utils.h
+++ b/src/tests/fixtures/valent-test-utils.h
@@ -13,6 +13,10 @@
 
 G_BEGIN_DECLS
 
+void             valent_test_ui_init      (int    *argcp,
+                                           char ***argvp,
+                                           ...);
+
 gboolean         valent_test_mute_domain  (const char     *log_domain,
                                            GLogLevelFlags  log_level,
                                            const char     *message,
@@ -58,8 +62,8 @@ gboolean         valent_test_upload       (ValentChannel  *channel,
  * v_assert_object_finalize:
  * @object: (type GObject.Object): a #GObject
  *
- * Iterate the main context until the reference count of @object reaches zero, before asserting
- * its finalization.
+ * Iterate the main context until the reference count of @object reaches zero,
+ * before asserting its finalization.
  */
 static inline void
 (v_assert_finalize_object) (GObject *object)
@@ -215,3 +219,4 @@ static inline void
   } G_STMT_END
 
 G_END_DECLS
+

--- a/src/tests/plugins/battery/meson.build
+++ b/src/tests/plugins/battery/meson.build
@@ -6,18 +6,26 @@ plugin_battery_test_deps = [
   plugin_battery_deps,
 ]
 
-test_program = executable('test-battery-plugin',
-                          'test-battery-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_battery_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_battery],
-)
+plugin_battery_tests = [
+  'test-battery-plugin',
+  'test-battery-preferences',
+]
 
-test('test-battery-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_battery_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_battery_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_battery],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/battery/test-battery-preferences.c
+++ b/src/tests/plugins/battery/test-battery-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_battery_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "battery");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/battery/preferences",
+                   test_battery_plugin_preferences);
+
+  return g_test_run ();
+}
+

--- a/src/tests/plugins/clipboard/meson.build
+++ b/src/tests/plugins/clipboard/meson.build
@@ -6,18 +6,26 @@ plugin_clipboard_test_deps = [
   plugin_clipboard_deps,
 ]
 
-test_program = executable('test-clipboard-plugin',
-                          'test-clipboard-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_clipboard_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_clipboard],
-)
+plugin_clipboard_tests = [
+  'test-clipboard-plugin',
+  'test-clipboard-preferences',
+]
 
-test('test-clipboard-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_clipboard_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_clipboard_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_clipboard],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/clipboard/test-clipboard-preferences.c
+++ b/src/tests/plugins/clipboard/test-clipboard-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_clipboard_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "clipboard");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/clipboard/preferences",
+                   test_clipboard_plugin_preferences);
+
+  return g_test_run ();
+}
+

--- a/src/tests/plugins/contacts/meson.build
+++ b/src/tests/plugins/contacts/meson.build
@@ -6,18 +6,26 @@ plugin_contacts_test_deps = [
   plugin_contacts_deps,
 ]
 
-test_program = executable('test-contacts-plugin',
-                          'test-contacts-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_contacts_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_contacts],
-)
+plugin_contacts_tests = [
+  'test-contacts-plugin',
+  'test-contacts-preferences',
+]
 
-test('test-contacts-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_contacts_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_contacts_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_contacts],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/contacts/test-contacts-preferences.c
+++ b/src/tests/plugins/contacts/test-contacts-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_contacts_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "contacts");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/contacts/preferences",
+                   test_contacts_plugin_preferences);
+
+  return g_test_run ();
+}
+

--- a/src/tests/plugins/notification/meson.build
+++ b/src/tests/plugins/notification/meson.build
@@ -6,18 +6,26 @@ plugin_notification_test_deps = [
   plugin_notification_deps,
 ]
 
-test_program = executable('test-notification-plugin',
-                          'test-notification-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_notification_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_notification],
-)
+plugin_notification_tests = [
+  'test-notification-plugin',
+  'test-notification-preferences',
+]
 
-test('test-notification-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_notification_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_notification_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_notification],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/notification/test-notification-preferences.c
+++ b/src/tests/plugins/notification/test-notification-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_notification_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "notification");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/notification/preferences",
+                   test_notification_plugin_preferences);
+
+  return g_test_run ();
+}
+

--- a/src/tests/plugins/runcommand/meson.build
+++ b/src/tests/plugins/runcommand/meson.build
@@ -6,18 +6,26 @@ plugin_runcommand_test_deps = [
   plugin_runcommand_deps,
 ]
 
-test_program = executable('test-runcommand-plugin',
-                          'test-runcommand-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_runcommand_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_runcommand],
-)
+plugin_runcommand_tests = [
+  'test-runcommand-plugin',
+  'test-runcommand-preferences',
+]
 
-test('test-runcommand-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_runcommand_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_runcommand_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_runcommand],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/runcommand/test-runcommand-preferences.c
+++ b/src/tests/plugins/runcommand/test-runcommand-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_runcommand_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "runcommand");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/runcommand/preferences",
+                   test_runcommand_plugin_preferences);
+
+  return g_test_run ();
+}
+

--- a/src/tests/plugins/telephony/meson.build
+++ b/src/tests/plugins/telephony/meson.build
@@ -6,18 +6,26 @@ plugin_telephony_test_deps = [
   plugin_telephony_deps,
 ]
 
-test_program = executable('test-telephony-plugin',
-                          'test-telephony-plugin.c',
-        c_args: test_c_args,
-  dependencies: plugin_telephony_test_deps,
-     link_args: test_link_args,
-    link_whole: [libvalent_test, plugin_telephony],
-)
+plugin_telephony_tests = [
+  'test-telephony-plugin',
+  'test-telephony-preferences',
+]
 
-test('test-telephony-plugin',
-     test_program,
-          env: test_env,
-  is_parallel: false,
-        suite: 'plugins',
-)
+foreach test : plugin_telephony_tests
+  source = ['@0@.c'.format(test)]
+
+  test_program = executable(test, source,
+          c_args: test_c_args,
+    dependencies: plugin_telephony_test_deps,
+       link_args: test_link_args,
+      link_whole: [libvalent_test, plugin_telephony],
+  )
+
+  test(test,
+       test_program,
+            env: test_env,
+    is_parallel: false,
+          suite: 'plugins',
+  )
+endforeach
 

--- a/src/tests/plugins/telephony/test-telephony-preferences.c
+++ b/src/tests/plugins/telephony/test-telephony-preferences.c
@@ -1,0 +1,39 @@
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_telephony_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *plugin_context = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "telephony");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_PLUGIN_PREFERENCES,
+                                        "plugin-context", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "plugin-context", &plugin_context, NULL);
+  g_assert_cmpstr (plugin_context, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add_func ("/plugins/telephony/preferences",
+                   test_telephony_plugin_preferences);
+
+  return g_test_run ();
+}
+


### PR DESCRIPTION
Add some basic tests for plugin preferences, just to ensure they don't
blow up or leak when constructed and disposed.