### PR TITLE
Fix compilation on 32bit architectures (Gint64 format string)

### DIFF
--- a/src/plugins/sms/valent-sms-conversation.c
+++ b/src/plugins/sms/valent-sms-conversation.c
@@ -284,7 +284,7 @@ valent_sms_conversation_populate_reverse (ValentSmsConversation *self)
       if (box != VALENT_SMS_MESSAGE_BOX_INBOX &&
           box != VALENT_SMS_MESSAGE_BOX_SENT)
         {
-          g_warning ("Unknown message type '%li'; discarding", (gint64)box);
+          g_warning ("Unknown message type '%" G_GINT64_FORMAT "'; discarding", (gint64)box);
           g_queue_pop_tail (self->messages);
           continue;
         }
@@ -916,7 +916,7 @@ valent_sms_conversation_scroll_to_date (ValentSmsConversation *conversation,
       if (type != VALENT_SMS_MESSAGE_BOX_INBOX &&
           type != VALENT_SMS_MESSAGE_BOX_SENT)
         {
-          g_warning ("Unknown message type '%li'; discarding", type);
+          g_warning ("Unknown message type '%" G_GINT64_FORMAT "'; discarding", type);
           g_queue_pop_tail (conversation->messages);
           continue;
         }

--- a/src/plugins/sms/valent-sms-store-private.h
+++ b/src/plugins/sms/valent-sms-store-private.h
@@ -88,16 +88,6 @@ G_BEGIN_DECLS
  *
  * Insert or update a message.
  */
-#define ADD_MESSAGE_FMT                                                \
-"INSERT INTO message(box,date,id,metadata,read,sender,text,thread_id)" \
-"  VALUES (%u, %li, %li, \"%s\", %u, \"%s\", \"%s\", %li)"             \
-"  ON CONFLICT(thread_id,id) DO UPDATE SET"                            \
-"    box=excluded.box,"                                                \
-"    date=excluded.date,"                                              \
-"    metadata=excluded.metadata,"                                      \
-"    read=excluded.read,"                                              \
-"    sender=excluded.sender;"
-
 #define ADD_MESSAGE_SQL                                                \
 "INSERT INTO message(box,date,id,metadata,read,sender,text,thread_id)" \
 "  VALUES (?, ?, ?, ?, ?, ?, ?, ?)"                                    \
@@ -110,7 +100,7 @@ G_BEGIN_DECLS
 
 #define ADD_PARTICIPANT_SQL                                            \
 "INSERT INTO participant"                                              \
-"  (thread_id, address) VALUES (%li, \"%s\");"                         \
+"  (thread_id, address) VALUES (?, ?);"                                \
 
 /**
  * REMOVE_MESSAGE_SQL:

--- a/src/plugins/sms/valent-sms-window.c
+++ b/src/plugins/sms/valent-sms-window.c
@@ -532,7 +532,7 @@ valent_sms_window_ensure_conversation (ValentSmsWindow *window,
   GtkWidget *conversation;
   g_autofree char *page_name = NULL;
 
-  page_name = g_strdup_printf ("%li", thread_id);
+  page_name = g_strdup_printf ("%" G_GINT64_FORMAT, thread_id);
   conversation = gtk_stack_get_child_by_name (window->content, page_name);
 
   if (conversation == NULL)
@@ -594,7 +594,7 @@ on_message_removed (ValentSmsWindow  *window,
     return;
 
   /* The GListModel handles the sidebar, so we only destroy the conversation */
-  thread_str = g_strdup_printf ("%li", thread_id);
+  thread_str = g_strdup_printf ("%" G_GINT64_FORMAT, thread_id);
   conversation = gtk_stack_get_child_by_name (window->content, thread_str);
 
   if (conversation != NULL)


### PR DESCRIPTION
I've been testing packaging this for alpine linux. 

A recent-ish change (72d2508?) introduced an architecture specific format string for a gint64. ([G_GINT64_FORMAT](https://docs.gtk.org/glib/const.GINT64_FORMAT.html) should be used instead).

See https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/26925#note_200269 for more information.

This PR fixes that. (That alpine Merge Request pulls in this patch, and shows a passing pipeline for armhf, armv7, and x86 (as well as x86_64, s390x, ppc64le, armhf, aarch64, which were passing beforehand) architectures.