### PR TITLE
valent-packet: replace macros with convenience function

### DIFF
--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -331,25 +331,18 @@ static void
 valent_device_handle_pair (ValentDevice *device,
                            JsonNode     *packet)
 {
-  JsonObject *body;
-  JsonNode *node;
   gboolean pair;
 
   g_assert (VALENT_IS_DEVICE (device));
   g_assert (VALENT_IS_PACKET (packet));
 
-  body = valent_packet_get_body (packet);
-
-  if G_UNLIKELY ((node = json_object_get_member (body, "pair")) == NULL ||
-                 json_node_get_value_type (node) != G_TYPE_BOOLEAN)
+  if (!valent_packet_get_boolean (packet, "pair", &pair))
     {
       g_warning ("%s(): malformed pair packet from \"%s\"",
                  G_STRFUNC,
                  device->name);
       return;
     }
-
-  pair = json_node_get_boolean (node);
 
   /* Device is requesting pairing or accepting our request */
   if (pair)

--- a/src/libvalent/core/valent-manager.c
+++ b/src/libvalent/core/valent-manager.c
@@ -254,9 +254,7 @@ on_channel (ValentChannelService *service,
       return;
     }
 
-  device_id = valent_identity_get_device_id (identity);
-
-  if G_UNLIKELY (device_id == NULL || *device_id == '\0')
+  if (!valent_packet_get_string (identity, "deviceId", &device_id))
     {
       g_warning ("%s(): %s missing deviceId",
                  G_STRFUNC,
@@ -445,7 +443,13 @@ ensure_device_main (gpointer user_data)
 
   g_assert (VALENT_IS_MAIN_THREAD ());
 
-  device_id = valent_identity_get_device_id (data->identity);
+  if (!valent_packet_get_string (data->identity, "deviceId", &device_id))
+    {
+      g_warning ("%s(): expected \"deviceId\" field holding a string",
+                 G_STRFUNC);
+      return G_SOURCE_REMOVE;
+    }
+
   device = valent_manager_ensure_device (data->manager, device_id);
   valent_device_handle_packet (device, data->identity);
 

--- a/src/libvalent/core/valent-packet.h
+++ b/src/libvalent/core/valent-packet.h
@@ -17,11 +17,11 @@ G_BEGIN_DECLS
 
 /**
  * ValentPacketError:
- * @VALENT_PACKET_ERROR_UNKNOWN: unknown error
- * @VALENT_PACKET_ERROR_MALFORMED: a malformed packet
- * @VALENT_PACKET_ERROR_INVALID_FIELD: an expected field is missing or holds an invalid type
- * @VALENT_PACKET_ERROR_UNKNOWN_MEMBER: the `id` field is missing
- * @VALENT_PACKET_ERROR_INVALID_DATA: invalid data
+ * @VALENT_PACKET_ERROR_UNKNOWN: an unknown error
+ * @VALENT_PACKET_ERROR_INVALID_DATA: the packet is %NULL or not JSON
+ * @VALENT_PACKET_ERROR_MALFORMED: the packet structure is malformed
+ * @VALENT_PACKET_ERROR_INVALID_FIELD: an expected field holds an invalid type
+ * @VALENT_PACKET_ERROR_MISSING_FIELD: an expected field is missing
  *
  * Error enumeration for KDE Connect packet validation.
  *
@@ -123,6 +123,35 @@ VALENT_AVAILABLE_IN_1_0
 void          valent_packet_set_payload_size (JsonNode       *packet,
                                               gssize          size);
 
+/* Field Helpers */
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_check_field      (JsonNode       *packet,
+                                              const char     *field);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_boolean      (JsonNode       *packet,
+                                              const char     *field,
+                                              gboolean       *value);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_double       (JsonNode       *packet,
+                                              const char     *field,
+                                              double         *value);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_int          (JsonNode       *packet,
+                                              const char     *field,
+                                              gint64         *value);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_string       (JsonNode       *packet,
+                                              const char     *field,
+                                              const char    **value);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_array        (JsonNode       *packet,
+                                              const char     *field,
+                                              JsonArray     **value);
+VALENT_AVAILABLE_IN_1_0
+gboolean      valent_packet_get_object       (JsonNode       *packet,
+                                              const char     *field,
+                                              JsonObject    **value);
+
 /* I/O Helpers */
 VALENT_AVAILABLE_IN_1_0
 gboolean      valent_packet_validate         (JsonNode       *packet,
@@ -141,112 +170,5 @@ char        * valent_packet_serialize        (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
 JsonNode    * valent_packet_deserialize      (const char     *json,
                                               GError        **error);
-
-/* Identity Packets */
-VALENT_AVAILABLE_IN_1_0
-const char  * valent_identity_get_device_id  (JsonNode       *identity);
-
-/**
- * valent_packet_check_boolean: (skip)
- * @body: (type Json.Object): a packet body
- * @member: a member name
- *
- * A quick and silent macro for getting a boolean member from a packet body. If
- * the member is missing or holds another type %FALSE is returned.
- *
- * Returns: a boolean
- */
-static inline gboolean
-(valent_packet_check_boolean) (JsonObject *body,
-                               const char *member)
-{
-  JsonNode *node;
-
-  if G_UNLIKELY ((node = json_object_get_member (body, member)) == NULL ||
-                 json_node_get_value_type (node) != G_TYPE_BOOLEAN)
-    return FALSE;
-
-  return json_node_get_boolean (node);
-}
-#define valent_packet_check_boolean(o,m) (valent_packet_check_boolean(o,m))
-
-/**
- * valent_packet_check_double: (skip)
- * @body: (type Json.Object): a packet body
- * @member: a member name
- *
- * A quick and silent macro for getting a double member from a packet body. If
- * the member is missing or holds another type `0.0` is returned.
- *
- * Returns: a double
- */
-static inline double
-(valent_packet_check_double) (JsonObject *body,
-                              const char *member)
-{
-  JsonNode *node;
-
-  if G_UNLIKELY ((node = json_object_get_member (body, member)) == NULL ||
-                 json_node_get_value_type (node) != G_TYPE_DOUBLE)
-    return 0.0;
-
-  return json_node_get_double (node);
-}
-#define valent_packet_check_double(o,m) (valent_packet_check_double(o,m))
-
-/**
- * valent_packet_check_int: (skip)
- * @body: (type Json.Object): a packet body
- * @member: a member name
- *
- * A quick and silent macro for getting an integer member from a packet body. If
- * the member is missing or holds another type `0` is returned.
- *
- * Returns: an integer
- */
-static inline gint64
-(valent_packet_check_int) (JsonObject *body,
-                           const char *member)
-{
-  JsonNode *node;
-
-  if G_UNLIKELY ((node = json_object_get_member (body, member)) == NULL ||
-                 json_node_get_value_type (node) != G_TYPE_INT64)
-    return 0;
-
-  return json_node_get_int (node);
-}
-#define valent_packet_check_int(o,m) (valent_packet_check_int(o,m))
-
-/**
- * valent_packet_check_string: (skip)
- * @body: (type Json.Object): a packet body
- * @member: a member name
- *
- * A quick and silent macro for getting a string member from a packet body. If
- * the member is missing, holds another type or an empty string %NULL is
- * returned.
- *
- * Returns: (nullable): a string
- */
-static inline const char *
-(valent_packet_check_string) (JsonObject *body,
-                              const char *member)
-{
-  JsonNode *node;
-  const char *value;
-
-  if G_UNLIKELY ((node = json_object_get_member (body, member)) == NULL ||
-                 json_node_get_value_type (node) != G_TYPE_STRING)
-    return NULL;
-
-  value = json_node_get_string (node);
-
-  if G_UNLIKELY (strlen (value) == 0)
-    return NULL;
-
-  return value;
-}
-#define valent_packet_check_string(o,m) (valent_packet_check_string(o,m))
 
 G_END_DECLS

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -97,7 +97,7 @@ valent_battery_plugin_handle_battery_request (ValentBatteryPlugin *self,
   g_assert (VALENT_IS_BATTERY_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (valent_packet_check_boolean (valent_packet_get_body (packet), "request"))
+  if (valent_packet_check_field (packet, "request"))
     valent_battery_plugin_send_state (self);
 }
 
@@ -284,22 +284,17 @@ static void
 valent_battery_plugin_handle_battery (ValentBatteryPlugin *self,
                                       JsonNode            *packet)
 {
-  JsonObject *body;
   gboolean changed = FALSE;
-  gboolean charging;
-  gint64 level;
-  gint64 threshold;
+  gboolean charging = self->charging;
+  gint64 level = self->level;
+  gint64 threshold = 0;
 
   g_assert (VALENT_IS_BATTERY_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
-  body = valent_packet_get_body (packet);
-  charging = json_object_get_boolean_member_with_default (body, "isCharging",
-                                                          self->charging);
-  level = json_object_get_int_member_with_default (body, "currentCharge",
-                                                   self->level);
-  threshold = json_object_get_int_member_with_default (body, "thresholdEvent",
-                                                       0);
+  valent_packet_get_boolean (packet, "isCharging", &charging);
+  valent_packet_get_int (packet, "currentCharge", &level);
+  valent_packet_get_int (packet, "thresholdEvent", &threshold);
 
   /* We get a lot of battery updates, so check if something changed */
   if (self->charging != charging || self->level != level)

--- a/src/plugins/bluez/valent-bluez-channel.c
+++ b/src/plugins/bluez/valent-bluez-channel.c
@@ -54,7 +54,8 @@ valent_bluez_channel_download (ValentChannel  *channel,
   if ((info = valent_packet_get_payload_full (packet, &size, error)) == NULL)
     return NULL;
 
-  if ((uuid = valent_packet_check_string (info, "uuid")) == NULL)
+  if ((uuid = json_object_get_string_member (info, "uuid")) == NULL ||
+      *uuid == '\0')
     {
       g_set_error_literal (error,
                            VALENT_PACKET_ERROR,

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -176,23 +176,17 @@ static void
 valent_clipboard_plugin_handle_clipboard (ValentClipboardPlugin *self,
                                           JsonNode              *packet)
 {
-  JsonObject *body;
-  JsonNode *node;
   const char *content;
 
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
-  body = valent_packet_get_body (packet);
-
-  if ((node = json_object_get_member (body, "content")) == NULL ||
-      json_node_get_value_type (node) != G_TYPE_STRING)
+  if (!valent_packet_get_string (packet, "content", &content))
     {
-      g_debug ("%s(): expected \"content\" field holding a string", G_STRFUNC);
+      g_warning ("%s(): expected \"content\" field holding a string",
+                 G_STRFUNC);
       return;
     }
-
-  content = json_node_get_string (node);
 
   /* Cache remote content */
   g_clear_pointer (&self->remote_text, g_free);
@@ -208,33 +202,25 @@ static void
 valent_clipboard_plugin_handle_clipboard_connect (ValentClipboardPlugin *self,
                                                   JsonNode              *packet)
 {
-  JsonObject *body;
-  JsonNode *node;
   gint64 timestamp;
   const char *content;
 
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
-  body = valent_packet_get_body (packet);
-
-  if ((node = json_object_get_member (body, "timestamp")) == NULL ||
-      json_node_get_value_type (node) != G_TYPE_INT64)
+  if (!valent_packet_get_int (packet, "timestamp", &timestamp))
     {
-      g_debug ("%s(): expected \"timestamp\" field holding an integer", G_STRFUNC);
+      g_warning ("%s(): expected \"timestamp\" field holding an integer",
+                 G_STRFUNC);
       return;
     }
 
-  timestamp = json_node_get_int (node);
-
-  if ((node = json_object_get_member (body, "content")) == NULL ||
-      json_node_get_value_type (node) != G_TYPE_STRING)
+  if (!valent_packet_get_string (packet, "content", &content))
     {
-      g_debug ("%s(): expected \"content\" field holding a string", G_STRFUNC);
+      g_warning ("%s(): expected \"content\" field holding a string",
+                 G_STRFUNC);
       return;
     }
-
-  content = json_node_get_string (node);
 
   /* Cache remote content */
   g_clear_pointer (&self->remote_text, g_free);

--- a/src/plugins/lan/valent-lan-channel.c
+++ b/src/plugins/lan/valent-lan-channel.c
@@ -93,7 +93,7 @@ valent_lan_channel_download (ValentChannel  *channel,
 {
   ValentLanChannel *self = VALENT_LAN_CHANNEL (channel);
   JsonObject *info;
-  guint16 port;
+  gint64 port;
   gssize size;
   g_autoptr (GSocketClient) client = NULL;
   g_autoptr (GSocketConnection) connection = NULL;
@@ -111,12 +111,13 @@ valent_lan_channel_download (ValentChannel  *channel,
   if ((info = valent_packet_get_payload_full (packet, &size, error)) == NULL)
     return NULL;
 
-  if ((port = valent_packet_check_int (info, "port")) == 0)
+  if ((port = json_object_get_int_member (info, "port")) == 0 ||
+      (port < 0 || port > G_MAXUINT16))
     {
       g_set_error_literal (error,
                            VALENT_PACKET_ERROR,
                            VALENT_PACKET_ERROR_INVALID_FIELD,
-                           "Invalid \"port\" field");
+                           "expected \"port\" field holding a uint16");
       return NULL;
     }
 
@@ -127,7 +128,7 @@ valent_lan_channel_download (ValentChannel  *channel,
                          NULL);
   connection = g_socket_client_connect_to_host (client,
                                                 host,
-                                                port,
+                                                (guint16)port,
                                                 cancellable,
                                                 error);
 

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -85,13 +85,10 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
 {
   g_autoptr (ValentTransfer) transfer = NULL;
   DownloadOperation *op;
-  JsonObject *body;
   const char *filename;
 
   g_assert (VALENT_IS_PHOTO_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
-
-  body = valent_packet_get_body (packet);
 
   if (!valent_packet_has_payload (packet))
     {
@@ -99,9 +96,10 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
       return;
     }
 
-  if ((filename = valent_packet_check_string (body, "filename")) == NULL)
+  if (!valent_packet_get_string (packet, "filename", &filename))
     {
-      g_warning ("%s(): invalid \"filename\" field", G_STRFUNC);
+      g_warning ("%s(): expected \"filename\" field holding a string",
+                 G_STRFUNC);
       return;
     }
 

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -36,16 +36,14 @@ valent_ping_plugin_handle_ping (ValentPingPlugin *self,
                                 JsonNode         *packet)
 {
   g_autoptr (GNotification) notification = NULL;
-  JsonObject *body;
   const char *message;
 
   g_assert (VALENT_IS_PING_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
   /* Check for the optional message */
-  body = valent_packet_get_body (packet);
-  message = json_object_get_string_member_with_default (body, "message",
-                                                        _("Ping!"));
+  if (!valent_packet_get_string (packet, "message", &message))
+    message = _("Ping!");
 
   /* Show a notification */
   notification = g_notification_new (valent_device_get_name (self->device));
@@ -64,7 +62,7 @@ valent_ping_plugin_send_ping (ValentPingPlugin *self,
 
   builder = valent_packet_start ("kdeconnect.ping");
 
-  if (message != NULL)
+  if (message != NULL && *message != '\0')
     {
       json_builder_set_member_name (builder, "message");
       json_builder_add_string_value (builder, message);

--- a/src/plugins/runcommand/valent-runcommand-plugin.c
+++ b/src/plugins/runcommand/valent-runcommand-plugin.c
@@ -238,25 +238,18 @@ static void
 valent_runcommand_plugin_handle_runcommand_request (ValentRuncommandPlugin *self,
                                                     JsonNode               *packet)
 {
-  JsonObject *body;
+  const char *key;
 
   g_assert (VALENT_IS_RUNCOMMAND_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
 
-  body = valent_packet_get_body (packet);
-
   /* A request for the local command list */
-  if (valent_packet_check_boolean (body, "requestCommandList"))
+  if (valent_packet_check_field (packet, "requestCommandList"))
     valent_runcommand_plugin_send_command_list (self);
 
   /* A request to execute a local command */
-  if (json_object_has_member (body, "key"))
-    {
-      const char *key;
-
-      key = valent_packet_check_string (body, "key");
-      valent_runcommand_plugin_execute_local_command (self, key);
-    }
+  if (valent_packet_get_string (packet, "key", &key))
+    valent_runcommand_plugin_execute_local_command (self, key);
 }
 
 /*

--- a/src/tests/libvalent/core/test-packet.c
+++ b/src/tests/libvalent/core/test-packet.c
@@ -72,9 +72,56 @@ test_packet_builder (void)
 
   body = valent_packet_get_body (packet);
   g_assert_nonnull (body);
+}
 
-  json_object_set_string_member (body, "deviceId", "device-id");
-  g_assert_cmpstr (valent_identity_get_device_id (packet), ==, "device-id");
+static void
+test_packet_get (void)
+{
+  JsonBuilder *builder;
+  g_autoptr (JsonNode) packet = NULL;
+  gboolean boolean_value = FALSE;
+  double double_value = 0.0;
+  gint64 int_value = 0;
+  const char *string_value;
+  JsonArray *array_value;
+  JsonObject *object_value;
+
+  builder = valent_packet_start ("kdeconnect.mock");
+  json_builder_set_member_name (builder, "boolean");
+  json_builder_add_boolean_value (builder, TRUE);
+  json_builder_set_member_name (builder, "double");
+  json_builder_add_double_value (builder, 3.14);
+  json_builder_set_member_name (builder, "int");
+  json_builder_add_int_value (builder, 42);
+  json_builder_set_member_name (builder, "string");
+  json_builder_add_string_value (builder, "string");
+  json_builder_set_member_name (builder, "array");
+  json_builder_begin_array (builder);
+  json_builder_end_array (builder);
+  json_builder_set_member_name (builder, "object");
+  json_builder_begin_object (builder);
+  json_builder_end_object (builder);
+  packet = valent_packet_finish (builder);
+
+  g_assert_true (valent_packet_is_valid (packet));
+
+  g_assert_true (valent_packet_get_boolean (packet, "boolean", &boolean_value));
+  g_assert_true (boolean_value);
+
+  g_assert_true (valent_packet_get_double (packet, "double", &double_value));
+  g_assert_cmpfloat (double_value, ==, 3.14);
+
+  g_assert_true (valent_packet_get_int (packet, "int", &int_value));
+  g_assert_cmpint (int_value, ==, 42);
+
+  g_assert_true (valent_packet_get_string (packet, "string", &string_value));
+  g_assert_cmpstr (string_value, ==, "string");
+
+  g_assert_true (valent_packet_get_array (packet, "array", &array_value));
+  g_assert_nonnull (array_value);
+
+  g_assert_true (valent_packet_get_object (packet, "object", &object_value));
+  g_assert_nonnull (object_value);
 }
 
 static void
@@ -249,6 +296,9 @@ main (int   argc,
 
   g_test_add_func ("/core/packet/payloads",
                    test_packet_payloads);
+
+  g_test_add_func ("/core/packet/get",
+                   test_packet_get);
 
   g_test_add ("/core/packet/invalid",
               PacketFixture, NULL,

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -112,7 +112,7 @@ g_socket_listener_accept_cb (GSocketListener   *listener,
   g_autoptr (GSocketConnection) connection = NULL;
   g_autoptr (JsonNode) peer_identity = NULL;
   JsonNode *identity;
-  const char *device_id;
+  const char *device_id = NULL;
   g_autoptr (GIOStream) tls_stream = NULL;
   GError *error = NULL;
 
@@ -130,7 +130,9 @@ g_socket_listener_accept_cb (GSocketListener   *listener,
   /* The test service is unverified, so we expect it to be accepted on a
    * trust-on-first-use basis.
    */
-  device_id = valent_identity_get_device_id (peer_identity);
+  valent_packet_get_string (peer_identity, "deviceId", &device_id);
+  g_assert_true (device_id != NULL && *device_id != '\0');
+
   tls_stream = valent_lan_encrypt_new_client (connection,
                                               fixture->certificate,
                                               device_id,


### PR DESCRIPTION
Replace the `valent_packet_check_*` macros with functions that operate
on the packet `JsonNode`.

The semantics of the functions make more sense and are more convenient
in C where they take a pointer to the field type and return a success
boolean.

These are a bit slower, but safer and make it easier to warn when a
packet is malformed.