### PR TITLE
ValentApplication: change the format of the `app.device` GAction

### DIFF
--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -305,18 +305,16 @@ valent_device_notify_pair (ValentDevice *device)
   g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_URGENT);
 
   g_notification_add_button_with_target (notification, _("Reject"), "app.device",
-                                         "(ssbv)",
+                                         "(ssav)",
                                          device->id,
                                          "unpair",
-                                         FALSE,
-                                         g_variant_new ("s", ""));
+                                         NULL);
 
   g_notification_add_button_with_target (notification, _("Accept"), "app.device",
-                                         "(ssbv)",
+                                         "(ssav)",
                                          device->id,
                                          "pair",
-                                         FALSE,
-                                         g_variant_new ("s", ""));
+                                         NULL);
 
   /* Show the pairing notification and set a timeout for 30s */
   valent_device_show_notification (device, "pair-request", notification);

--- a/src/libvalent/core/valent-utils.c
+++ b/src/libvalent/core/valent-utils.c
@@ -199,26 +199,23 @@ valent_notification_set_device_action (GNotification *notification,
                                        const char    *action,
                                        GVariant      *target)
 {
-  const char *device_id;
-  gboolean has_target;
+  GVariantBuilder builder;
 
   g_return_if_fail (G_IS_NOTIFICATION (notification));
   g_return_if_fail (VALENT_IS_DEVICE (device));
-  g_return_if_fail (action != NULL);
+  g_return_if_fail (action != NULL && *action != '\0');
 
-  device_id = valent_device_get_id (device);
-  has_target = (target != NULL);
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("av"));
 
-  if (!has_target)
-    target = g_variant_new_string ("");
+  if (target != NULL)
+    g_variant_builder_add (&builder, "v", target);
 
   g_notification_set_default_action_and_target (notification,
                                                 "app.device",
-                                                "(ssbv)",
-                                                device_id,
+                                                "(ssav)",
+                                                valent_device_get_id (device),
                                                 action,
-                                                has_target,
-                                                target);
+                                                &builder);
 }
 
 /**
@@ -240,27 +237,24 @@ valent_notification_add_device_button (GNotification *notification,
                                        const char    *action,
                                        GVariant      *target)
 {
-  const char *device_id;
-  gboolean has_target;
+  GVariantBuilder builder;
 
   g_return_if_fail (G_IS_NOTIFICATION (notification));
   g_return_if_fail (VALENT_IS_DEVICE (device));
-  g_return_if_fail (label != NULL);
-  g_return_if_fail (action != NULL);
+  g_return_if_fail (label != NULL && *label != '\0');
+  g_return_if_fail (action != NULL && *action != '\0');
 
-  device_id = valent_device_get_id (device);
-  has_target = (target != NULL);
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("av"));
 
-  if (!has_target)
-    target = g_variant_new_string ("");
+  if (target != NULL)
+    g_variant_builder_add (&builder, "v", target);
 
   g_notification_add_button_with_target (notification,
                                          label,
                                          "app.device",
-                                         "(ssbv)",
-                                         device_id,
+                                         "(ssav)",
+                                         valent_device_get_id (device),
                                          action,
-                                         has_target,
-                                         target);
+                                         &builder);
 }
 

--- a/src/tests/extra/setup.cfg
+++ b/src/tests/extra/setup.cfg
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: No rights reserved
 
 [codespell]
-ignore-words-list = doubleclick,inout
+ignore-words-list = doubleclick,inout,sav
 skip = ./_build*,./src/tests/data,./subprojects,*.po,./.*
 
 [pylint]


### PR DESCRIPTION
Change the GVariant format of the `app.device` GAction from `(ssbv)` to
`(ssav)`. This is a more conventional approach to passing option action
targets, and a little bit less clunky.