### PR TITLE
test: fix test-mpris-component and test-task-queue

### DIFF
--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -618,6 +618,8 @@ valent_mpris_remote_flush (ValentMprisRemote *self)
             g_variant_builder_add (&changed_props, "{sv}", prop_name, value);
           else
             g_variant_builder_add (&invalidated_props, "s", prop_name);
+
+          g_hash_table_iter_remove (&iter);
         }
 
       properties = g_variant_new ("(s@a{sv}@as)",
@@ -637,7 +639,6 @@ valent_mpris_remote_flush (ValentMprisRemote *self)
         g_warning ("%s: %s", G_STRFUNC, error->message);
     }
 
-  g_hash_table_remove_all (self->player_buffer);
   g_clear_handle_id (&self->flush_id, g_source_remove);
 }
 
@@ -1058,8 +1059,8 @@ valent_mpris_remote_export_full (ValentMprisRemote   *remote,
                                  gpointer             user_data)
 {
   g_autoptr (GTask) task = NULL;
-  GError *error = NULL;
   g_autofree char *address = NULL;
+  GError *error = NULL;
 
   g_return_if_fail (VALENT_IS_MPRIS_REMOTE (remote));
   g_return_if_fail (g_dbus_is_name (bus_name));
@@ -1127,6 +1128,7 @@ valent_mpris_remote_unexport (ValentMprisRemote *remote)
     return;
 
   /* Unexport in reverse order */
+  g_clear_handle_id (&remote->flush_id, g_source_remove);
   g_clear_handle_id (&remote->bus_name_id, g_bus_unown_name);
 
   if (remote->player_id > 0)

--- a/src/tests/libvalent/core/test-task-queue.c
+++ b/src/tests/libvalent/core/test-task-queue.c
@@ -125,6 +125,7 @@ test_task_queue_check (TaskQueueFixture *fixture,
     }
 
   fixture->n_tasks += 1;
+  g_clear_pointer (&fixture->queue, valent_task_queue_unref);
   g_main_loop_run (fixture->loop);
 }
 
@@ -188,16 +189,17 @@ static void
 test_task_queue_dispose (TaskQueueFixture *fixture,
                          gconstpointer     user_data)
 {
+  GTask *task;
+
+  /* Standard tasks (return success, expect success) */
   for (unsigned int i = 0; i < fixture->n_tasks; i++)
     {
-      g_autoptr (GTask) task = NULL;
-
       task = g_task_new (NULL, NULL, task_success_cb, fixture);
       valent_task_queue_run (fixture->queue, task, task_success_func);
+      g_clear_object (&task);
     }
 
-  /* Queue the unref to happen before any tasks complete*/
-  g_idle_add_full (G_PRIORITY_HIGH, task_queue_unref_idle, fixture, NULL);
+  g_clear_pointer (&fixture->queue, valent_task_queue_unref);
   g_main_loop_run (fixture->loop);
 }
 

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -67,23 +67,6 @@ on_player_removed (GObject               *object,
 }
 
 static void
-on_player_changed (ValentMedia           *media,
-                   ValentMediaPlayer     *player,
-                   MprisComponentFixture *fixture)
-{
-  fixture->state = TRUE;
-}
-
-static void
-on_player_seeked (ValentMedia           *media,
-                  ValentMediaPlayer     *player,
-                  gint64                 offset,
-                  MprisComponentFixture *fixture)
-{
-  fixture->state = (offset == 1000);
-}
-
-static void
 on_player_method (ValentMediaPlayer     *player,
                   const char            *method_name,
                   GVariant              *args,
@@ -97,7 +80,7 @@ static void
 test_mpris_component_provider (MprisComponentFixture *fixture,
                                gconstpointer          user_data)
 {
-  g_autoptr (ValentMedia) media = NULL;
+  ValentMedia *media;
   g_autoptr (GPtrArray) players = NULL;
   g_autoptr (GPtrArray) extensions = NULL;
   ValentMediaPlayerProvider *provider;
@@ -144,7 +127,7 @@ static void
 test_mpris_component_player (MprisComponentFixture *fixture,
                              gconstpointer          user_data)
 {
-  g_autoptr (ValentMedia) media = NULL;
+  ValentMedia *media;
   g_autoptr (ValentMprisRemote) remote = NULL;
   ValentMediaActions flags;
   ValentMediaState state;
@@ -261,7 +244,7 @@ static void
 test_mpris_component_dispose (MprisComponentFixture *fixture,
                               gconstpointer          user_data)
 {
-  g_autoptr (ValentMedia) media = NULL;
+  ValentMedia *media;
   g_autoptr (ValentMprisRemote) remote = NULL;
   GPtrArray *extensions;
   ValentMediaPlayerProvider *provider;


### PR DESCRIPTION
* ValentMprisRemote: minor fixes and cleanup
  * consume pending properties while preparing emission
  * remove flush GSource when unexported
* fix timeout in test-mpris-component
* fix timeout in test-task-queue