### PR TITLE
ValentDevicePlugin: optimize valent_device_plugin_update_state()

### DIFF
--- a/src/libvalent/core/valent-device-plugin.h
+++ b/src/libvalent/core/valent-device-plugin.h
@@ -10,6 +10,8 @@
 #include <json-glib/json-glib.h>
 #include <libpeas/peas.h>
 
+#include "valent-device.h"
+
 G_BEGIN_DECLS
 
 /*
@@ -36,7 +38,8 @@ struct _ValentDevicePluginInterface
   void             (*handle_packet) (ValentDevicePlugin *plugin,
                                      const char         *type,
                                      JsonNode           *packet);
-  void             (*update_state)  (ValentDevicePlugin *plugin);
+  void             (*update_state)  (ValentDevicePlugin *plugin,
+                                     ValentDeviceState   state);
 };
 
 /* Core Interface */
@@ -45,7 +48,8 @@ void        valent_device_plugin_enable              (ValentDevicePlugin    *plu
 void        valent_device_plugin_handle_packet       (ValentDevicePlugin    *plugin,
                                                       const char            *type,
                                                       JsonNode              *packet);
-void        valent_device_plugin_update_state        (ValentDevicePlugin    *plugin);
+void        valent_device_plugin_update_state        (ValentDevicePlugin    *plugin,
+                                                      ValentDeviceState      state);
 
 /* Utility Functions */
 GSettings * valent_device_plugin_new_settings        (const char            *device_id,

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -416,18 +416,16 @@ valent_battery_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_battery_plugin_update_state (ValentDevicePlugin *plugin)
+valent_battery_plugin_update_state (ValentDevicePlugin *plugin,
+                                    ValentDeviceState   state)
 {
   ValentBatteryPlugin *self = VALENT_BATTERY_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_BATTERY_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -327,16 +327,16 @@ valent_clipboard_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_clipboard_plugin_update_state (ValentDevicePlugin *plugin)
+valent_clipboard_plugin_update_state (ValentDevicePlugin *plugin,
+                                      ValentDeviceState   state)
 {
   ValentClipboardPlugin *self = VALENT_CLIPBOARD_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -460,16 +460,16 @@ valent_contacts_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_contacts_plugin_update_state (ValentDevicePlugin *plugin)
+valent_contacts_plugin_update_state (ValentDevicePlugin *plugin,
+                                     ValentDeviceState   state)
 {
   ValentContactsPlugin *self = VALENT_CONTACTS_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_CONTACTS_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/findmyphone/valent-findmyphone-plugin.c
+++ b/src/plugins/findmyphone/valent-findmyphone-plugin.c
@@ -118,18 +118,16 @@ valent_findmyphone_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_findmyphone_plugin_update_state (ValentDevicePlugin *plugin)
+valent_findmyphone_plugin_update_state (ValentDevicePlugin *plugin,
+                                        ValentDeviceState   state)
 {
   ValentFindmyphonePlugin *self = VALENT_FINDMYPHONE_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_FINDMYPHONE_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/lock/valent-lock-plugin.c
+++ b/src/plugins/lock/valent-lock-plugin.c
@@ -230,18 +230,16 @@ valent_lock_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_lock_plugin_update_state (ValentDevicePlugin *plugin)
+valent_lock_plugin_update_state (ValentDevicePlugin *plugin,
+                                 ValentDeviceState   state)
 {
   ValentLockPlugin *self = VALENT_LOCK_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_LOCK_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   if (available)

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -458,12 +458,9 @@ static const ValentMenuEntry items[] = {
 static void
 valent_mousepad_plugin_enable (ValentDevicePlugin *plugin)
 {
-  /* Register GActions */
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
-
-  /* Register GMenu items */
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -476,18 +473,16 @@ valent_mousepad_plugin_disable (ValentDevicePlugin *plugin)
 
   g_assert (VALENT_IS_MOUSEPAD_PLUGIN (self));
 
-  /* Unregister GMenu items */
+  /* Destroy the input dialog if necessary */
+  if (self->dialog != NULL)
+    gtk_window_destroy (GTK_WINDOW (self->dialog));
+
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
-
-  if (self->dialog != NULL)
-    gtk_window_destroy (GTK_WINDOW (self->dialog));
 }
 
 static void
@@ -505,7 +500,6 @@ valent_mousepad_plugin_update_state (ValentDevicePlugin *plugin,
   if (available)
     valent_mousepad_plugin_mousepad_keyboardstate (self);
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
                                        actions,
                                        G_N_ELEMENTS (actions),

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -491,18 +491,16 @@ valent_mousepad_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_mousepad_plugin_update_state (ValentDevicePlugin *plugin)
+valent_mousepad_plugin_update_state (ValentDevicePlugin *plugin,
+                                     ValentDeviceState   state)
 {
   ValentMousepadPlugin *self = VALENT_MOUSEPAD_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_MOUSEPAD_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   if (available)
     valent_mousepad_plugin_mousepad_keyboardstate (self);

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -907,16 +907,16 @@ valent_mpris_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_mpris_plugin_update_state (ValentDevicePlugin *plugin)
+valent_mpris_plugin_update_state (ValentDevicePlugin *plugin,
+                                  ValentDeviceState   state)
 {
   ValentMprisPlugin *self = VALENT_MPRIS_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_MPRIS_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* Media Players */
   watch_media (self, available);

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -1102,16 +1102,16 @@ valent_notification_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_notification_plugin_update_state (ValentDevicePlugin *plugin)
+valent_notification_plugin_update_state (ValentDevicePlugin *plugin,
+                                         ValentDeviceState   state)
 {
   ValentNotificationPlugin *self = VALENT_NOTIFICATION_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_NOTIFICATION_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -1084,20 +1084,16 @@ valent_notification_plugin_disable (ValentDevicePlugin *plugin)
 {
   ValentNotificationPlugin *self = VALENT_NOTIFICATION_PLUGIN (plugin);
 
-  /* Stop watching for local notifications */
+  /* Stop watching for local notifications and cancel pending transfers */
   if (self->notifications)
     g_signal_handlers_disconnect_by_data (self->notifications, self);
 
-  /* Unregister GActions */
-  valent_device_plugin_unregister_actions (plugin,
-                                           actions,
-                                           G_N_ELEMENTS (actions));
-
-  /* Cancel pending tasks */
   g_cancellable_cancel (self->cancellable);
   g_clear_object (&self->cancellable);
 
-  /* Dispose GSettings */
+  valent_device_plugin_unregister_actions (plugin,
+                                           actions,
+                                           G_N_ELEMENTS (actions));
   g_clear_object (&self->settings);
 }
 
@@ -1113,7 +1109,6 @@ valent_notification_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
                                        actions, G_N_ELEMENTS (actions),
                                        available);
@@ -1131,6 +1126,7 @@ valent_notification_plugin_handle_packet (ValentDevicePlugin *plugin,
                                           JsonNode           *packet)
 {
   ValentNotificationPlugin *self = VALENT_NOTIFICATION_PLUGIN (plugin);
+
   g_assert (VALENT_IS_NOTIFICATION_PLUGIN (plugin));
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -188,16 +188,15 @@ valent_photo_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_photo_plugin_update_state (ValentDevicePlugin *plugin)
+valent_photo_plugin_update_state (ValentDevicePlugin *plugin,
+                                  ValentDeviceState   state)
 {
-  ValentPhotoPlugin *self = VALENT_PHOTO_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_PHOTO_PLUGIN (plugin));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -162,12 +162,11 @@ static const ValentMenuEntry items[] = {
 static void
 valent_photo_plugin_enable (ValentDevicePlugin *plugin)
 {
-  /* Register GActions */
+  g_assert (VALENT_IS_PHOTO_PLUGIN (plugin));
+
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
-
-  /* Register GMenu items */
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -176,12 +175,11 @@ valent_photo_plugin_enable (ValentDevicePlugin *plugin)
 static void
 valent_photo_plugin_disable (ValentDevicePlugin *plugin)
 {
-  /* Unregister GMenu items */
+  g_assert (VALENT_IS_PHOTO_PLUGIN (plugin));
+
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
@@ -198,9 +196,9 @@ valent_photo_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
-                                       actions, G_N_ELEMENTS (actions),
+                                       actions,
+                                       G_N_ELEMENTS (actions),
                                        available);
 }
 

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -109,12 +109,9 @@ static const ValentMenuEntry items[] = {
 static void
 valent_ping_plugin_enable (ValentDevicePlugin *plugin)
 {
-  /* Register GActions */
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
-
-  /* Register GMenu items */
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -123,12 +120,9 @@ valent_ping_plugin_enable (ValentDevicePlugin *plugin)
 static void
 valent_ping_plugin_disable (ValentDevicePlugin *plugin)
 {
-  /* Unregister GMenu items */
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
@@ -145,9 +139,9 @@ valent_ping_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
-                                       actions, G_N_ELEMENTS (actions),
+                                       actions,
+                                       G_N_ELEMENTS (actions),
                                        available);
 }
 

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -135,18 +135,15 @@ valent_ping_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_ping_plugin_update_state (ValentDevicePlugin *plugin)
+valent_ping_plugin_update_state (ValentDevicePlugin *plugin,
+                                 ValentDeviceState   state)
 {
-  ValentPingPlugin *self = VALENT_PING_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  g_assert (VALENT_IS_PING_PLUGIN (self));
+  g_assert (VALENT_IS_PING_PLUGIN (plugin));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/runcommand/valent-runcommand-plugin.c
+++ b/src/plugins/runcommand/valent-runcommand-plugin.c
@@ -412,16 +412,16 @@ valent_runcommand_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_runcommand_plugin_update_state (ValentDevicePlugin *plugin)
+valent_runcommand_plugin_update_state (ValentDevicePlugin *plugin,
+                                       ValentDeviceState   state)
 {
   ValentRuncommandPlugin *self = VALENT_RUNCOMMAND_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_RUNCOMMAND_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,
@@ -431,7 +431,8 @@ valent_runcommand_plugin_update_state (ValentDevicePlugin *plugin)
   if (available)
     valent_runcommand_plugin_send_command_list (self);
 
-  if (!paired)
+  /* If the device is unpaired it is no longer trusted */
+  if ((state & VALENT_DEVICE_STATE_PAIRED) == 0)
     launcher_clear (self);
 }
 

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -676,18 +676,16 @@ valent_sftp_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_sftp_plugin_update_state (ValentDevicePlugin *plugin)
+valent_sftp_plugin_update_state (ValentDevicePlugin *plugin,
+                                 ValentDeviceState   state)
 {
   ValentSftpPlugin *self = VALENT_SFTP_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_SFTP_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -722,21 +722,23 @@ valent_share_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 static void
-valent_share_plugin_update_state (ValentDevicePlugin *plugin)
+valent_share_plugin_update_state (ValentDevicePlugin *plugin,
+                                  ValentDeviceState   state)
 {
-  ValentSharePlugin *self = VALENT_SHARE_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_SHARE_PLUGIN (plugin));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,
                               actions, G_N_ELEMENTS (actions),
                               available);
+
+  if ((state & VALENT_DEVICE_STATE_PAIRED) == 0)
+    VALENT_TODO ("Device is unpaired; cancel ongoing transfers");
 }
 
 static void

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -477,18 +477,16 @@ valent_sms_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_sms_plugin_update_state (ValentDevicePlugin *plugin)
+valent_sms_plugin_update_state (ValentDevicePlugin *plugin,
+                                ValentDeviceState   state)
 {
   ValentSmsPlugin *self = VALENT_SMS_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  g_assert (VALENT_IS_SMS_PLUGIN (plugin));
+  g_assert (VALENT_IS_SMS_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -461,19 +461,16 @@ valent_sms_plugin_disable (ValentDevicePlugin *plugin)
 
   g_assert (VALENT_IS_SMS_PLUGIN (plugin));
 
-  /* Unregister GMenu items */
-  valent_device_plugin_remove_menu_entries (plugin,
-                                            items,
-                                            G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
-  valent_device_plugin_unregister_actions (plugin,
-                                           actions,
-                                           G_N_ELEMENTS (actions));
-
   /* Close message window and drop SMS Store */
   g_clear_pointer (&self->window, gtk_window_destroy);
   g_clear_object (&self->store);
+
+  valent_device_plugin_remove_menu_entries (plugin,
+                                            items,
+                                            G_N_ELEMENTS (items));
+  valent_device_plugin_unregister_actions (plugin,
+                                           actions,
+                                           G_N_ELEMENTS (actions));
 }
 
 static void
@@ -488,7 +485,6 @@ valent_sms_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
                                        actions, G_N_ELEMENTS (actions),
                                        available);

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -309,18 +309,16 @@ valent_systemvolume_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_systemvolume_plugin_update_state (ValentDevicePlugin *plugin)
+valent_systemvolume_plugin_update_state (ValentDevicePlugin *plugin,
+                                         ValentDeviceState   state)
 {
   ValentSystemvolumePlugin *self = VALENT_SYSTEMVOLUME_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
   g_assert (VALENT_IS_SYSTEMVOLUME_PLUGIN (self));
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   if (self->mixer == NULL)
     self->mixer = valent_mixer_get_default ();

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -389,16 +389,15 @@ valent_telephony_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_telephony_plugin_update_state (ValentDevicePlugin *plugin)
+valent_telephony_plugin_update_state (ValentDevicePlugin *plugin,
+                                      ValentDeviceState   state)
 {
-  ValentTelephonyPlugin *self = VALENT_TELEPHONY_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_TELEPHONY_PLUGIN (plugin));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   /* GActions */
   valent_device_plugin_toggle_actions (plugin,

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -364,11 +364,8 @@ valent_telephony_plugin_enable (ValentDevicePlugin *plugin)
 
   g_assert (VALENT_IS_TELEPHONY_PLUGIN (self));
 
-  /* Setup GSettings */
   device_id = valent_device_get_id (self->device);
   self->settings = valent_device_plugin_new_settings (device_id, "telephony");
-
-  /* Register GActions */
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
@@ -379,12 +376,9 @@ valent_telephony_plugin_disable (ValentDevicePlugin *plugin)
 {
   ValentTelephonyPlugin *self = VALENT_TELEPHONY_PLUGIN (plugin);
 
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
-
-  /* Dispose GSettings */
   g_clear_object (&self->settings);
 }
 
@@ -399,7 +393,6 @@ valent_telephony_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  /* GActions */
   valent_device_plugin_toggle_actions (plugin,
                                        actions, G_N_ELEMENTS (actions),
                                        available);

--- a/src/tests/fixtures/packetless-plugin.c
+++ b/src/tests/fixtures/packetless-plugin.c
@@ -51,6 +51,8 @@ static const ValentMenuEntry items[] = {
 static void
 valent_packetless_plugin_enable (ValentDevicePlugin *plugin)
 {
+  g_assert (VALENT_IS_PACKETLESS_PLUGIN (plugin));
+
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
@@ -63,12 +65,11 @@ valent_packetless_plugin_enable (ValentDevicePlugin *plugin)
 static void
 valent_packetless_plugin_disable (ValentDevicePlugin *plugin)
 {
-  /* Unregister GMenu items */
+  g_assert (VALENT_IS_PACKETLESS_PLUGIN (plugin));
+
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
@@ -78,10 +79,9 @@ static void
 valent_packetless_plugin_update_state (ValentDevicePlugin *plugin,
                                        ValentDeviceState   state)
 {
-  ValentPacketlessPlugin *self = VALENT_PACKETLESS_PLUGIN (plugin);
   gboolean available;
 
-  g_assert (VALENT_IS_PACKETLESS_PLUGIN (self));
+  g_assert (VALENT_IS_PACKETLESS_PLUGIN (plugin));
 
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
@@ -170,7 +170,6 @@ valent_packetless_plugin_register_types (PeasObjectModule *module)
 {
   valent_packetless_plugin_register_type (G_TYPE_MODULE (module));
 
-  /* Plugin Interface */
   peas_object_module_register_extension_type (module,
                                               VALENT_TYPE_DEVICE_PLUGIN,
                                               VALENT_TYPE_PACKETLESS_PLUGIN);

--- a/src/tests/fixtures/packetless-plugin.c
+++ b/src/tests/fixtures/packetless-plugin.c
@@ -75,16 +75,16 @@ valent_packetless_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_packetless_plugin_update_state (ValentDevicePlugin *plugin)
+valent_packetless_plugin_update_state (ValentDevicePlugin *plugin,
+                                       ValentDeviceState   state)
 {
   ValentPacketlessPlugin *self = VALENT_PACKETLESS_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_PACKETLESS_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   valent_device_plugin_toggle_actions (plugin,
                                        actions,

--- a/src/tests/fixtures/valent-mock-device-plugin.c
+++ b/src/tests/fixtures/valent-mock-device-plugin.c
@@ -29,17 +29,17 @@ enum {
  * Packet Handlers
  */
 static void
-handle_mock_echo (ValentDevicePlugin *plugin,
-                  JsonNode           *packet)
+handle_mock_echo (ValentMockDevicePlugin *self,
+                  JsonNode               *packet)
 {
-  ValentMockDevicePlugin *self = VALENT_MOCK_DEVICE_PLUGIN (plugin);
   g_autoptr (JsonNode) response = NULL;
   g_autofree char *packet_json = NULL;
 
-  g_assert (VALENT_IS_DEVICE_PLUGIN (plugin));
+  g_assert (VALENT_IS_MOCK_DEVICE_PLUGIN (self));
+  g_assert (VALENT_IS_PACKET (packet));
 
   packet_json = json_to_string (packet, TRUE);
-  g_message ("%s", packet_json);
+  g_message ("Received echo: %s", packet_json);
 
   response = json_from_string (packet_json, NULL);
   valent_device_queue_packet (self->device, response);
@@ -71,11 +71,13 @@ static const ValentMenuEntry items[] = {
 };
 
 /**
- * ValentDevicePlugin Implementation
+ * ValentDevicePlugin
  */
 static void
 valent_mock_device_plugin_enable (ValentDevicePlugin *plugin)
 {
+  g_assert (VALENT_IS_MOCK_DEVICE_PLUGIN (plugin));
+
   valent_device_plugin_register_actions (plugin,
                                          actions,
                                          G_N_ELEMENTS (actions));
@@ -88,12 +90,11 @@ valent_mock_device_plugin_enable (ValentDevicePlugin *plugin)
 static void
 valent_mock_device_plugin_disable (ValentDevicePlugin *plugin)
 {
-  /* Unregister GMenu items */
+  g_assert (VALENT_IS_MOCK_DEVICE_PLUGIN (plugin));
+
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-
-  /* Unregister GActions */
   valent_device_plugin_unregister_actions (plugin,
                                            actions,
                                            G_N_ELEMENTS (actions));
@@ -119,15 +120,17 @@ valent_mock_device_plugin_update_state (ValentDevicePlugin *plugin,
 
 static void
 valent_mock_device_plugin_handle_packet (ValentDevicePlugin *plugin,
-                                  const char         *type,
-                                  JsonNode           *packet)
+                                         const char         *type,
+                                         JsonNode           *packet)
 {
+  ValentMockDevicePlugin *self = VALENT_MOCK_DEVICE_PLUGIN (plugin);
+
   g_assert (VALENT_IS_MOCK_DEVICE_PLUGIN (plugin));
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
   if (g_strcmp0 (type, "kdeconnect.mock.echo") == 0)
-    handle_mock_echo (plugin, packet);
+    handle_mock_echo (self, packet);
   else
     g_assert_not_reached ();
 }

--- a/src/tests/fixtures/valent-mock-device-plugin.c
+++ b/src/tests/fixtures/valent-mock-device-plugin.c
@@ -100,16 +100,16 @@ valent_mock_device_plugin_disable (ValentDevicePlugin *plugin)
 }
 
 static void
-valent_mock_device_plugin_update_state (ValentDevicePlugin *plugin)
+valent_mock_device_plugin_update_state (ValentDevicePlugin *plugin,
+                                        ValentDeviceState   state)
 {
   ValentMockDevicePlugin *self = VALENT_MOCK_DEVICE_PLUGIN (plugin);
-  gboolean connected;
-  gboolean paired;
   gboolean available;
 
-  connected = valent_device_get_connected (self->device);
-  paired = valent_device_get_paired (self->device);
-  available = (connected && paired);
+  g_assert (VALENT_IS_MOCK_DEVICE_PLUGIN (self));
+
+  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
+              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
   valent_device_plugin_toggle_actions (plugin,
                                        actions,


### PR DESCRIPTION
Every plugin that implements this interface immediately makes calls to
`valent_device_get_connected()` and `valent_device_get_paired()`, which
both involve locking a mutex now.

Since plugins are always interested in the device state, get that via a
single call to `valent_device_get_state()` and pass it as an argument.