### PR TITLE
lan plugin: various cleanups

### DIFF
--- a/src/plugins/lan/valent-lan-channel-service.h
+++ b/src/plugins/lan/valent-lan-channel-service.h
@@ -4,16 +4,12 @@
 #pragma once
 
 #include <libvalent-core.h>
-#include <gio/gio.h>
-#include <libpeas/peas.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_LAN_CHANNEL_SERVICE (valent_lan_channel_service_get_type())
 
 G_DECLARE_FINAL_TYPE (ValentLanChannelService, valent_lan_channel_service, VALENT, LAN_CHANNEL_SERVICE, ValentChannelService)
-
-GTlsCertificate * valent_lan_channel_service_get_certificate (ValentLanChannelService *lan_channel_service);
 
 G_END_DECLS
 

--- a/src/plugins/lan/valent-lan-utils.h
+++ b/src/plugins/lan/valent-lan-utils.h
@@ -7,26 +7,26 @@
 
 G_BEGIN_DECLS
 
-GIOStream * valent_lan_encrypt_new_client      (GSocketConnection  *connection,
-                                                GTlsCertificate    *certificate,
-                                                const char         *device_id,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
-GIOStream * valent_lan_encrypt_client          (GSocketConnection  *connection,
-                                                GTlsCertificate    *certificate,
-                                                GTlsCertificate    *peer_cert,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
-GIOStream * valent_lan_encrypt_new_server      (GSocketConnection  *connection,
-                                                GTlsCertificate    *certificate,
-                                                const char         *device_id,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
-GIOStream * valent_lan_encrypt_server          (GSocketConnection  *connection,
-                                                GTlsCertificate    *certificate,
-                                                GTlsCertificate    *peer_cert,
-                                                GCancellable       *cancellable,
-                                                GError            **error);
+GIOStream * valent_lan_encrypt_new_client (GSocketConnection  *connection,
+                                           GTlsCertificate    *certificate,
+                                           const char         *device_id,
+                                           GCancellable       *cancellable,
+                                           GError            **error);
+GIOStream * valent_lan_encrypt_client     (GSocketConnection  *connection,
+                                           GTlsCertificate    *certificate,
+                                           GTlsCertificate    *peer_cert,
+                                           GCancellable       *cancellable,
+                                           GError            **error);
+GIOStream * valent_lan_encrypt_new_server (GSocketConnection  *connection,
+                                           GTlsCertificate    *certificate,
+                                           const char         *device_id,
+                                           GCancellable       *cancellable,
+                                           GError            **error);
+GIOStream * valent_lan_encrypt_server     (GSocketConnection  *connection,
+                                           GTlsCertificate    *certificate,
+                                           GTlsCertificate    *peer_cert,
+                                           GCancellable       *cancellable,
+                                           GError            **error);
 
 G_END_DECLS
 

--- a/src/tests/extra/tsan.supp
+++ b/src/tests/extra/tsan.supp
@@ -49,9 +49,9 @@ race:valent_lan_channel_get_property
 # TODO: ValentLanChanneService::port is construct-only
 race:valent_lan_channel_get_port
 
-# src/plugins/valent-lan-channel-service.c
-race:on_connection
-race:on_packet
+# src/plugins/lan/valent-lan-channel-service.c
+race:on_incoming_connection
+race:on_incoming_broadcast
 race:valent_lan_channel_service_finalize
 race:valent_lan_channel_service_stop
 race:valent_lan_channel_service_tcp_setup


### PR DESCRIPTION
* ValentLanChannelService
  * remove unused property accessor
  * connect to GThreadedSocketService::run instead of overriding vfunc
  * drop port number assertions in favour of reasonable GParamSpec range
  * trigger cancellable in stop()
* lan-utils: cleanup some comments and code style