### PR TITLE
ValentApplication: break window presentation code into a function

### DIFF
--- a/src/libvalent/core/valent-debug.h.in
+++ b/src/libvalent/core/valent-debug.h.in
@@ -145,22 +145,26 @@ void valent_trace_mark (const char *strfunc,
 
 /**
  * VALENT_NOTE: (skip)
+ * @fmt: the message format (ie. `printf()`)
+ * @...: the message parameters
  *
  * Logs a formatted message at %G_LOG_LEVEL_DEBUG.
  */
 
 /**
- * VALENT_FIXME: (skip)
- * @_msg: the message to append to the log.
+ * VALENT_TODO: (skip)
+ * @fmt: the message format (ie. `printf()`)
+ * @...: the message parameters
  *
- * Appends to the log that unstable code has been reached.
+ * Appends to the log that incomplete code has been reached.
  */
 
 /**
- * VALENT_TODO: (skip)
- * @_msg: the message to append to the log.
+ * VALENT_FIXME: (skip)
+ * @fmt: the message format (ie. `printf()`)
+ * @...: the message parameters
  *
- * Appends to the log that incomplete code has been reached.
+ * Appends to the log that unstable code has been reached.
  */
 
 /**
@@ -177,12 +181,12 @@ void valent_trace_mark (const char *strfunc,
 # define VALENT_NOTE(fmt, ...)                                              \
    g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, " NOTE: %s():%d: " fmt,           \
          G_STRFUNC, __LINE__, ##__VA_ARGS__)
-# define VALENT_FIXME(_msg)                                                 \
-   g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, "FIXME: %s():%d: %s",             \
-         G_STRFUNC, __LINE__, _msg)
-# define VALENT_TODO(_msg)                                                  \
-   g_log(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, " TODO: %s():%d: %s",             \
-         G_STRFUNC, __LINE__, _msg)
+# define VALENT_TODO(fmt, ...)                                              \
+   g_log(G_LOG_DOMAIN, G_LOG_LEVEL_INFO, " TODO: %s():%d: " fmt,            \
+         G_STRFUNC, __LINE__, ##__VA_ARGS__)
+# define VALENT_FIXME(fmt, ...)                                             \
+   g_log(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "FIXME: %s():%d: " fmt,         \
+         G_STRFUNC, __LINE__, ##__VA_ARGS__)
 # define VALENT_JSON(_node, _ctx)                                           \
    G_STMT_START {                                                           \
      char *__json_str = json_to_string (_node, TRUE);                       \
@@ -192,8 +196,8 @@ void valent_trace_mark (const char *strfunc,
    } G_STMT_END
 #else
 # define VALENT_NOTE(fmt, ...)         G_STMT_START {          } G_STMT_END
-# define VALENT_FIXME(_msg)            G_STMT_START {          } G_STMT_END
-# define VALENT_TODO(_msg)             G_STMT_START {          } G_STMT_END
+# define VALENT_TODO(fmt, ...)         G_STMT_START {          } G_STMT_END
+# define VALENT_FIXME(fmt, ...)        G_STMT_START {          } G_STMT_END
 # define VALENT_JSON(_node, _ctx)      G_STMT_START {          } G_STMT_END
 #endif
 

--- a/src/libvalent/ui/valent-application.c
+++ b/src/libvalent/ui/valent-application.c
@@ -31,6 +31,30 @@ struct _ValentApplication
 G_DEFINE_TYPE (ValentApplication, valent_application, GTK_TYPE_APPLICATION)
 
 
+static void
+valent_application_present_window (ValentApplication *self,
+                                   const char        *startup_id)
+{
+  g_assert (VALENT_IS_APPLICATION (self));
+
+  if (self->window == NULL)
+    {
+      self->window = g_object_new (VALENT_TYPE_WINDOW,
+                                   "application",    self,
+                                   "default-width",  600,
+                                   "default-height", 480,
+                                   "manager",        self->manager,
+                                   NULL);
+      g_object_add_weak_pointer (G_OBJECT (self->window),
+                                 (gpointer) &self->window);
+    }
+
+  if (startup_id != NULL)
+    gtk_window_set_startup_id (self->window, startup_id);
+
+  gtk_window_present_with_time (self->window, GDK_CURRENT_TIME);
+}
+
 /*
  * GActions
  */
@@ -103,19 +127,7 @@ prefs_action (GSimpleAction *action,
 
   g_assert (VALENT_IS_APPLICATION (self));
 
-  if (self->window == NULL)
-    {
-      self->window = g_object_new (VALENT_TYPE_WINDOW,
-                                   "application",    self,
-                                   "default-width",  600,
-                                   "default-height", 480,
-                                   "manager",        self->manager,
-                                   NULL);
-      g_object_add_weak_pointer (G_OBJECT (self->window),
-                                 (gpointer) &self->window);
-    }
-
-  gtk_window_present_with_time (self->window, GDK_CURRENT_TIME);
+  valent_application_present_window (self, NULL);
 }
 
 static void
@@ -161,12 +173,7 @@ valent_application_activate (GApplication *application)
 
   g_assert (VALENT_IS_APPLICATION (self));
 
-  /* This isn't really ideal for a few reasons:
-   *
-   * - Interacting with device notifications can trigger this
-   * - It happens at startup, which isn't desirable if acting as a service
-   */
-  prefs_action (NULL, NULL, self);
+  valent_application_present_window (self, NULL);
 }
 
 static void

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -260,7 +260,7 @@ valent_telephony_plugin_handle_telephony (ValentTelephonyPlugin *self,
   /* Currently, only "ringing" and "talking" events are supported */
   if (g_strcmp0 (event, "ringing") != 0 && g_strcmp0 (event, "talking") != 0)
     {
-      VALENT_TODO (event);
+      VALENT_TODO ("\"%s\" event", event);
       return;
     }
 


### PR DESCRIPTION
Rather than having the GApplication::activate handler call the
preferences action, which is kind of weird, have them both call a
new `valent_application_present_window()` function.

This comes with a `startup_id` argument, which might be useful sometime?