### PR TITLE
tests: add a more helpful version of g_assert_finalize_object()

### DIFF
--- a/src/tests/fixtures/valent-mock-channel-service.c
+++ b/src/tests/fixtures/valent-mock-channel-service.c
@@ -124,7 +124,7 @@ valent_mock_channel_service_stop (ValentChannelService *service)
   if (self->channel)
     {
       valent_channel_close_async (self->channel, NULL, NULL, NULL);
-      v_assert_finalize_object (self->channel);
+      v_await_finalize_object (self->channel);
       self->channel = NULL;
     }
 

--- a/src/tests/fixtures/valent-test-plugin-fixture.c
+++ b/src/tests/fixtures/valent-test-plugin-fixture.c
@@ -138,13 +138,13 @@ valent_test_plugin_fixture_clear (ValentTestPluginFixture *fixture,
   if (fixture->endpoint)
     {
       valent_channel_close (fixture->endpoint, NULL, NULL);
-      v_assert_finalize_object (fixture->endpoint);
+      v_await_finalize_object (fixture->endpoint);
     }
 
   if (fixture->channel)
     {
       valent_channel_close (fixture->channel, NULL, NULL);
-      v_assert_finalize_object (fixture->channel);
+      v_await_finalize_object (fixture->channel);
     }
 
   if (fixture->data && fixture->data_free)

--- a/src/tests/libvalent/clipboard/test-clipboard-component.c
+++ b/src/tests/libvalent/clipboard/test-clipboard-component.c
@@ -26,7 +26,7 @@ static void
 clipboard_component_fixture_tear_down (ClipboardComponentFixture *fixture,
                                        gconstpointer              user_data)
 {
-  g_assert_finalize_object (fixture->clipboard);
+  v_assert_finalize_object (fixture->clipboard);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
 }
 

--- a/src/tests/libvalent/contacts/test-contacts-component.c
+++ b/src/tests/libvalent/contacts/test-contacts-component.c
@@ -186,9 +186,9 @@ static void
 contacts_component_fixture_tear_down (ContactsComponentFixture *fixture,
                                       gconstpointer             user_data)
 {
-  v_assert_finalize_object (fixture->contacts);
-  v_assert_finalize_object (fixture->store);
-  g_assert_finalize_object (fixture->contact);
+  v_await_finalize_object (fixture->contacts);
+  v_await_finalize_object (fixture->store);
+  v_assert_finalize_object (fixture->contact);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
 }
 

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -53,9 +53,9 @@ device_fixture_tear_down (DeviceFixture *fixture,
                           gconstpointer  user_data)
 {
   valent_channel_close (fixture->endpoint, NULL, NULL);
-  v_assert_finalize_object (fixture->endpoint);
-  v_assert_finalize_object (fixture->device);
-  v_assert_finalize_object (fixture->channel);
+  v_await_finalize_object (fixture->endpoint);
+  v_await_finalize_object (fixture->device);
+  v_await_finalize_object (fixture->channel);
 
   g_clear_pointer (&fixture->packets, json_node_unref);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
@@ -164,7 +164,7 @@ test_device_new (void)
   g_assert_cmpuint (plugins->len, ==, 1);
   g_ptr_array_unref (plugins);
 
-  g_assert_finalize_object (device);
+  v_assert_finalize_object (device);
 }
 
 /*

--- a/src/tests/libvalent/core/test-manager.c
+++ b/src/tests/libvalent/core/test-manager.c
@@ -54,7 +54,7 @@ manager_fixture_tear_down (ManagerFixture *fixture,
 {
   valent_manager_stop (fixture->manager);
 
-  v_assert_finalize_object (fixture->manager);
+  v_await_finalize_object (fixture->manager);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
 }
 

--- a/src/tests/libvalent/input/test-input-component.c
+++ b/src/tests/libvalent/input/test-input-component.c
@@ -23,7 +23,7 @@ static void
 input_component_fixture_tear_down (InputComponentFixture *fixture,
                                    gconstpointer          user_data)
 {
-  g_assert_finalize_object (fixture->input);
+  v_assert_finalize_object (fixture->input);
 }
 
 static void

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -31,8 +31,8 @@ static void
 media_component_fixture_tear_down (MediaComponentFixture *fixture,
                                    gconstpointer          user_data)
 {
-  g_assert_finalize_object (fixture->media);
-  g_assert_finalize_object (fixture->player);
+  v_assert_finalize_object (fixture->media);
+  v_assert_finalize_object (fixture->player);
 
   while (g_main_context_iteration (NULL, FALSE))
     continue;

--- a/src/tests/libvalent/mixer/test-mixer-component.c
+++ b/src/tests/libvalent/mixer/test-mixer-component.c
@@ -63,9 +63,9 @@ static void
 mixer_component_fixture_tear_down (MixerComponentFixture *fixture,
                                    gconstpointer          user_data)
 {
-  g_assert_finalize_object (fixture->mixer);
-  g_assert_finalize_object (fixture->input);
-  g_assert_finalize_object (fixture->output);
+  v_assert_finalize_object (fixture->mixer);
+  v_assert_finalize_object (fixture->input);
+  v_assert_finalize_object (fixture->output);
 }
 
 static void

--- a/src/tests/libvalent/notifications/test-notifications-component.c
+++ b/src/tests/libvalent/notifications/test-notifications-component.c
@@ -45,8 +45,8 @@ static void
 notifications_component_fixture_tear_down (NotificationsComponentFixture *fixture,
                                            gconstpointer                  user_data)
 {
-  g_assert_finalize_object (fixture->notifications);
-  g_assert_finalize_object (fixture->notification);
+  v_assert_finalize_object (fixture->notifications);
+  v_assert_finalize_object (fixture->notification);
 }
 
 static void

--- a/src/tests/libvalent/session/test-session-component.c
+++ b/src/tests/libvalent/session/test-session-component.c
@@ -24,7 +24,7 @@ static void
 session_component_fixture_tear_down (SessionComponentFixture *fixture,
                                      gconstpointer            user_data)
 {
-  g_assert_finalize_object (fixture->session);
+  v_assert_finalize_object (fixture->session);
 }
 
 static void

--- a/src/tests/plugins/fdo/test-fdo-notifications.c
+++ b/src/tests/plugins/fdo/test-fdo-notifications.c
@@ -60,8 +60,8 @@ fdo_notifications_fixture_tear_down (FdoNotificationsFixture *fixture,
   g_clear_object (&fixture->connection);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_pointer (&fixture->notification_id, g_free);
-  g_assert_finalize_object (fixture->notification);
-  g_assert_finalize_object (fixture->notifications);
+  v_assert_finalize_object (fixture->notification);
+  v_assert_finalize_object (fixture->notifications);
 }
 
 static void

--- a/src/tests/plugins/fdo/test-fdo-session.c
+++ b/src/tests/plugins/fdo/test-fdo-session.c
@@ -38,7 +38,7 @@ fdo_session_fixture_tear_down (FdoSessionFixture *fixture,
 {
   g_clear_object (&fixture->connection);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
-  g_assert_finalize_object (fixture->session);
+  v_assert_finalize_object (fixture->session);
 }
 
 static void

--- a/src/tests/plugins/gtk/test-gdk-clipboard.c
+++ b/src/tests/plugins/gtk/test-gdk-clipboard.c
@@ -32,7 +32,7 @@ static void
 clipboard_component_fixture_tear_down (GdkClipboardFixture *fixture,
                                        gconstpointer        user_data)
 {
-  g_assert_finalize_object (fixture->clipboard);
+  v_assert_finalize_object (fixture->clipboard);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_pointer (&fixture->data, g_free);
 }

--- a/src/tests/plugins/gtk/test-gtk-notifications.c
+++ b/src/tests/plugins/gtk/test-gtk-notifications.c
@@ -59,8 +59,8 @@ gtk_notifications_fixture_tear_down (GtkNotificationsFixture *fixture,
   g_clear_object (&fixture->connection);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_pointer (&fixture->notification_id, g_free);
-  g_assert_finalize_object (fixture->notification);
-  g_assert_finalize_object (fixture->notifications);
+  v_assert_finalize_object (fixture->notification);
+  v_assert_finalize_object (fixture->notifications);
 }
 
 

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -90,18 +90,15 @@ static void
 lan_service_fixture_tear_down (LanBackendFixture *fixture,
                                gconstpointer      user_data)
 {
-  while (g_main_context_iteration (NULL, FALSE))
-    continue;
-
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_pointer (&fixture->packets, json_node_unref);
 
-  v_assert_finalize_object (fixture->service);
-  g_assert_finalize_object (fixture->channel);
+  v_await_finalize_object (fixture->service);
+  v_await_finalize_object (fixture->channel);
+  v_await_finalize_object (fixture->endpoint);
 
-  g_assert_finalize_object (fixture->endpoint);
-  g_assert_finalize_object (fixture->certificate);
-  g_assert_finalize_object (fixture->socket);
+  v_assert_finalize_object (fixture->certificate);
+  v_assert_finalize_object (fixture->socket);
 }
 
 /*

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -57,7 +57,7 @@ mpris_provider_fixture_tear_down (MprisComponentFixture *fixture,
   g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_object (&fixture->player);
 
-  g_assert_finalize_object (fixture->media);
+  v_assert_finalize_object (fixture->media);
 }
 
 static void


### PR DESCRIPTION
Add version of `g_assert_finalize_object()` that actually tells you
where the object is that failed to finalize.

Also, rename the current macro `v_assert_finalize_object()` to
`v_await_finalize_object()` to reflect its actual behaviour.