### PR TITLE
libvalent-ui: fix enable/disable for network plugins

### DIFF
--- a/src/libvalent/ui/valent-plugin-row.c
+++ b/src/libvalent/ui/valent-plugin-row.c
@@ -66,15 +66,18 @@ valent_plugin_row_constructed (GObject *object)
 
   /* Plugin Toggle */
   if (self->plugin_type == VALENT_TYPE_DEVICE_PLUGIN)
-    path = g_strdup_printf ("/ca/andyholmes/valent/device/%s/plugin/%s/",
-                            self->plugin_context,
-                            module);
+    {
+      path = g_strdup_printf ("/ca/andyholmes/valent/device/%s/plugin/%s/",
+                              self->plugin_context,
+                              module);
+      self->settings = g_settings_new_with_path ("ca.andyholmes.Valent.Plugin",
+                                                 path);
+    }
   else
-    path = g_strdup_printf ("/ca/andyholmes/valent/%s/plugin/%s/",
-                            self->plugin_context,
-                            module);
-
-  self->settings = g_settings_new_with_path ("ca.andyholmes.Valent.Plugin", path);
+    {
+      self->settings = valent_component_new_settings (self->plugin_context,
+                                                      module);
+    }
 
   g_settings_bind (self->settings, "enabled",
                    self->sw,       "active",

--- a/src/libvalent/ui/valent-window.ui
+++ b/src/libvalent/ui/valent-window.ui
@@ -161,7 +161,7 @@
                 <child>
                   <object class="ValentPluginGroup" id="networking_section">
                     <property name="title" translatable="yes">Networking</property>
-                    <property name="plugin-context">channel</property>
+                    <property name="plugin-context">network</property>
                     <property name="plugin-type">ValentChannelService</property>
                   </object>
                 </child>


### PR DESCRIPTION
Fix enabling and disabling network components, which were being passed a
`plugin-context` of `channel` instead of `network` in
`valent-window.ui`.

Also use `valent_component_new_settings()` in `ValentPluginRow` to
ensure the same GSettings path is being used.