### PR TITLE
meson: set symbol visibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,6 +128,10 @@ if get_option('optimization') in ['2', '3', 's']
   endif
 endif
 
+if get_option('default_library') != 'static'
+  project_c_args += ['-fvisibility=hidden']
+endif
+
 add_project_arguments(cc.get_supported_arguments(project_c_args),
   language: 'c',
 )
@@ -183,6 +187,10 @@ config_h_functions = {
 foreach define, function : config_h_functions
   config_h.set(define, cc.has_function(function))
 endforeach
+
+if cc.has_argument('-fvisibility=hidden')
+  config_h.set('_VALENT_EXTERN', '__attribute__((visibility("default"))) extern')
+endif
 
 configure_file(
          output: 'config.h',

--- a/src/libvalent/clipboard/valent-clipboard-adapter.h
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.h
@@ -7,12 +7,13 @@
 # error "Only <libvalent-clipboard.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CLIPBOARD_ADAPTER (valent_clipboard_adapter_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentClipboardAdapter, valent_clipboard_adapter, VALENT, CLIPBOARD_ADAPTER, GObject)
 
 struct _ValentClipboardAdapterClass
@@ -35,16 +36,21 @@ struct _ValentClipboardAdapterClass
   void           (*changed)         (ValentClipboardAdapter  *adapter);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void     valent_clipboard_adapter_emit_changed    (ValentClipboardAdapter  *adapter);
+VALENT_AVAILABLE_IN_1_0
 void     valent_clipboard_adapter_get_text_async  (ValentClipboardAdapter  *adapter,
                                                    GCancellable            *cancellable,
                                                    GAsyncReadyCallback      callback,
                                                    gpointer                 user_data);
+VALENT_AVAILABLE_IN_1_0
 char   * valent_clipboard_adapter_get_text_finish (ValentClipboardAdapter  *adapter,
                                                    GAsyncResult            *result,
                                                    GError                 **error);
+VALENT_AVAILABLE_IN_1_0
 void     valent_clipboard_adapter_set_text        (ValentClipboardAdapter  *adapter,
                                                    const char              *text);
+VALENT_AVAILABLE_IN_1_0
 gint64   valent_clipboard_adapter_get_timestamp   (ValentClipboardAdapter  *adapter);
 
 G_END_DECLS

--- a/src/libvalent/clipboard/valent-clipboard.h
+++ b/src/libvalent/clipboard/valent-clipboard.h
@@ -13,19 +13,25 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_CLIPBOARD (valent_clipboard_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentClipboard, valent_clipboard, VALENT, CLIPBOARD, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 void              valent_clipboard_get_text_async  (ValentClipboard      *clipboard,
                                                     GCancellable         *cancellable,
                                                     GAsyncReadyCallback   callback,
                                                     gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 char            * valent_clipboard_get_text_finish (ValentClipboard      *clipboard,
                                                     GAsyncResult         *result,
                                                     GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void              valent_clipboard_set_text        (ValentClipboard      *clipboard,
                                                     const char           *text);
+VALENT_AVAILABLE_IN_1_0
 gint64            valent_clipboard_get_timestamp   (ValentClipboard      *clipboard);
 
+VALENT_AVAILABLE_IN_1_0
 ValentClipboard * valent_clipboard_get_default     (void);
 
 G_END_DECLS

--- a/src/libvalent/contacts/meson.build
+++ b/src/libvalent/contacts/meson.build
@@ -45,6 +45,7 @@ libvalent_contacts_public_sources = [
 libvalent_contacts_enums = gnome.mkenums_simple('valent-contacts-enums',
      body_prefix: '#include "config.h"',
    header_prefix: '#include <libvalent-core.h>',
+       decorator: '_VALENT_EXTERN',
          sources: libvalent_contacts_enum_headers,
   install_header: true,
      install_dir: libvalent_contacts_header_dir,

--- a/src/libvalent/contacts/valent-contact-cache.h
+++ b/src/libvalent/contacts/valent-contact-cache.h
@@ -7,7 +7,6 @@
 # error "Only <libvalent-contacts.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
 #include <libvalent-core.h>
 
 #include "valent-contact-store.h"
@@ -16,6 +15,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_CONTACT_CACHE (valent_contact_cache_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentContactCache, valent_contact_cache, VALENT, CONTACT_CACHE, ValentContactStore)
 
 G_END_DECLS

--- a/src/libvalent/contacts/valent-contact-store-provider.h
+++ b/src/libvalent/contacts/valent-contact-store-provider.h
@@ -7,14 +7,15 @@
 # error "Only <libvalent-contacts.h> can be included directly."
 #endif
 
-#include "valent-contact-store.h"
+#include <libvalent-core.h>
 
-#include <gio/gio.h>
+#include "valent-contact-store.h"
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CONTACT_STORE_PROVIDER (valent_contact_store_provider_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentContactStoreProvider, valent_contact_store_provider, VALENT, CONTACT_STORE_PROVIDER, GObject)
 
 struct _ValentContactStoreProviderClass
@@ -37,15 +38,20 @@ struct _ValentContactStoreProviderClass
                                    ValentContactStore          *store);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void        valent_contact_store_provider_emit_store_added   (ValentContactStoreProvider  *provider,
                                                               ValentContactStore          *store);
+VALENT_AVAILABLE_IN_1_0
 void        valent_contact_store_provider_emit_store_removed (ValentContactStoreProvider  *provider,
                                                               ValentContactStore          *store);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray * valent_contact_store_provider_get_stores         (ValentContactStoreProvider  *provider);
+VALENT_AVAILABLE_IN_1_0
 void        valent_contact_store_provider_load_async         (ValentContactStoreProvider  *provider,
                                                               GCancellable                *cancellable,
                                                               GAsyncReadyCallback          callback,
                                                               gpointer                     user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean    valent_contact_store_provider_load_finish        (ValentContactStoreProvider  *provider,
                                                               GAsyncResult                *result,
                                                               GError                     **error);

--- a/src/libvalent/contacts/valent-contact-store.h
+++ b/src/libvalent/contacts/valent-contact-store.h
@@ -7,7 +7,6 @@
 # error "Only <libvalent-contacts.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
 #include <libvalent-core.h>
 
 #include "valent-eds.h"
@@ -16,6 +15,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_CONTACT_STORE (valent_contact_store_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentContactStore, valent_contact_store, VALENT, CONTACT_STORE, ValentObject)
 
 struct _ValentContactStoreClass
@@ -52,67 +52,86 @@ struct _ValentContactStoreClass
 };
 
 
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_emit_contact_added   (ValentContactStore   *store,
                                                         EContact             *contact);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_emit_contact_removed (ValentContactStore   *store,
                                                         const char           *uid);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_contact_store_get_name             (ValentContactStore   *store);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_set_name             (ValentContactStore   *store,
                                                         const char           *name);
+VALENT_AVAILABLE_IN_1_0
 ESource    * valent_contact_store_get_source           (ValentContactStore   *store);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_contact_store_get_uid              (ValentContactStore   *store);
 
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_add_contact          (ValentContactStore   *store,
                                                         EContact             *contact,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_add_contacts         (ValentContactStore   *store,
                                                         GSList               *contacts,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_contact_store_add_finish           (ValentContactStore   *store,
                                                         GAsyncResult         *result,
                                                         GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_remove_contact       (ValentContactStore   *store,
                                                         const char           *uid,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_contact_store_remove_finish        (ValentContactStore   *store,
                                                         GAsyncResult         *result,
                                                         GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_get_contact          (ValentContactStore   *store,
                                                         const char           *uid,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 EContact   * valent_contact_store_get_contact_finish   (ValentContactStore   *store,
                                                         GAsyncResult         *result,
                                                         GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_get_contacts         (ValentContactStore   *store,
                                                         char                **uids,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_query                (ValentContactStore   *store,
                                                         const char           *query,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 GSList     * valent_contact_store_query_finish         (ValentContactStore   *store,
                                                         GAsyncResult         *result,
                                                         GError              **error);
 
 /* Convenience Methods */
+VALENT_AVAILABLE_IN_1_0
 EContact   * valent_contact_store_dup_for_phone        (ValentContactStore   *store,
                                                         const char           *number);
+VALENT_AVAILABLE_IN_1_0
 void         valent_contact_store_dup_for_phone_async  (ValentContactStore   *store,
                                                         const char           *number,
                                                         GCancellable         *cancellable,
                                                         GAsyncReadyCallback   callback,
                                                         gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 EContact   * valent_contact_store_dup_for_phone_finish (ValentContactStore   *store,
                                                         GAsyncResult         *result,
                                                         GError              **error);

--- a/src/libvalent/contacts/valent-contact-utils.h
+++ b/src/libvalent/contacts/valent-contact-utils.h
@@ -3,15 +3,18 @@
 
 #pragma once
 
-#include <glib.h>
+#include <libvalent-core.h>
 
 #include "valent-eds.h"
 
 G_BEGIN_DECLS
 
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_phone_number_equal              (const char  *number1,
                                                    const char  *number2);
+VALENT_AVAILABLE_IN_1_0
 char     * valent_phone_number_normalize          (const char  *number);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_phone_number_of_contact         (EContact    *contact,
                                                    const char  *number);
 

--- a/src/libvalent/contacts/valent-contacts.h
+++ b/src/libvalent/contacts/valent-contacts.h
@@ -60,15 +60,20 @@ typedef enum
 
 #define VALENT_TYPE_CONTACTS (valent_contacts_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentContacts, valent_contacts, VALENT, CONTACTS, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 ValentContacts     * valent_contacts_get_default  (void);
 
+VALENT_AVAILABLE_IN_1_0
 ValentContactStore * valent_contacts_ensure_store (ValentContacts *contacts,
                                                    const char     *uid,
                                                    const char     *name);
+VALENT_AVAILABLE_IN_1_0
 ValentContactStore * valent_contacts_get_store    (ValentContacts *contacts,
                                                    const char     *uid);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray          * valent_contacts_get_stores   (ValentContacts *contacts);
 
 G_END_DECLS

--- a/src/libvalent/core/libvalent-core.h
+++ b/src/libvalent/core/libvalent-core.h
@@ -19,6 +19,7 @@
 #include "valent-packet.h"
 #include "valent-transfer.h"
 #include "valent-utils.h"
+#include "valent-version.h"
 
 #undef VALENT_CORE_INSIDE
 

--- a/src/libvalent/core/meson.build
+++ b/src/libvalent/core/meson.build
@@ -58,7 +58,25 @@ libvalent_core_public_sources = [
   'valent-packet.c',
   'valent-transfer.c',
   'valent-utils.c',
+  'valent-version.c',
 ]
+
+
+# Versioning
+version_data = configuration_data()
+version_data.set('MAJOR_VERSION', MAJOR_VERSION)
+version_data.set('MINOR_VERSION', MINOR_VERSION)
+version_data.set('VERSION', meson.project_version())
+
+libvalent_core_version_h = configure_file(
+          input: 'valent-version.h.in',
+         output: 'valent-version.h',
+  configuration: version_data,
+        install: true,
+    install_dir: libvalent_core_header_dir,
+)
+
+libvalent_core_generated_headers += [libvalent_core_version_h]
 
 
 # Debugging and Profiling Support
@@ -81,6 +99,7 @@ libvalent_core_generated_headers += [libvalent_debug_h]
 libvalent_core_enums = gnome.mkenums_simple('valent-core-enums',
           body_prefix: '#include "config.h"',
         header_prefix: '#include <libvalent-core.h>',
+            decorator: '_VALENT_EXTERN',
               sources: libvalent_core_enum_headers,
        install_header: true,
           install_dir: libvalent_core_header_dir,

--- a/src/libvalent/core/valent-certificate.h
+++ b/src/libvalent/core/valent-certificate.h
@@ -9,18 +9,26 @@
 
 #include <gio/gio.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
+VALENT_AVAILABLE_IN_1_0
 void              valent_certificate_new             (const char           *path,
                                                       GCancellable         *cancellable,
                                                       GAsyncReadyCallback   callback,
                                                       gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 GTlsCertificate * valent_certificate_new_finish      (GAsyncResult         *result,
                                                       GError              **error);
+VALENT_AVAILABLE_IN_1_0
 GTlsCertificate * valent_certificate_new_sync        (const char           *path,
                                                       GError              **error);
+VALENT_AVAILABLE_IN_1_0
 const char      * valent_certificate_get_common_name (GTlsCertificate  *certificate);
+VALENT_AVAILABLE_IN_1_0
 const char      * valent_certificate_get_fingerprint (GTlsCertificate  *certificate);
+VALENT_AVAILABLE_IN_1_0
 GByteArray      * valent_certificate_get_public_key  (GTlsCertificate  *certificate);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-channel-service.h
+++ b/src/libvalent/core/valent-channel-service.h
@@ -19,6 +19,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_CHANNEL_SERVICE (valent_channel_service_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentChannelService, valent_channel_service, VALENT, CHANNEL_SERVICE, ValentObject)
 
 struct _ValentChannelServiceClass
@@ -43,22 +44,31 @@ struct _ValentChannelServiceClass
                                          ValentChannel         *channel);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void       valent_channel_service_emit_channel    (ValentChannelService  *service,
                                                    ValentChannel         *channel);
+VALENT_AVAILABLE_IN_1_0
 char     * valent_channel_service_dup_id          (ValentChannelService  *service);
+VALENT_AVAILABLE_IN_1_0
 JsonNode * valent_channel_service_ref_identity    (ValentChannelService  *service);
 
+VALENT_AVAILABLE_IN_1_0
 void       valent_channel_service_build_identity  (ValentChannelService  *service);
+VALENT_AVAILABLE_IN_1_0
 void       valent_channel_service_identify        (ValentChannelService  *service,
                                                    const char            *target);
+VALENT_AVAILABLE_IN_1_0
 void       valent_channel_service_start           (ValentChannelService  *service,
                                                    GCancellable          *cancellable,
                                                    GAsyncReadyCallback    callback,
                                                    gpointer               user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_channel_service_start_finish    (ValentChannelService  *service,
                                                    GAsyncResult          *result,
                                                    GError               **error);
+VALENT_AVAILABLE_IN_1_0
 void       valent_channel_service_stop            (ValentChannelService  *service);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_channel_service_supports_plugin (ValentChannelService  *service,
                                                    PeasPluginInfo        *info);
 

--- a/src/libvalent/core/valent-channel.h
+++ b/src/libvalent/core/valent-channel.h
@@ -17,6 +17,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_CHANNEL (valent_channel_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentChannel, valent_channel, VALENT, CHANNEL, ValentObject)
 
 struct _ValentChannelClass
@@ -38,42 +39,56 @@ struct _ValentChannelClass
 };
 
 
+VALENT_AVAILABLE_IN_1_0
 GIOStream  * valent_channel_ref_base_stream      (ValentChannel        *channel);
+VALENT_AVAILABLE_IN_1_0
 JsonNode   * valent_channel_get_identity         (ValentChannel        *channel);
+VALENT_AVAILABLE_IN_1_0
 JsonNode   * valent_channel_get_peer_identity    (ValentChannel        *channel);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_channel_get_verification_key (ValentChannel        *channel);
+VALENT_AVAILABLE_IN_1_0
 GIOStream  * valent_channel_download             (ValentChannel        *channel,
                                                   JsonNode             *packet,
                                                   GCancellable         *cancellable,
                                                   GError              **error);
+VALENT_AVAILABLE_IN_1_0
 GIOStream  * valent_channel_upload               (ValentChannel        *channel,
                                                   JsonNode             *packet,
                                                   GCancellable         *cancellable,
                                                   GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_channel_store_data           (ValentChannel        *channel,
                                                   ValentData           *data);
+VALENT_AVAILABLE_IN_1_0
 void         valent_channel_read_packet          (ValentChannel        *channel,
                                                   GCancellable         *cancellable,
                                                   GAsyncReadyCallback   callback,
                                                   gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 JsonNode   * valent_channel_read_packet_finish   (ValentChannel        *channel,
                                                   GAsyncResult         *result,
                                                   GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_channel_write_packet         (ValentChannel        *channel,
                                                   JsonNode             *packet,
                                                   GCancellable         *cancellable,
                                                   GAsyncReadyCallback   callback,
                                                   gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_channel_write_packet_finish  (ValentChannel        *channel,
                                                   GAsyncResult         *result,
                                                   GError              **error);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_channel_close                (ValentChannel        *channel,
                                                   GCancellable         *cancellable,
                                                   GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void         valent_channel_close_async          (ValentChannel        *channel,
                                                   GCancellable         *cancellable,
                                                   GAsyncReadyCallback   callback,
                                                   gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_channel_close_finish         (ValentChannel        *channel,
                                                   GAsyncResult         *result,
                                                   GError              **error);

--- a/src/libvalent/core/valent-component.h
+++ b/src/libvalent/core/valent-component.h
@@ -10,10 +10,13 @@
 #include <gio/gio.h>
 #include <libpeas/peas.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_COMPONENT (valent_component_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentComponent, valent_component, VALENT, COMPONENT, GObject)
 
 struct _ValentComponentClass
@@ -27,8 +30,10 @@ struct _ValentComponentClass
                                        PeasExtension   *extension);
 };
 
+VALENT_AVAILABLE_IN_1_0
 PeasExtension * valent_component_get_priority_provider (ValentComponent *component,
                                                         const char      *key);
+VALENT_AVAILABLE_IN_1_0
 GSettings     * valent_component_new_settings          (const char      *context,
                                                         const char      *module_name);
 

--- a/src/libvalent/core/valent-data.h
+++ b/src/libvalent/core/valent-data.h
@@ -9,10 +9,13 @@
 
 #include <gio/gio.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_DATA (valent_data_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentData, valent_data, VALENT, DATA, GObject)
 
 struct _ValentDataClass
@@ -20,28 +23,41 @@ struct _ValentDataClass
   GObjectClass   parent_class;
 };
 
+VALENT_AVAILABLE_IN_1_0
 ValentData    * valent_data_new          (const char      *context,
                                           ValentData      *parent);
 
 /* Properties */
+VALENT_AVAILABLE_IN_1_0
 const char * valent_data_get_cache_path  (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_data_get_config_path (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_data_get_data_path   (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_data_get_context     (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 ValentData * valent_data_get_parent      (ValentData      *data);
 
 /* Public Methods */
+VALENT_AVAILABLE_IN_1_0
 void         valent_data_clear_cache     (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 void         valent_data_clear_data      (ValentData      *data);
+VALENT_AVAILABLE_IN_1_0
 GFile      * valent_data_new_cache_file  (ValentData      *data,
                                           const char      *filename);
+VALENT_AVAILABLE_IN_1_0
 GFile      * valent_data_new_config_file (ValentData      *data,
                                           const char      *filename);
+VALENT_AVAILABLE_IN_1_0
 GFile      * valent_data_new_data_file   (ValentData      *data,
                                           const char      *filename);
 
 /* Static Utilities */
+VALENT_AVAILABLE_IN_1_0
 char       * valent_data_get_directory   (GUserDirectory   directory);
+VALENT_AVAILABLE_IN_1_0
 GFile      * valent_data_get_file        (const char      *dirname,
                                           const char      *basename,
                                           gboolean         unique);

--- a/src/libvalent/core/valent-debug.h.in
+++ b/src/libvalent/core/valent-debug.h.in
@@ -10,9 +10,13 @@
 
 #include <glib.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
+VALENT_AVAILABLE_IN_1_0
 void   valent_debug_init  (void);
+VALENT_AVAILABLE_IN_1_0
 void   valent_debug_clear (void);
 
 

--- a/src/libvalent/core/valent-device-plugin.h
+++ b/src/libvalent/core/valent-device-plugin.h
@@ -26,6 +26,7 @@ typedef struct
 
 #define VALENT_TYPE_DEVICE_PLUGIN (valent_device_plugin_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_INTERFACE (ValentDevicePlugin, valent_device_plugin, VALENT, DEVICE_PLUGIN, GObject)
 
 struct _ValentDevicePluginInterface
@@ -43,47 +44,62 @@ struct _ValentDevicePluginInterface
 };
 
 /* Core Interface */
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_disable             (ValentDevicePlugin    *plugin);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_enable              (ValentDevicePlugin    *plugin);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_handle_packet       (ValentDevicePlugin    *plugin,
                                                       const char            *type,
                                                       JsonNode              *packet);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_update_state        (ValentDevicePlugin    *plugin,
                                                       ValentDeviceState      state);
 
 /* Utility Functions */
+VALENT_AVAILABLE_IN_1_0
 GSettings * valent_device_plugin_new_settings        (const char            *device_id,
                                                       const char            *module_name);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_register_actions    (ValentDevicePlugin    *plugin,
                                                       const GActionEntry    *entries,
                                                       int                    n_entries);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_unregister_actions  (ValentDevicePlugin    *plugin,
                                                       const GActionEntry    *entries,
                                                       int                    n_entries);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_toggle_actions      (ValentDevicePlugin    *plugin,
                                                       const GActionEntry    *actions,
                                                       int                    n_entries,
                                                       gboolean               state);
 
 /* TODO: GMenuModel XML */
+VALENT_AVAILABLE_IN_1_0
 int          valent_device_plugin_find_menu_item     (ValentDevicePlugin    *plugin,
                                                       const char            *attribute,
                                                       const GVariant        *value);
+VALENT_AVAILABLE_IN_1_0
 int          valent_device_plugin_remove_menu_item   (ValentDevicePlugin    *plugin,
                                                       const char            *attribute,
                                                       const GVariant        *value);
+VALENT_AVAILABLE_IN_1_0
 void         valent_device_plugin_replace_menu_item  (ValentDevicePlugin    *plugin,
                                                       GMenuItem             *item,
                                                       const char            *attribute);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_add_menu_entries    (ValentDevicePlugin    *plugin,
                                                       const ValentMenuEntry *entries,
                                                       int                    n_entries);
+VALENT_AVAILABLE_IN_1_0
 void        valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
                                                       const ValentMenuEntry *entries,
                                                       int                    n_entries);
 
 /* Plugin Info Helpers */
+VALENT_AVAILABLE_IN_1_0
 GStrv       valent_device_plugin_get_incoming        (PeasPluginInfo        *info);
+VALENT_AVAILABLE_IN_1_0
 GStrv       valent_device_plugin_get_outgoing        (PeasPluginInfo        *info);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -39,35 +39,54 @@ typedef enum
 
 #define VALENT_TYPE_DEVICE (valent_device_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentDevice, valent_device, VALENT, DEVICE, ValentObject)
 
+VALENT_AVAILABLE_IN_1_0
 ValentDevice      * valent_device_new                (const char           *id);
+VALENT_AVAILABLE_IN_1_0
 GActionGroup      * valent_device_get_actions        (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 ValentChannel     * valent_device_ref_channel        (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 ValentData        * valent_device_ref_data           (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_get_connected      (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_icon_name      (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_id             (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 GMenuModel        * valent_device_get_menu           (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_name           (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_get_paired         (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_device_get_plugins        (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 ValentDeviceState   valent_device_get_state          (ValentDevice         *device);
+VALENT_AVAILABLE_IN_1_0
 void                valent_device_queue_packet       (ValentDevice         *device,
                                                       JsonNode             *packet);
+VALENT_AVAILABLE_IN_1_0
 void                valent_device_send_packet        (ValentDevice         *device,
                                                       JsonNode             *packet,
                                                       GCancellable         *cancellable,
                                                       GAsyncReadyCallback   callback,
                                                       gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_send_packet_finish (ValentDevice         *device,
                                                       GAsyncResult         *result,
                                                       GError              **error);
+VALENT_AVAILABLE_IN_1_0
 void                valent_device_hide_notification  (ValentDevice         *device,
                                                       const char           *id);
+VALENT_AVAILABLE_IN_1_0
 void                valent_device_show_notification  (ValentDevice         *device,
                                                       const char           *id,
                                                       GNotification        *notification);
+VALENT_AVAILABLE_IN_1_0
 GFile             * valent_device_new_download_file  (ValentDevice         *device,
                                                       const char           *filename,
                                                       gboolean              unique);

--- a/src/libvalent/core/valent-manager.h
+++ b/src/libvalent/core/valent-manager.h
@@ -16,30 +16,41 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MANAGER (valent_manager_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentManager, valent_manager, VALENT, MANAGER, GObject)
 
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_new         (ValentData           *data,
                                             GCancellable         *cancellable,
                                             GAsyncReadyCallback   callback,
                                             gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 ValentManager * valent_manager_new_finish  (GAsyncResult         *result,
                                             GError              **error);
+VALENT_AVAILABLE_IN_1_0
 ValentManager * valent_manager_new_sync    (ValentData           *data,
                                             GCancellable         *cancellable,
                                             GError              **error);
-
+VALENT_AVAILABLE_IN_1_0
 ValentDevice  * valent_manager_get_device  (ValentManager        *manager,
                                             const char           *id);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray     * valent_manager_get_devices (ValentManager        *manager);
+VALENT_AVAILABLE_IN_1_0
 const char    * valent_manager_get_id      (ValentManager        *manager);
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_identify    (ValentManager        *manager,
                                             const char           *uri);
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_start       (ValentManager        *manager);
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_stop        (ValentManager        *manager);
 
 /* D-Bus */
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_export      (ValentManager        *manager,
                                             GDBusConnection      *connection);
+VALENT_AVAILABLE_IN_1_0
 void            valent_manager_unexport    (ValentManager        *manager);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-object.h
+++ b/src/libvalent/core/valent-object.h
@@ -10,10 +10,13 @@
 
 #include <gio/gio.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_OBJECT (valent_object_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentObject, valent_object, VALENT, OBJECT, GObject)
 
 struct _ValentObjectClass
@@ -23,19 +26,28 @@ struct _ValentObjectClass
   void           (*destroy)     (ValentObject *object);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_lock              (ValentObject  *object);
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_unlock            (ValentObject  *object);
+VALENT_AVAILABLE_IN_1_0
 GCancellable * valent_object_ref_cancellable   (ValentObject  *object);
+VALENT_AVAILABLE_IN_1_0
 gboolean       valent_object_in_destruction    (ValentObject  *object);
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_destroy           (ValentObject  *object);
 
 /* Utilities */
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_notify            (gpointer       object,
                                                 const char    *property_name);
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_notify_by_pspec   (gpointer       object,
                                                 GParamSpec    *pspec);
 
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_list_free         (gpointer       list);
+VALENT_AVAILABLE_IN_1_0
 void           valent_object_slist_free        (gpointer       slist);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-packet.h
+++ b/src/libvalent/core/valent-packet.h
@@ -10,6 +10,8 @@
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
 
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
 
@@ -33,6 +35,7 @@ typedef enum {
   VALENT_PACKET_ERROR_MISSING_FIELD,
 } ValentPacketError;
 
+VALENT_AVAILABLE_IN_1_0
 GQuark   valent_packet_error_quark (void);
 #define VALENT_PACKET_ERROR (valent_packet_error_quark ())
 
@@ -87,41 +90,60 @@ valent_packet_is_valid (JsonNode *packet)
 
 
 /* Packet Helpers */
+VALENT_AVAILABLE_IN_1_0
 JsonNode    * valent_packet_new              (const char     *type);
+VALENT_AVAILABLE_IN_1_0
 JsonBuilder * valent_packet_start            (const char     *type);
+VALENT_AVAILABLE_IN_1_0
 JsonNode    * valent_packet_finish           (JsonBuilder    *builder);
+VALENT_AVAILABLE_IN_1_0
 gint64        valent_packet_get_id           (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 const char  * valent_packet_get_type         (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 JsonObject  * valent_packet_get_body         (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 gboolean      valent_packet_has_payload      (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 JsonObject  * valent_packet_get_payload_full (JsonNode       *packet,
                                               gssize         *size,
                                               GError        **error);
+VALENT_AVAILABLE_IN_1_0
 void          valent_packet_set_payload_full (JsonNode       *packet,
                                               JsonObject     *info,
                                               gssize          size);
+VALENT_AVAILABLE_IN_1_0
 JsonObject  * valent_packet_get_payload_info (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 void          valent_packet_set_payload_info (JsonNode       *packet,
                                               JsonObject     *info);
+VALENT_AVAILABLE_IN_1_0
 gssize        valent_packet_get_payload_size (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 void          valent_packet_set_payload_size (JsonNode       *packet,
                                               gssize          size);
 
 /* I/O Helpers */
+VALENT_AVAILABLE_IN_1_0
 gboolean      valent_packet_validate         (JsonNode       *packet,
                                               GError        **error);
+VALENT_AVAILABLE_IN_1_0
 JsonNode    * valent_packet_from_stream      (GInputStream   *stream,
                                               GCancellable   *cancellable,
                                               GError        **error);
+VALENT_AVAILABLE_IN_1_0
 gboolean      valent_packet_to_stream        (GOutputStream  *stream,
                                               JsonNode       *packet,
                                               GCancellable   *cancellable,
                                               GError        **error);
+VALENT_AVAILABLE_IN_1_0
 char        * valent_packet_serialize        (JsonNode       *packet);
+VALENT_AVAILABLE_IN_1_0
 JsonNode    * valent_packet_deserialize      (const char     *json,
                                               GError        **error);
 
 /* Identity Packets */
+VALENT_AVAILABLE_IN_1_0
 const char  * valent_identity_get_device_id  (JsonNode       *identity);
 
 /**

--- a/src/libvalent/core/valent-transfer.h
+++ b/src/libvalent/core/valent-transfer.h
@@ -11,6 +11,9 @@
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
 
+#include "valent-device.h"
+#include "valent-version.h"
+
 G_BEGIN_DECLS
 
 /**
@@ -30,6 +33,7 @@ typedef enum
 
 #define VALENT_TYPE_TRANSFER (valent_transfer_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentTransfer, valent_transfer, VALENT, TRANSFER, GObject)
 
 struct _ValentTransferClass
@@ -37,36 +41,48 @@ struct _ValentTransferClass
   GObjectClass parent_class;
 };
 
+VALENT_AVAILABLE_IN_1_0
 ValentTransfer      * valent_transfer_new            (ValentDevice         *device);
 
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_add_bytes      (ValentTransfer       *transfer,
                                                       JsonNode             *packet,
                                                       GBytes               *bytes);
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_add_file       (ValentTransfer       *transfer,
                                                       JsonNode             *packet,
                                                       GFile                *file);
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_add_stream     (ValentTransfer       *transfer,
                                                       JsonNode             *packet,
                                                       GInputStream         *source,
                                                       GOutputStream        *target,
                                                       gssize                size);
+VALENT_AVAILABLE_IN_1_0
 GFile *               valent_transfer_cache_file     (ValentTransfer       *transfer,
                                                       JsonNode             *packet,
                                                       const char           *name);
 
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_cancel         (ValentTransfer       *transfer);
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_execute        (ValentTransfer       *transfer,
                                                       GCancellable         *cancellable,
                                                       GAsyncReadyCallback   callback,
                                                       gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean              valent_transfer_execute_finish (ValentTransfer       *transfer,
                                                       GAsyncResult         *result,
                                                       GError              **error);
 
+VALENT_AVAILABLE_IN_1_0
 ValentDevice        * valent_transfer_get_device     (ValentTransfer       *transfer);
+VALENT_AVAILABLE_IN_1_0
 const char          * valent_transfer_get_id         (ValentTransfer       *transfer);
+VALENT_AVAILABLE_IN_1_0
 void                  valent_transfer_set_id         (ValentTransfer       *transfer,
                                                       const char           *id);
+VALENT_AVAILABLE_IN_1_0
 ValentTransferState   valent_transfer_get_state      (ValentTransfer       *transfer);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-utils.h
+++ b/src/libvalent/core/valent-utils.h
@@ -14,19 +14,26 @@
 
 G_BEGIN_DECLS
 
+VALENT_AVAILABLE_IN_1_0
 PeasEngine * valent_get_engine      (void);
+VALENT_AVAILABLE_IN_1_0
 GThread    * valent_get_main_thread (void);
+VALENT_AVAILABLE_IN_1_0
 gboolean     valent_in_flatpak      (void);
+VALENT_AVAILABLE_IN_1_0
 void         valent_load_plugins    (PeasEngine *engine);
+VALENT_AVAILABLE_IN_1_0
 gint64       valent_timestamp_ms    (void);
 
 
 /* Miscellaneous Helpers */
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_set_device_action (GNotification *notification,
                                                   ValentDevice  *device,
                                                   const char    *action,
                                                   GVariant      *target);
 
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_add_device_button (GNotification *notification,
                                                   ValentDevice  *device,
                                                   const char    *label,

--- a/src/libvalent/core/valent-version.c
+++ b/src/libvalent/core/valent-version.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2022 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include "config.h"
+
+#include <glib.h>
+
+#include "valent-version.h"
+
+
+/**
+ * valent_check_version:
+ * @major: required major version
+ * @minor: required minor version
+ *
+ * Run-time version check. Evaluates to %TRUE if the running version of
+ * Valent is greater than or equal to the required one.
+ *
+ * Returns: %TRUE if the requirement is met, or %FALSE if not
+ */
+gboolean
+valent_check_version (unsigned int major,
+                      unsigned int minor)
+{
+  if (major > VALENT_MAJOR_VERSION)
+    return TRUE;
+
+  if (major == VALENT_MAJOR_VERSION && minor >= VALENT_MINOR_VERSION)
+    return TRUE;
+
+  return FALSE;
+}
+
+/**
+ * valent_get_major_version:
+ *
+ * Get the major version component of the Valent library. For example, if the
+ * version `1.2` this is `1`.
+ *
+ * Returns: the major version component of libvalent
+ */
+unsigned int
+valent_get_major_version (void)
+{
+  return VALENT_MAJOR_VERSION;
+}
+
+/**
+ * valent_get_minor_version:
+ *
+ * Get the minor version component of the Valent library. For example, if the
+ * version `1.2` this is `2`.
+ *
+ * Returns: the minor version component of libvalent
+ */
+unsigned int
+valent_get_minor_version (void)
+{
+  return VALENT_MINOR_VERSION;
+}
+

--- a/src/libvalent/core/valent-version.h.in
+++ b/src/libvalent/core/valent-version.h.in
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2022 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#if !defined(VALENT_CORE_INSIDE) && !defined(VALENT_CORE_COMPILATION)
+# error "Only <libvalent-core.h> can be included directly."
+#endif
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#ifndef _VALENT_EXTERN
+#define _VALENT_EXTERN extern
+#endif
+
+// TODO: replace with `valent-version-macros.h`
+#ifndef VALENT_AVAILABLE_IN_1_0
+#define VALENT_AVAILABLE_IN_1_0 _VALENT_EXTERN
+#endif
+
+/**
+ * VALENT_MAJOR_VERSION:
+ *
+ * The major version component of libvalent (e.g. 1 if %VALENT_VERSION is 1.2)
+ */
+#define VALENT_MAJOR_VERSION (@MAJOR_VERSION@)
+
+/**
+ * VALENT_MINOR_VERSION:
+ *
+ * The minor version component of libvalent (e.g. 2 if %VALENT_VERSION is 1.2)
+ */
+#define VALENT_MINOR_VERSION (@MINOR_VERSION@)
+
+/**
+ * VALENT_VERSION
+ *
+ * libvalent version.
+ */
+#define VALENT_VERSION (@VERSION@)
+
+/**
+ * VALENT_VERSION_S:
+ *
+ * libvalent version, encoded as a string, useful for printing and
+ * concatenation.
+ */
+#define VALENT_VERSION_S "@VERSION@"
+
+/**
+ * VALENT_CHECK_VERSION:
+ * @major: required major version
+ * @minor: required minor version
+ *
+ * Compile-time version check. Evaluates to %TRUE if the version of libvalent is
+ * is greater than or equal to the required one.
+ *
+ * Returns: %TRUE if the requirement is met, or %FALSE if not
+ */
+#define VALENT_CHECK_VERSION(major,minor)  \
+        (VALENT_MAJOR_VERSION > (major) || \
+         (VALENT_MAJOR_VERSION == (major) && VALENT_MINOR_VERSION > (minor)))
+
+
+VALENT_AVAILABLE_IN_1_0
+gboolean       valent_check_version     (unsigned int major,
+                                         unsigned int minor);
+VALENT_AVAILABLE_IN_1_0
+unsigned int   valent_get_major_version (void) G_GNUC_CONST;
+VALENT_AVAILABLE_IN_1_0
+unsigned int   valent_get_minor_version (void) G_GNUC_CONST;
+
+G_END_DECLS
+

--- a/src/libvalent/input/meson.build
+++ b/src/libvalent/input/meson.build
@@ -39,6 +39,7 @@ libvalent_input_public_sources = [
 libvalent_input_enums = gnome.mkenums_simple('valent-input-enums',
      body_prefix: '#include "config.h"',
    header_prefix: '#include <libvalent-core.h>',
+       decorator: '_VALENT_EXTERN',
          sources: libvalent_input_enum_headers,
   install_header: true,
      install_dir: libvalent_input_header_dir,

--- a/src/libvalent/input/valent-input-adapter.h
+++ b/src/libvalent/input/valent-input-adapter.h
@@ -7,7 +7,7 @@
 # error "Only <libvalent-input.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 #include "valent-input-keydef.h"
 
@@ -15,6 +15,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_INPUT_ADAPTER (valent_input_adapter_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentInputAdapter, valent_input_adapter, VALENT, INPUT_ADAPTER, GObject)
 
 struct _ValentInputAdapterClass
@@ -39,18 +40,23 @@ struct _ValentInputAdapterClass
                                       double              y);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void   valent_input_adapter_keyboard_keysym  (ValentInputAdapter  *adapter,
                                               unsigned int         keysym,
                                               gboolean             state);
+VALENT_AVAILABLE_IN_1_0
 void   valent_input_adapter_pointer_axis     (ValentInputAdapter  *adapter,
                                               double               dx,
                                               double               dy);
+VALENT_AVAILABLE_IN_1_0
 void   valent_input_adapter_pointer_button   (ValentInputAdapter  *adapter,
                                               ValentPointerButton  button,
                                               gboolean             state);
+VALENT_AVAILABLE_IN_1_0
 void   valent_input_adapter_pointer_motion   (ValentInputAdapter  *adapter,
                                               double               dx,
                                               double               dy);
+VALENT_AVAILABLE_IN_1_0
 void   valent_input_adapter_pointer_position (ValentInputAdapter  *adapter,
                                               double               x,
                                               double               y);

--- a/src/libvalent/input/valent-input.h
+++ b/src/libvalent/input/valent-input.h
@@ -17,31 +17,41 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_INPUT (valent_input_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentInput, valent_input, VALENT, INPUT, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 ValentInput * valent_input_get_default      (void);
 
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_keyboard_action  (ValentInput         *input,
                                              unsigned int         keysym,
                                              GdkModifierType      mask);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_keyboard_keysym  (ValentInput         *input,
                                              unsigned int         keysym,
                                              gboolean             state);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_keyboard_mask    (ValentInput         *input,
                                              GdkModifierType      mask,
                                              gboolean             lock);
 
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_pointer_axis     (ValentInput         *input,
                                              double               dx,
                                              double               dy);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_pointer_button   (ValentInput         *input,
                                              ValentPointerButton  button,
                                              gboolean             state);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_pointer_click    (ValentInput         *input,
                                              ValentPointerButton  button);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_pointer_motion   (ValentInput         *input,
                                              double               dx,
                                              double               dy);
+VALENT_AVAILABLE_IN_1_0
 void          valent_input_pointer_position (ValentInput         *input,
                                              double               x,
                                              double               y);

--- a/src/libvalent/media/meson.build
+++ b/src/libvalent/media/meson.build
@@ -40,6 +40,7 @@ libvalent_media_public_sources = [
 libvalent_media_enums = gnome.mkenums_simple('valent-media-enums',
      body_prefix: '#include "config.h"',
    header_prefix: '#include <libvalent-core.h>',
+       decorator: '_VALENT_EXTERN',
          sources: libvalent_media_enum_headers,
   install_header: true,
      install_dir: libvalent_media_header_dir,

--- a/src/libvalent/media/valent-media-player-provider.h
+++ b/src/libvalent/media/valent-media-player-provider.h
@@ -15,6 +15,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MEDIA_PLAYER_PROVIDER (valent_media_player_provider_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentMediaPlayerProvider, valent_media_player_provider, VALENT, MEDIA_PLAYER_PROVIDER, GObject)
 
 struct _ValentMediaPlayerProviderClass
@@ -37,15 +38,20 @@ struct _ValentMediaPlayerProviderClass
                                     ValentMediaPlayer          *player);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void        valent_media_player_provider_emit_player_added   (ValentMediaPlayerProvider  *provider,
                                                               ValentMediaPlayer          *player);
+VALENT_AVAILABLE_IN_1_0
 void        valent_media_player_provider_emit_player_removed (ValentMediaPlayerProvider  *provider,
                                                               ValentMediaPlayer          *player);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray * valent_media_player_provider_get_players         (ValentMediaPlayerProvider  *provider);
+VALENT_AVAILABLE_IN_1_0
 void        valent_media_player_provider_load_async          (ValentMediaPlayerProvider  *provider,
                                                               GCancellable               *cancellable,
                                                               GAsyncReadyCallback         callback,
                                                               gpointer                    user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean    valent_media_player_provider_load_finish         (ValentMediaPlayerProvider  *provider,
                                                               GAsyncResult               *result,
                                                               GError                    **error);

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -7,7 +7,7 @@
 # error "Only <libvalent-media.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
@@ -71,6 +71,7 @@ typedef enum
 
 #define VALENT_TYPE_MEDIA_PLAYER (valent_media_player_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentMediaPlayer, valent_media_player, VALENT, MEDIA_PLAYER, GObject)
 
 struct _ValentMediaPlayerClass
@@ -109,33 +110,53 @@ struct _ValentMediaPlayerClass
                                             gint64             position);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_emit_changed        (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_emit_seeked         (ValentMediaPlayer *player,
                                                               gint64             offset);
+VALENT_AVAILABLE_IN_1_0
 gboolean             valent_media_player_is_playing          (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 ValentMediaActions   valent_media_player_get_flags           (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 GVariant           * valent_media_player_get_metadata        (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 const char         * valent_media_player_get_name            (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 gint64               valent_media_player_get_position        (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_position        (ValentMediaPlayer *player,
                                                               const char        *track_id,
                                                               gint64             position);
+VALENT_AVAILABLE_IN_1_0
 ValentMediaState     valent_media_player_get_state           (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_state           (ValentMediaPlayer *player,
                                                               ValentMediaState   state);
+VALENT_AVAILABLE_IN_1_0
 double               valent_media_player_get_volume          (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_volume          (ValentMediaPlayer *player,
                                                               double             volume);
 
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_next                (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_open_uri            (ValentMediaPlayer *player,
                                                               const char        *uri);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_pause               (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_play                (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_play_pause          (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_previous            (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_seek                (ValentMediaPlayer *player,
                                                               gint64             offset);
+VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_stop                (ValentMediaPlayer *player);
 
 G_END_DECLS

--- a/src/libvalent/media/valent-media.h
+++ b/src/libvalent/media/valent-media.h
@@ -17,15 +17,21 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MEDIA (valent_media_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentMedia, valent_media, VALENT, MEDIA, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_media_get_players        (ValentMedia *media);
+VALENT_AVAILABLE_IN_1_0
 ValentMediaPlayer * valent_media_get_player_by_name (ValentMedia *media,
                                                      const char  *name);
 
+VALENT_AVAILABLE_IN_1_0
 void                valent_media_pause              (ValentMedia *media);
+VALENT_AVAILABLE_IN_1_0
 void                valent_media_unpause            (ValentMedia *media);
 
+VALENT_AVAILABLE_IN_1_0
 ValentMedia       * valent_media_get_default        (void);
 
 G_END_DECLS

--- a/src/libvalent/mixer/meson.build
+++ b/src/libvalent/mixer/meson.build
@@ -40,6 +40,7 @@ libvalent_mixer_public_sources = [
 libvalent_mixer_enums = gnome.mkenums_simple('valent-mixer-enums',
      body_prefix: '#include "config.h"',
    header_prefix: '#include <libvalent-core.h>',
+       decorator: '_VALENT_EXTERN',
          sources: libvalent_mixer_enum_headers,
   install_header: true,
      install_dir: libvalent_mixer_header_dir,

--- a/src/libvalent/mixer/valent-mixer-control.h
+++ b/src/libvalent/mixer/valent-mixer-control.h
@@ -7,8 +7,7 @@
 # error "Only <libvalent-mixer.h> can be included directly."
 #endif
 
-#include <glib.h>
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 #include "valent-mixer-stream.h"
 
@@ -17,6 +16,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MIXER_CONTROL (valent_mixer_control_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentMixerControl, valent_mixer_control, VALENT, MIXER_CONTROL, GObject)
 
 struct _ValentMixerControlClass
@@ -37,19 +37,28 @@ struct _ValentMixerControlClass
 };
 
 /* Signal Quarks */
+VALENT_AVAILABLE_IN_1_0
 GQuark              valent_mixer_stream_input_quark          (void);
+VALENT_AVAILABLE_IN_1_0
 GQuark              valent_mixer_stream_output_quark         (void);
 
 /* Core Interface */
+VALENT_AVAILABLE_IN_1_0
 void                valent_mixer_control_emit_stream_added   (ValentMixerControl *control,
                                                               ValentMixerStream  *stream);
+VALENT_AVAILABLE_IN_1_0
 void                valent_mixer_control_emit_stream_changed (ValentMixerControl *control,
                                                               ValentMixerStream  *stream);
+VALENT_AVAILABLE_IN_1_0
 void                valent_mixer_control_emit_stream_removed (ValentMixerControl *control,
                                                               ValentMixerStream  *stream);
+VALENT_AVAILABLE_IN_1_0
 ValentMixerStream * valent_mixer_control_get_default_input   (ValentMixerControl *control);
+VALENT_AVAILABLE_IN_1_0
 ValentMixerStream * valent_mixer_control_get_default_output  (ValentMixerControl *control);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_mixer_control_get_inputs          (ValentMixerControl *control);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_mixer_control_get_outputs         (ValentMixerControl *control);
 
 G_END_DECLS

--- a/src/libvalent/mixer/valent-mixer-stream.h
+++ b/src/libvalent/mixer/valent-mixer-stream.h
@@ -7,8 +7,7 @@
 # error "Only <libvalent-mixer.h> can be included directly."
 #endif
 
-#include <glib.h>
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 
 G_BEGIN_DECLS
@@ -43,6 +42,7 @@ typedef enum
 
 #define VALENT_TYPE_MIXER_STREAM (valent_mixer_stream_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentMixerStream, valent_mixer_stream, VALENT, MIXER_STREAM, GObject)
 
 struct _ValentMixerStreamClass
@@ -60,15 +60,22 @@ struct _ValentMixerStreamClass
                                      gboolean           state);
 };
 
-const char             * valent_mixer_stream_get_name           (ValentMixerStream *stream);
-const char             * valent_mixer_stream_get_description    (ValentMixerStream *stream);
-ValentMixerStreamFlags   valent_mixer_stream_get_flags          (ValentMixerStream *stream);
-unsigned int             valent_mixer_stream_get_level          (ValentMixerStream *stream);
-void                     valent_mixer_stream_set_level          (ValentMixerStream *stream,
-                                                                 unsigned int       level);
-gboolean                 valent_mixer_stream_get_muted          (ValentMixerStream *stream);
-void                     valent_mixer_stream_set_muted          (ValentMixerStream *stream,
-                                                                 gboolean           state);
+VALENT_AVAILABLE_IN_1_0
+const char             * valent_mixer_stream_get_name        (ValentMixerStream *stream);
+VALENT_AVAILABLE_IN_1_0
+const char             * valent_mixer_stream_get_description (ValentMixerStream *stream);
+VALENT_AVAILABLE_IN_1_0
+ValentMixerStreamFlags   valent_mixer_stream_get_flags       (ValentMixerStream *stream);
+VALENT_AVAILABLE_IN_1_0
+unsigned int             valent_mixer_stream_get_level       (ValentMixerStream *stream);
+VALENT_AVAILABLE_IN_1_0
+void                     valent_mixer_stream_set_level       (ValentMixerStream *stream,
+                                                              unsigned int       level);
+VALENT_AVAILABLE_IN_1_0
+gboolean                 valent_mixer_stream_get_muted       (ValentMixerStream *stream);
+VALENT_AVAILABLE_IN_1_0
+void                     valent_mixer_stream_set_muted       (ValentMixerStream *stream,
+                                                              gboolean           state);
 
 G_END_DECLS
 

--- a/src/libvalent/mixer/valent-mixer.h
+++ b/src/libvalent/mixer/valent-mixer.h
@@ -15,13 +15,19 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MIXER (valent_mixer_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentMixer, valent_mixer, VALENT, MIXER, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 ValentMixer       * valent_mixer_get_default        (void);
 
+VALENT_AVAILABLE_IN_1_0
 ValentMixerStream * valent_mixer_get_default_output (ValentMixer *mixer);
+VALENT_AVAILABLE_IN_1_0
 ValentMixerStream * valent_mixer_get_default_input  (ValentMixer *mixer);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_mixer_get_inputs         (ValentMixer *mixer);
+VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_mixer_get_outputs        (ValentMixer *mixer);
 
 G_END_DECLS

--- a/src/libvalent/notifications/valent-notification-source.h
+++ b/src/libvalent/notifications/valent-notification-source.h
@@ -7,7 +7,7 @@
 # error "Only <libvalent-notifications.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 #include "valent-notification.h"
 
@@ -15,6 +15,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_NOTIFICATION_SOURCE (valent_notification_source_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentNotificationSource, valent_notification_source, VALENT, NOTIFICATION_SOURCE, GObject)
 
 struct _ValentNotificationSourceClass
@@ -41,18 +42,24 @@ struct _ValentNotificationSourceClass
                                           const char               *id);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_source_emit_notification_added   (ValentNotificationSource  *source,
                                                                  ValentNotification        *notification);
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_source_emit_notification_removed (ValentNotificationSource  *source,
                                                                  const char                *id);
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_source_add_notification          (ValentNotificationSource  *source,
                                                                  ValentNotification        *notification);
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_source_remove_notification       (ValentNotificationSource  *source,
                                                                  const char                *id);
+VALENT_AVAILABLE_IN_1_0
 void       valent_notification_source_load_async                (ValentNotificationSource  *source,
                                                                  GCancellable              *cancellable,
                                                                  GAsyncReadyCallback        callback,
                                                                  gpointer                   user_data);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_notification_source_load_finish               (ValentNotificationSource  *source,
                                                                  GAsyncResult              *result,
                                                                  GError                   **error);

--- a/src/libvalent/notifications/valent-notification.h
+++ b/src/libvalent/notifications/valent-notification.h
@@ -7,53 +7,76 @@
 # error "Only <libvalent-notifications.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_NOTIFICATION (valent_notification_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentNotification, valent_notification, VALENT, NOTIFICATION, GObject)
 
+VALENT_AVAILABLE_IN_1_0
 const char            * valent_notification_get_application        (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_application        (ValentNotification    *notification,
                                                                     const char            *name);
+VALENT_AVAILABLE_IN_1_0
 const char            * valent_notification_get_body               (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_body               (ValentNotification    *notification,
                                                                     const char            *body);
+VALENT_AVAILABLE_IN_1_0
 GIcon                 * valent_notification_get_icon               (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_icon               (ValentNotification    *notification,
                                                                     GIcon                 *icon);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_icon_from_string   (ValentNotification    *notification,
                                                                     const char            *icon_name);
+VALENT_AVAILABLE_IN_1_0
 const char            * valent_notification_get_id                 (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_id                 (ValentNotification    *notification,
                                                                     const char            *id);
+VALENT_AVAILABLE_IN_1_0
 GNotificationPriority   valent_notification_get_priority           (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_priority           (ValentNotification    *notification,
                                                                     GNotificationPriority  priority);
+VALENT_AVAILABLE_IN_1_0
 gint64                  valent_notification_get_time               (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_time               (ValentNotification    *notification,
                                                                     gint64                 time);
+VALENT_AVAILABLE_IN_1_0
 const char            * valent_notification_get_title              (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_title              (ValentNotification    *notification,
                                                                     const char            *title);
 
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_action             (ValentNotification    *notification,
                                                                     const char            *action);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_set_action_and_target  (ValentNotification    *notification,
                                                                     const char            *action,
                                                                     GVariant              *target);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_add_button             (ValentNotification    *notification,
                                                                     const char            *label,
                                                                     const char            *action);
+VALENT_AVAILABLE_IN_1_0
 void                    valent_notification_add_button_with_target (ValentNotification    *notification,
                                                                     const char            *label,
                                                                     const char            *action,
                                                                     GVariant              *target);
 
+VALENT_AVAILABLE_IN_1_0
 ValentNotification    * valent_notification_new                    (const char            *title);
+VALENT_AVAILABLE_IN_1_0
 GVariant              * valent_notification_serialize              (ValentNotification    *notification);
+VALENT_AVAILABLE_IN_1_0
 ValentNotification    * valent_notification_deserialize            (GVariant              *variant);
 
 G_END_DECLS

--- a/src/libvalent/notifications/valent-notifications.h
+++ b/src/libvalent/notifications/valent-notifications.h
@@ -7,16 +7,18 @@
 # error "Only <libvalent-notifications.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
 #include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_NOTIFICATIONS (valent_notifications_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentNotifications, valent_notifications, VALENT, NOTIFICATIONS, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 ValentNotifications * valent_notifications_get_default      (void);
+VALENT_AVAILABLE_IN_1_0
 GVariant            * valent_notifications_get_applications (ValentNotifications *notifications);
 
 G_END_DECLS

--- a/src/libvalent/session/valent-session-adapter.h
+++ b/src/libvalent/session/valent-session-adapter.h
@@ -7,12 +7,13 @@
 # error "Only <libvalent-session.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SESSION_ADAPTER (valent_session_adapter_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentSessionAdapter, valent_session_adapter, VALENT, SESSION_ADAPTER, GObject)
 
 struct _ValentSessionAdapterClass
@@ -29,9 +30,13 @@ struct _ValentSessionAdapterClass
   void           (*changed)    (ValentSessionAdapter *adapter);
 };
 
+VALENT_AVAILABLE_IN_1_0
 void       valent_session_adapter_emit_changed (ValentSessionAdapter *adapter);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_session_adapter_get_active   (ValentSessionAdapter *adapter);
+VALENT_AVAILABLE_IN_1_0
 gboolean   valent_session_adapter_get_locked   (ValentSessionAdapter *adapter);
+VALENT_AVAILABLE_IN_1_0
 void       valent_session_adapter_set_locked   (ValentSessionAdapter *adapter,
                                                 gboolean              state);
 

--- a/src/libvalent/session/valent-session.h
+++ b/src/libvalent/session/valent-session.h
@@ -13,13 +13,18 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_SESSION (valent_session_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentSession, valent_session, VALENT, SESSION, ValentComponent)
 
+VALENT_AVAILABLE_IN_1_0
 gboolean        valent_session_get_active  (ValentSession *session);
+VALENT_AVAILABLE_IN_1_0
 gboolean        valent_session_get_locked  (ValentSession *session);
+VALENT_AVAILABLE_IN_1_0
 void            valent_session_set_locked  (ValentSession *session,
                                             gboolean       state);
 
+VALENT_AVAILABLE_IN_1_0
 ValentSession * valent_session_get_default (void);
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-application.h
+++ b/src/libvalent/ui/valent-application.h
@@ -8,13 +8,16 @@
 #endif
 
 #include <gtk/gtk.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_APPLICATION (valent_application_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentApplication, valent_application, VALENT, APPLICATION, GtkApplication)
 
+VALENT_AVAILABLE_IN_1_0
 ValentApplication * _valent_application_new (void);
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-device-activity.h
+++ b/src/libvalent/ui/valent-device-activity.h
@@ -7,12 +7,13 @@
 # error "Only <libvalent-ui.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_DEVICE_ACTIVITY (valent_device_activity_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_INTERFACE (ValentDeviceActivity, valent_device_activity, VALENT, DEVICE_ACTIVITY, GObject)
 
 struct _ValentDeviceActivityInterface

--- a/src/libvalent/ui/valent-device-gadget.h
+++ b/src/libvalent/ui/valent-device-gadget.h
@@ -7,12 +7,13 @@
 # error "Only <libvalent-ui.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_DEVICE_GADGET (valent_device_gadget_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_INTERFACE (ValentDeviceGadget, valent_device_gadget, VALENT, DEVICE_GADGET, GObject)
 
 struct _ValentDeviceGadgetInterface

--- a/src/libvalent/ui/valent-device-panel.c
+++ b/src/libvalent/ui/valent-device-panel.c
@@ -4,12 +4,14 @@
 #include "config.h"
 
 #include <glib/gi18n.h>
+#include <adwaita.h>
 #include <gtk/gtk.h>
 #include <pango/pango.h>
 #include <libvalent-core.h>
 
 #include "valent-device-gadget.h"
 #include "valent-device-panel.h"
+#include "valent-menu-list.h"
 #include "valent-menu-stack.h"
 #include "valent-plugin-preferences.h"
 #include "valent-plugin-row.h"
@@ -463,6 +465,11 @@ valent_device_panel_class_init (ValentDevicePanelClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+
+  /* Ensure the private types we need are ready */
+  g_type_ensure (VALENT_TYPE_MENU_LIST);
+  g_type_ensure (VALENT_TYPE_MENU_STACK);
+  g_type_ensure (VALENT_TYPE_PLUGIN_ROW);
 }
 
 static void

--- a/src/libvalent/ui/valent-panel.h
+++ b/src/libvalent/ui/valent-panel.h
@@ -8,11 +8,13 @@
 #endif
 
 #include <gtk/gtk.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_PANEL (valent_panel_get_type())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_DERIVABLE_TYPE (ValentPanel, valent_panel, VALENT, PANEL, GtkWidget)
 
 struct _ValentPanelClass
@@ -20,22 +22,32 @@ struct _ValentPanelClass
   GtkWidgetClass   parent_class;
 };
 
+VALENT_AVAILABLE_IN_1_0
 GtkWidget  * valent_panel_new           (void);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_append        (ValentPanel *panel,
                                          GtkWidget   *child);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_prepend       (ValentPanel *panel,
                                          GtkWidget   *child);
-
+VALENT_AVAILABLE_IN_1_0
 const char * valent_panel_get_icon_name (ValentPanel *panel);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_set_icon_name (ValentPanel *panel,
                                          const char  *icon_name);
+VALENT_AVAILABLE_IN_1_0
 const char * valent_panel_get_title     (ValentPanel *panel);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_set_title     (ValentPanel *panel,
                                          const char  *title);
+VALENT_AVAILABLE_IN_1_0
 GtkWidget  * valent_panel_get_header    (ValentPanel *panel);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_set_header    (ValentPanel *panel,
                                          GtkWidget   *child);
+VALENT_AVAILABLE_IN_1_0
 GtkWidget  * valent_panel_get_footer    (ValentPanel *panel);
+VALENT_AVAILABLE_IN_1_0
 void         valent_panel_set_footer    (ValentPanel *panel,
                                          GtkWidget   *child);
 

--- a/src/libvalent/ui/valent-plugin-preferences.h
+++ b/src/libvalent/ui/valent-plugin-preferences.h
@@ -7,13 +7,14 @@
 # error "Only <libvalent-ui.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
 #include <gtk/gtk.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_PLUGIN_PREFERENCES (valent_plugin_preferences_get_type ())
 
+VALENT_AVAILABLE_IN_1_0
 G_DECLARE_INTERFACE (ValentPluginPreferences, valent_plugin_preferences, VALENT, PLUGIN_PREFERENCES, GObject)
 
 struct _ValentPluginPreferencesInterface
@@ -22,6 +23,7 @@ struct _ValentPluginPreferencesInterface
 };
 
 /* Utility Functions */
+VALENT_AVAILABLE_IN_1_0
 int   valent_plugin_preferences_row_sort (GtkListBoxRow *row1,
                                           GtkListBoxRow *row2,
                                           gpointer       user_data);

--- a/src/libvalent/ui/valent-plugin-row.c
+++ b/src/libvalent/ui/valent-plugin-row.c
@@ -5,11 +5,11 @@
 
 #include "config.h"
 
-#include <gtk/gtk.h>
 #include <adwaita.h>
+#include <gtk/gtk.h>
 #include <libpeas/peas.h>
-#include <pango/pango.h>
 #include <libvalent-core.h>
+#include <pango/pango.h>
 
 #include "valent-plugin-preferences.h"
 #include "valent-plugin-row.h"

--- a/src/libvalent/ui/valent-plugin-row.h
+++ b/src/libvalent/ui/valent-plugin-row.h
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include <gtk/gtk.h>
 #include <adwaita.h>
-#include <libpeas/peas.h>
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-ui-utils.c
+++ b/src/libvalent/ui/valent-ui-utils.c
@@ -5,8 +5,8 @@
 
 #include "config.h"
 
-#include <gdk-pixbuf/gdk-pixdata.h>
 #include <glib/gi18n.h>
+#include <gdk-pixbuf/gdk-pixdata.h>
 
 #include "valent-ui-utils.h"
 

--- a/src/libvalent/ui/valent-ui-utils.h
+++ b/src/libvalent/ui/valent-ui-utils.h
@@ -4,13 +4,16 @@
 #pragma once
 
 #include <gdk-pixbuf/gdk-pixdata.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
+VALENT_AVAILABLE_IN_1_0
 GdkPixbuf * valent_ui_pixbuf_from_base64 (const char  *base64,
                                           GError     **error);
-
+VALENT_AVAILABLE_IN_1_0
 char      * valent_ui_timestamp          (gint64       timestamp);
+VALENT_AVAILABLE_IN_1_0
 char      * valent_ui_timestamp_short    (gint64       timestamp);
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-window.c
+++ b/src/libvalent/ui/valent-window.c
@@ -18,6 +18,7 @@
 #include "valent-device-panel.h"
 #include "valent-panel.h"
 #include "valent-plugin-group.h"
+#include "valent-plugin-row.h"
 #include "valent-window.h"
 
 
@@ -683,5 +684,10 @@ valent_window_class_init (ValentWindowClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+
+  /* Ensure the private types we need are ready */
+  g_type_ensure (VALENT_TYPE_DEVICE_PANEL);
+  g_type_ensure (VALENT_TYPE_PLUGIN_GROUP);
+  g_type_ensure (VALENT_TYPE_PLUGIN_ROW);
 }
 

--- a/src/libvalent/ui/valent-window.h
+++ b/src/libvalent/ui/valent-window.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <adwaita.h>
-#include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
This adds a stub for versioning macros, so that symbol visibility can be
properly set. If/when 1.0 is tagged, a header with proper version macros
should be added, but for now `VALENT_AVAILABLE_IN_1_0` is just a
synonym for `_VALENT_EXTERN`.

* add -fvisibility=hidden compile arg
* add `valent-version.h` and `valent-version.c`
* annotate public API with `VALENT_AVAILABLE_IN_1_0` macro