### PR TITLE
refactor: Refactor ValentDevicePlugin as an abstract base-class

### DIFF
--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -135,8 +135,8 @@ valent_device_manager_export_device (ValentDeviceManager *self,
   g_autoptr (GDBusObjectSkeleton) object = NULL;
   g_autoptr (GDBusInterfaceSkeleton) iface = NULL;
   ExportedDevice *info;
-  GActionGroup *actions;
-  GMenuModel *menu;
+  GActionGroup *action_group;
+  GMenuModel *menu_model;
 
   VALENT_ENTRY;
 
@@ -157,16 +157,16 @@ valent_device_manager_export_device (ValentDeviceManager *self,
   iface = valent_device_impl_new (device);
   g_dbus_object_skeleton_add_interface (object, iface);
 
-  actions = valent_device_get_actions (device);
+  action_group = G_ACTION_GROUP (device);
   info->actions_id = g_dbus_connection_export_action_group (info->connection,
                                                             info->object_path,
-                                                            actions,
+                                                            action_group,
                                                             NULL);
 
-  menu = valent_device_get_menu (device);
+  menu_model = valent_device_get_menu (device);
   info->menu_id = g_dbus_connection_export_menu_model (info->connection,
                                                        info->object_path,
-                                                       menu,
+                                                       menu_model,
                                                        NULL);
 
   g_dbus_object_manager_server_export (self->dbus, object);

--- a/src/libvalent/core/valent-device-plugin.c
+++ b/src/libvalent/core/valent-device-plugin.c
@@ -16,35 +16,14 @@
 
 
 /**
- * SECTION:valentdeviceplugin
- * @short_description: Interface for device plugins
- * @title: ValentDevicePlugin
- * @stability: Unstable
- * @include: libvalent-core.h
+ * ValentDevicePlugin:
  *
- * The #ValentDevicePlugin interface should be implemented by plugins that
- * operate in the scope of a single device. This generally means exchanging
- * packets with other devices.
+ * An abstract base-class for device plugins.
  *
- * Implementations should not send packets to disconnected or unpaired devices
- * and attempting to do so will log a warning or critical, respectively. When
- * the device state changes, valent_device_plugin_update_state() will be called
- * to notify the plugin.
- *
- * # `.plugin` File
- *
- * Device plugins require extra information in the `.plugin` file to be
- * processed correctly.
- *
- * - `X-IncomingCapabilities`
- *
- *     A list of strings separated by semi-colons indicating the packets that
- *     the plugin can handle.
- *
- * - `X-OutgoingCapabilities`
- *
- *     A list of strings separated by semi-colons indicating the packets that
- *     the plugin may provide.
+ * #ValentDevicePlugin is a base-class for plugins that operate in the scope of
+ * a single device. This usually means communicating with other devices, however
+ * plugins aren't required to be packet based and may offer connectionless
+ * functionality.
  *
  * # Plugin States
  *
@@ -57,24 +36,74 @@
  * - the plugin doesn't list any capabilities (eg. a non-packet based plugin)
  *
  * When a plugin becomes available, it may be enabled, disabled and configured
- * independent of the device's connected state. This allows the user to restrict
- * the device's access before pairing and configure plugins while it is offline.
+ * independent of the device state. This allows the user to restrict the
+ * device's access before pairing and configure plugins while it is offline.
  *
- * The #PeasExtension is only constructed once the plugin has been enabled, and
- * valent_device_plugin_enable() and valent_device_plugin_update_state() will be
- * called to setup the plugin. When a plugin is disabled the #PeasExtension will
- * be disposed immediately after valent_device_plugin_disable() is called.
+ * The [class@Peas.Extension] instance is only constructed once the plugin has
+ * been enabled by the user, after which [method@Valent.DevicePlugin.enable] and
+ * [method@Valent.DevicePlugin.update_state] will be called to setup the plugin.
+ * When the plugin is disabled, [method@Valent.DevicePlugin.disable] will be
+ * called just before the [class@Peas.Extension] is disposed.
  *
- * If the connected or paired state changes, valent_device_plugin_update_state()
- * will be called for each enabled plugin. Note that this function is not called
- * when a plugin is disabled, so plugins must ensure that they cleanup any state
- * when valent_device_plugin_disable() is called.
+ * If the connected or paired state of the device changes,
+ * [method@Valent.DevicePlugin.update_state] will be called on the plugin. Note
+ * that this function is not called when a plugin is disabled, so plugins must
+ * ensure they cleanup any state when [method@Valent.DevicePlugin.disable] is
+ * called.
+ *
+ * # Plugin Actions
+ *
+ * #ValentDevicePlugin implements the [iface@Gio.ActionGroup] and
+ * [iface@Gio.ActionMap] interfaces, providing a simple way for plugins to
+ * expose functions and states. If the [class@Valent.DeviceManager] is exported
+ * on D-Bus, the actions will be exported along with the [class@Valent.Device].
+ *
+ * Each [iface@Gio.Action] added to the action map will be added to the device
+ * action group with the plugin's module name as a prefix. For example, if a
+ * plugin with the module name `share` has an action with the name `files`, the
+ * action will be available as `share.files` in the device action group.
+ *
+ * # `.plugin` File
+ *
+ * Device plugins may contain extra information in the `.plugin` file:
+ *
+ * - `X-IncomingCapabilities`
+ *
+ *     A list of strings separated by semi-colons indicating the packets that
+ *     the plugin can handle.
+ *
+ * - `X-OutgoingCapabilities`
+ *
+ *     A list of strings separated by semi-colons indicating the packets that
+ *     the plugin may provide.
  */
 
-G_DEFINE_INTERFACE (ValentDevicePlugin, valent_device_plugin, G_TYPE_OBJECT)
+typedef struct
+{
+  ValentDevice   *device;
+  PeasPluginInfo *plugin_info;
+  GHashTable     *actions;
+} ValentDevicePluginPrivate;
+
+static void   g_action_group_iface_init (GActionGroupInterface *iface);
+static void   g_action_map_iface_init   (GActionMapInterface   *iface);
+
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentDevicePlugin, valent_device_plugin, VALENT_TYPE_OBJECT,
+                                  G_ADD_PRIVATE (ValentDevicePlugin)
+                                  G_IMPLEMENT_INTERFACE (G_TYPE_ACTION_GROUP, g_action_group_iface_init)
+                                  G_IMPLEMENT_INTERFACE (G_TYPE_ACTION_MAP, g_action_map_iface_init))
+
+enum {
+  PROP_0,
+  PROP_DEVICE,
+  PROP_PLUGIN_INFO,
+  N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 /**
- * ValentDevicePluginInterface:
+ * ValentDevicePluginClass:
  * @enable: the virtual function pointer for valent_device_plugin_enable()
  * @disable: the virtual function pointer for valent_device_plugin_disable()
  * @handle_packet: the virtual function pointer for valent_device_plugin_handle_packet()
@@ -83,15 +112,215 @@ G_DEFINE_INTERFACE (ValentDevicePlugin, valent_device_plugin, G_TYPE_OBJECT)
  * The virtual function table for #ValentDevicePlugin.
  */
 
+
+/*
+ * GActionGroup
+ */
+static void
+valent_device_plugin_activate_action (GActionGroup *action_group,
+                                      const char   *action_name,
+                                      GVariant     *parameter)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_group);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    g_action_activate (action, parameter);
+}
+
+static void
+valent_device_plugin_change_action_state (GActionGroup *action_group,
+                                          const char   *action_name,
+                                          GVariant     *value)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_group);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    g_action_change_state (action, value);
+}
+
+static char **
+valent_device_plugin_list_actions (GActionGroup *action_group)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_group);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  g_auto (GStrv) actions = NULL;
+  GHashTableIter iter;
+  gpointer key;
+  unsigned int i = 0;
+
+  actions = g_new0 (char *, g_hash_table_size (priv->actions) + 1);
+
+  g_hash_table_iter_init (&iter, priv->actions);
+
+  while (g_hash_table_iter_next (&iter, &key, NULL))
+    actions[i++] = g_strdup (key);
+
+  return g_steal_pointer (&actions);
+}
+
+static gboolean
+valent_device_plugin_query_action (GActionGroup        *action_group,
+                                   const char          *action_name,
+                                   gboolean            *enabled,
+                                   const GVariantType **parameter_type,
+                                   const GVariantType **state_type,
+                                   GVariant           **state_hint,
+                                   GVariant           **state)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_group);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) == NULL)
+    return FALSE;
+
+  if (enabled)
+    *enabled = g_action_get_enabled (action);
+
+  if (parameter_type)
+    *parameter_type = g_action_get_parameter_type (action);
+
+  if (state_type)
+    *state_type = g_action_get_state_type (action);
+
+  if (state_hint)
+    *state_hint = g_action_get_state_hint (action);
+
+  if (state)
+    *state = g_action_get_state (action);
+
+  return TRUE;
+}
+
+static void
+g_action_group_iface_init (GActionGroupInterface *iface)
+{
+  iface->activate_action = valent_device_plugin_activate_action;
+  iface->change_action_state = valent_device_plugin_change_action_state;
+  iface->list_actions = valent_device_plugin_list_actions;
+  iface->query_action = valent_device_plugin_query_action;
+}
+
+/*
+ * GActionMap
+ */
+static void
+on_action_enabled_changed (GAction      *action,
+                           GParamSpec   *pspec,
+                           GActionGroup *action_group)
+{
+  g_action_group_action_enabled_changed (action_group,
+                                         g_action_get_name (action),
+                                         g_action_get_enabled (action));
+}
+
+static void
+on_action_state_changed (GAction      *action,
+                         GParamSpec   *pspec,
+                         GActionGroup *action_group)
+{
+  g_autoptr (GVariant) value = NULL;
+
+  value = g_action_get_state (action);
+  g_action_group_action_state_changed (action_group,
+                                       g_action_get_name (action),
+                                       value);
+}
+
+static void
+valent_device_plugin_disconnect_action (ValentDevicePlugin *self,
+                                        GAction            *action)
+{
+  g_signal_handlers_disconnect_by_func (action, on_action_enabled_changed, self);
+  g_signal_handlers_disconnect_by_func (action, on_action_state_changed, self);
+}
+
+static GAction *
+valent_device_plugin_lookup_action (GActionMap *action_map,
+                                    const char *action_name)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_map);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+
+  return g_hash_table_lookup (priv->actions, action_name);
+}
+
+static void
+valent_device_plugin_add_action (GActionMap *action_map,
+                                 GAction    *action)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_map);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  const char *action_name;
+  GAction *replacing;
+
+  action_name = g_action_get_name (action);
+
+  if ((replacing = g_hash_table_lookup (priv->actions, action_name)) == action)
+    return;
+
+  if (replacing != NULL)
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (action_map), action_name);
+      valent_device_plugin_disconnect_action (self, replacing);
+    }
+
+  g_signal_connect (action,
+                    "notify::enabled",
+                    G_CALLBACK (on_action_enabled_changed),
+                    action_map);
+
+  if (g_action_get_state_type (action) != NULL)
+    g_signal_connect (action,
+                      "notify::state",
+                      G_CALLBACK (on_action_state_changed),
+                      action_map);
+
+  g_hash_table_replace (priv->actions,
+                        g_strdup (action_name),
+                        g_object_ref (action));
+  g_action_group_action_added (G_ACTION_GROUP (action_map), action_name);
+}
+
+static void
+valent_device_plugin_remove_action (GActionMap *action_map,
+                                    const char *action_name)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (action_map);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (action_map), action_name);
+      valent_device_plugin_disconnect_action (self, action);
+      g_hash_table_remove (priv->actions, action_name);
+    }
+}
+
+static void
+g_action_map_iface_init (GActionMapInterface *iface)
+{
+  iface->add_action = valent_device_plugin_add_action;
+  iface->lookup_action = valent_device_plugin_lookup_action;
+  iface->remove_action = valent_device_plugin_remove_action;
+}
+
 /* LCOV_EXCL_START */
 static void
 valent_device_plugin_real_disable (ValentDevicePlugin *plugin)
 {
+  g_assert (VALENT_IS_DEVICE_PLUGIN (plugin));
 }
 
 static void
 valent_device_plugin_real_enable (ValentDevicePlugin *plugin)
 {
+  g_assert (VALENT_IS_DEVICE_PLUGIN (plugin));
 }
 
 static void
@@ -99,37 +328,269 @@ valent_device_plugin_real_handle_packet (ValentDevicePlugin *plugin,
                                          const char         *type,
                                          JsonNode           *packet)
 {
+  g_assert (VALENT_IS_DEVICE_PLUGIN (plugin));
+  g_assert (type != NULL && *type != '\0');
+  g_assert (VALENT_IS_PACKET (packet));
+
+  g_critical ("%s: expected handler for \"%s\" packet",
+              G_OBJECT_TYPE_NAME (plugin),
+              type);
 }
 
 static void
 valent_device_plugin_real_update_state (ValentDevicePlugin *plugin,
                                         ValentDeviceState   state)
 {
+  g_assert (VALENT_IS_DEVICE_PLUGIN (plugin));
 }
 /* LCOV_EXCL_STOP */
 
+/*
+ * GObject
+ */
 static void
-valent_device_plugin_default_init (ValentDevicePluginInterface *iface)
+valent_device_plugin_dispose (GObject *object)
 {
-  iface->disable = valent_device_plugin_real_disable;
-  iface->enable = valent_device_plugin_real_enable;
-  iface->handle_packet = valent_device_plugin_real_handle_packet;
-  iface->update_state = valent_device_plugin_real_update_state;
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (object);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+  GHashTableIter iter;
+  const char *action_name;
+  GAction *action;
+
+  g_hash_table_iter_init (&iter, priv->actions);
+
+  while (g_hash_table_iter_next (&iter, (void **)&action_name, (void **)&action))
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (self), action_name);
+      valent_device_plugin_disconnect_action (self, action);
+      g_hash_table_iter_remove (&iter);
+    }
+
+  G_OBJECT_CLASS (valent_device_plugin_parent_class)->dispose (object);
+}
+
+static void
+valent_device_plugin_finalize (GObject *object)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (object);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+
+  g_clear_pointer (&priv->actions, g_hash_table_unref);
+
+  G_OBJECT_CLASS (valent_device_plugin_parent_class)->finalize (object);
+}
+
+static void
+valent_device_plugin_get_property (GObject    *object,
+                                   guint       prop_id,
+                                   GValue     *value,
+                                   GParamSpec *pspec)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (object);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE:
+      g_value_set_object (value, priv->device);
+      break;
+
+    case PROP_PLUGIN_INFO:
+      g_value_set_boxed (value, priv->plugin_info);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_device_plugin_set_property (GObject      *object,
+                                   guint         prop_id,
+                                   const GValue *value,
+                                   GParamSpec   *pspec)
+{
+  ValentDevicePlugin *self = VALENT_DEVICE_PLUGIN (object);
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE:
+      priv->device = g_value_get_object (value);
+      break;
+
+    case PROP_PLUGIN_INFO:
+      priv->plugin_info = g_value_get_boxed (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_device_plugin_class_init (ValentDevicePluginClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = valent_device_plugin_dispose;
+  object_class->finalize = valent_device_plugin_finalize;
+  object_class->get_property = valent_device_plugin_get_property;
+  object_class->set_property = valent_device_plugin_set_property;
+
+  klass->disable = valent_device_plugin_real_disable;
+  klass->enable = valent_device_plugin_real_enable;
+  klass->handle_packet = valent_device_plugin_real_handle_packet;
+  klass->update_state = valent_device_plugin_real_update_state;
 
   /**
-   * ValentDevicePlugin:device:
+   * ValentDevicePlugin:device: (getter get_device)
    *
-   * The #ValentDevice this plugin is bound to.
+   * The device this plugin is bound is bound to.
    */
-  g_object_interface_install_property (iface,
-                                       g_param_spec_object ("device",
-                                                            "Device",
-                                                            "Device",
-                                                            VALENT_TYPE_DEVICE,
-                                                            (G_PARAM_READWRITE |
-                                                             G_PARAM_CONSTRUCT_ONLY |
-                                                             G_PARAM_EXPLICIT_NOTIFY |
-                                                             G_PARAM_STATIC_STRINGS)));
+  properties [PROP_DEVICE] =
+    g_param_spec_object ("device",
+                         "Device",
+                         "The device this plugin is bound to",
+                         VALENT_TYPE_DEVICE,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentDevicePlugin:plugin-info:
+   *
+   * The #PeasPluginInfo describing this device plugin.
+   */
+  properties [PROP_PLUGIN_INFO] =
+    g_param_spec_boxed ("plugin-info",
+                        "Plugin Info",
+                        "Plugin Info",
+                        PEAS_TYPE_PLUGIN_INFO,
+                        (G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_EXPLICIT_NOTIFY |
+                         G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+}
+
+static void
+valent_device_plugin_init (ValentDevicePlugin *self)
+{
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (self);
+
+  priv->actions = g_hash_table_new_full (g_str_hash,
+                                         g_str_equal,
+                                         g_free,
+                                         g_object_unref);
+}
+
+/**
+ * valent_device_plugin_get_device: (get-property device)
+ * @plugin: a #ValentDevicePlugin
+ *
+ * Get the device this plugin is bound to.
+ *
+ * Returns: (transfer none): a #ValentDevice
+ */
+ValentDevice *
+valent_device_plugin_get_device (ValentDevicePlugin *plugin)
+{
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
+
+  g_return_val_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin), NULL);
+
+  return priv->device;
+}
+
+/**
+ * valent_device_plugin_queue_packet:
+ * @plugin: a #ValentDevicePlugin
+ * @packet: a KDE Connect packet
+ *
+ * Queue a KDE Connect packet to be sent to the device this plugin is bound to.
+ *
+ * This is a convenience for calling [method@Valent.DevicePlugin.get_device] and
+ * then [method@Valent.Device.queue_packet].
+ */
+void
+valent_device_plugin_queue_packet (ValentDevicePlugin *plugin,
+                                   JsonNode           *packet)
+{
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
+
+  g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
+  g_return_if_fail (VALENT_IS_PACKET (packet));
+
+  valent_device_queue_packet (priv->device, packet);
+}
+
+/**
+ * valent_device_plugin_show_notification:
+ * @plugin: a #ValentDevicePlugin
+ * @id: an id for the notification
+ * @notification: a #GNotification
+ *
+ * A convenience for showing a local notification.
+ *
+ * @id will be automatically prepended with the device ID and plugin module to
+ * prevent conflicting with other devices and plugins.
+ *
+ * Call [method@Valent.DevicePlugin.hide_notification] to make the same
+ * transformation on @id and withdraw the notification.
+ */
+void
+valent_device_plugin_show_notification (ValentDevicePlugin *plugin,
+                                        const char         *id,
+                                        GNotification      *notification)
+{
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
+  GApplication *application = g_application_get_default ();
+  g_autofree char *notification_id = NULL;
+
+  g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
+  g_return_if_fail (id != NULL);
+  g_return_if_fail (G_IS_NOTIFICATION (notification));
+
+  if G_UNLIKELY (application == NULL)
+    return;
+
+  notification_id = g_strdup_printf ("%s::%s::%s",
+                                     valent_device_get_id (priv->device),
+                                     peas_plugin_info_get_module_name (priv->plugin_info),
+                                     id);
+  g_application_send_notification (application, notification_id, notification);
+}
+
+/**
+ * valent_device_plugin_hide_notification:
+ * @plugin: a #ValentDevicePlugin
+ * @id: an id for the notification
+ *
+ * A convenience for withdrawing a notification previously shown with
+ * [method@Valent.DevicePlugin.show_notification].
+ */
+void
+valent_device_plugin_hide_notification (ValentDevicePlugin *plugin,
+                                        const char         *id)
+{
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
+  GApplication *application = g_application_get_default ();
+  g_autofree char *notification_id = NULL;
+
+  g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
+  g_return_if_fail (id != NULL);
+
+  if G_UNLIKELY (application == NULL)
+    return;
+
+  notification_id = g_strdup_printf ("%s::%s::%s",
+                                     valent_device_get_id (priv->device),
+                                     peas_plugin_info_get_module_name (priv->plugin_info),
+                                     id);
+  g_application_withdraw_notification (application, notification_id);
 }
 
 /**
@@ -137,11 +598,12 @@ valent_device_plugin_default_init (ValentDevicePluginInterface *iface)
  * @device_id: a #ValentDevice ID
  * @module_name: a #PeasPluginInfo module name
  *
- * A convenience function for plugins to create a #GSettings object for a device
- * ID and module name.
+ * A convenience function for plugins to create a [class@Gio.Settings] object
+ * for a device ID and plugin module name.
  *
  * It is expected that @device_id is a valid string for a #GSettings path and
- * that the target #GSettingsSchema is of the form `ca.andyholmes.valent.module_name`.
+ * that the target [class@Gio.SettingsSchema] is of the form
+ * `ca.andyholmes.valent.module_name`.
  *
  * Returns: (transfer full): the new #GSettings object
  */
@@ -173,7 +635,8 @@ valent_device_plugin_new_settings (const char *device_id,
  * valent_device_plugin_get_incoming:
  * @info: a #ValentDevicePluginInfo
  *
- * Gets the list of incoming packets @plugin can handle.
+ * Get a list of incoming KDE Connect packets that the plugin described by @info
+ * can handle.
  *
  * Returns: (transfer full) (nullable): a list of packet types
  */
@@ -193,7 +656,8 @@ valent_device_plugin_get_incoming (PeasPluginInfo *info)
  * valent_device_plugin_get_outgoing:
  * @info: a #PeasPluginInfo
  *
- * Gets the list of outgoing packets @plugin can provide.
+ * Get a list of outgoing KDE Connect packets that the plugin described by @info
+ * may provide.
  *
  * Returns: (transfer full) (nullable): a list of packet types
  */
@@ -210,119 +674,52 @@ valent_device_plugin_get_outgoing (PeasPluginInfo *info)
 }
 
 /**
- * valent_device_plugin_register_actions:
- * @plugin: a #ValentDevicePlugin
- * @entries: (array length=n_entries) (element-type GActionEntry): a pointer to
- *           the first item in an array of #GActionEntry structs
- * @n_entries: the length of @entries, or -1 if @entries is %NULL-terminated
- *
- * Register #GAction @entries with the #ValentDevice for @plugin. Each action is
- * passed @plugin as the user data for #GAction::activate.
- */
-void
-valent_device_plugin_register_actions (ValentDevicePlugin *plugin,
-                                       const GActionEntry *entries,
-                                       int                 n_entries)
-{
-  g_autoptr (ValentDevice) device = NULL;
-  GActionMap *actions;
-
-  g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
-  g_return_if_fail (entries != NULL || n_entries == 0);
-
-  g_object_get (plugin, "device", &device, NULL);
-  actions = G_ACTION_MAP (valent_device_get_actions (device));
-
-  g_action_map_add_action_entries (actions, entries, n_entries, plugin);
-}
-
-/**
- * valent_device_plugin_unregister_actions:
- * @plugin: a #ValentDevicePlugin
- * @entries: (array length=n_entries) (element-type GActionEntry): a pointer to
- *           the first item in an array of #GActionEntry structs
- * @n_entries: the length of @entries, or -1 if @entries is %NULL-terminated
- *
- * Unregister #GAction @entries with the #ValentDevice for @plugin.
- */
-void
-valent_device_plugin_unregister_actions (ValentDevicePlugin *plugin,
-                                         const GActionEntry *entries,
-                                         int                 n_entries)
-{
-  g_autoptr (ValentDevice) device = NULL;
-  GActionMap *actions;
-
-  g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
-  g_return_if_fail (entries != NULL || n_entries == 0);
-
-  g_object_get (plugin, "device", &device, NULL);
-  actions = G_ACTION_MAP (valent_device_get_actions (device));
-
-  for (int i = 0; i < n_entries; i++)
-    g_action_map_remove_action (actions, entries[i].name);
-}
-
-/**
  * valent_device_plugin_toggle_actions:
  * @plugin: a #ValentDevicePlugin
- * @actions: (array length=n_entries) (element-type GActionEntry): a pointer to
- *           the first item in an array of #GActionEntry structs
- * @n_entries: the length of @entries, or -1 if @entries is %NULL-terminated
- * @state: boolean
+ * @enabled: boolean
  *
- * Enable or disable @actions for @device based on @state.
+ * Set the [property@Gio.Action:enabled] property of the actions for @plugin to
+ * @enabled.
  */
 void
 valent_device_plugin_toggle_actions (ValentDevicePlugin *plugin,
-                                     const GActionEntry *entries,
-                                     int                 n_entries,
-                                     gboolean            state)
+                                     gboolean            enabled)
 {
-  g_autoptr (ValentDevice) device = NULL;
-  GActionMap *actions;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
+  GHashTableIter iter;
+  GSimpleAction *action;
 
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
-  g_return_if_fail (entries != NULL || n_entries == 0);
 
-  g_object_get (plugin, "device", &device, NULL);
-  actions = G_ACTION_MAP (valent_device_get_actions (device));
+  g_hash_table_iter_init (&iter, priv->actions);
 
-  for (int i = 0; i < n_entries; i++)
-    {
-      GAction *action;
-
-      action = g_action_map_lookup_action (actions, entries[i].name);
-
-      if (action != NULL)
-        g_simple_action_set_enabled (G_SIMPLE_ACTION (action), state);
-    }
+  while (g_hash_table_iter_next (&iter, NULL, (void **)&action))
+    g_simple_action_set_enabled (action, enabled);
 }
 
 /**
  * valent_device_plugin_add_menu_entries:
  * @plugin: a #ValentDevicePlugin
- * @entries: (array length=n_entries) (element-type ValentMenuEntry): a pointer
+ * @entries: (array length=n_entries) (element-type Valent.MenuEntry): a pointer
  *           to the first item in an array of #ValentMenuEntry structs
  * @n_entries: the length of @entries, or -1 if @entries is %NULL-terminated
  *
- * A convenience function for creating multiple #GMenuItem instances and adding
- * them to a #ValentDevice's #GMenu. Each action is constructed as per one
- * #ValentMenuEntry.
+ * A convenience function for creating multiple [class@Gio.MenuItem] instances
+ * and adding them to the device [class@Gio.MenuModel]. Each item is
+ * constructed as per one [struct@Valent.MenuEntry].
  */
 void
 valent_device_plugin_add_menu_entries (ValentDevicePlugin    *plugin,
                                        const ValentMenuEntry *entries,
                                        int                    n_entries)
 {
-  g_autoptr (ValentDevice) device = NULL;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
   GMenu *menu;
 
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
   g_return_if_fail (entries != NULL || n_entries == 0);
 
-  g_object_get (plugin, "device", &device, NULL);
-  menu = G_MENU (valent_device_get_menu (device));
+  menu = G_MENU (valent_device_get_menu (priv->device));
 
   for (int i = 0; i < n_entries; i++)
     {
@@ -365,25 +762,24 @@ _g_menu_find_action (GMenu      *menu,
 /**
  * valent_device_plugin_remove_menu_entries:
  * @plugin: a #ValentDevicePlugin
- * @entries: (array length=n_entries) (element-type ValentMenuEntry): a pointer
+ * @entries: (array length=n_entries) (element-type Valent.MenuEntry): a pointer
  *           to the first item in an array of #ValentMenuEntry structs
  * @n_entries: the length of @entries, or -1 if @entries is %NULL-terminated
  *
- * A counterpart to valent_device_plugin_add_menu_entries().
+ * A counterpart to [method@Valent.DevicePlugin.add_menu_entries].
  */
 void
 valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
                                           const ValentMenuEntry *entries,
                                           int                    n_entries)
 {
-  g_autoptr (ValentDevice) device = NULL;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
   GMenu *menu;
 
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
   g_return_if_fail (entries != NULL || n_entries == 0);
 
-  g_object_get (plugin, "device", &device, NULL);
-  menu = G_MENU (valent_device_get_menu (device));
+  menu = G_MENU (valent_device_get_menu (priv->device));
 
   for (int i = 0; i < n_entries; i++)
     {
@@ -400,8 +796,8 @@ valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
  * @attribute: an attribute name to match
  * @value: an attribute value to match
  *
- * Search the top-level of a #GMenuModel for the index of an item with the
- * attribute @name holding @value.
+ * Search the top-level of a [class@Gio.MenuModel] for the index of an item with
+ * the attribute @name holding @value.
  *
  * Returns: position of the item or -1 if not found
  */
@@ -410,7 +806,7 @@ valent_device_plugin_find_menu_item (ValentDevicePlugin *plugin,
                                      const char         *attribute,
                                      const GVariant     *value)
 {
-  g_autoptr (ValentDevice) device = NULL;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
   GMenuModel *model;
   int i, n_items;
 
@@ -418,8 +814,7 @@ valent_device_plugin_find_menu_item (ValentDevicePlugin *plugin,
   g_return_val_if_fail (attribute != NULL, -1);
   g_return_val_if_fail (value != NULL, -1);
 
-  g_object_get (plugin, "device", &device, NULL);
-  model = valent_device_get_menu (device);
+  model = valent_device_get_menu (priv->device);
 
   n_items = g_menu_model_get_n_items (model);
 
@@ -445,8 +840,8 @@ valent_device_plugin_find_menu_item (ValentDevicePlugin *plugin,
  * @attribute: an attribute name to match
  * @value: an attribute value to match
  *
- * Removes an item in @menu with a the specified attribute and value. If @menu
- * contains a top-level item with @attribute holding @value it is removed.
+ * Remove an item in the top-level of the device [class@Gio.MenuModel] with
+ * the specified attribute and value.
  *
  * Returns: the index of the removed item or -1 if not found.
  */
@@ -455,7 +850,7 @@ valent_device_plugin_remove_menu_item (ValentDevicePlugin *plugin,
                                        const char         *attribute,
                                        const GVariant     *value)
 {
-  g_autoptr (ValentDevice) device = NULL;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
   GMenu *menu;
   int position;
 
@@ -463,8 +858,7 @@ valent_device_plugin_remove_menu_item (ValentDevicePlugin *plugin,
   g_return_val_if_fail (attribute != NULL, -1);
   g_return_val_if_fail (value != NULL, -1);
 
-  g_object_get (plugin, "device", &device, NULL);
-  menu = G_MENU (valent_device_get_menu (device));
+  menu = G_MENU (valent_device_get_menu (priv->device));
   position = valent_device_plugin_find_menu_item (plugin, attribute, value);
 
   if (position > -1)
@@ -479,18 +873,18 @@ valent_device_plugin_remove_menu_item (ValentDevicePlugin *plugin,
  * @item: a #GMenuItem
  * @attribute: an attribute name to match
  *
- * Replaces an item in @menu with @item.
+ * Replace an item in the top-level of the device [class@Gio.MenuModel] with
+ * @item.
  *
- * If @menu contains a top-level item with the same action name as @item, it is
- * removed and @item is inserted at the same position. Otherwise @item is
- * appended to @menu.
+ * If the devices menu does not contain a top-level item with the same action
+ * name as @item, the item will be appended instead.
  */
 void
 valent_device_plugin_replace_menu_item (ValentDevicePlugin *plugin,
                                         GMenuItem          *item,
                                         const char         *attribute)
 {
-  g_autoptr (ValentDevice) device = NULL;
+  ValentDevicePluginPrivate *priv = valent_device_plugin_get_instance_private (plugin);
   g_autoptr (GVariant) value = NULL;
   GMenu *menu;
   int position = -1;
@@ -498,8 +892,7 @@ valent_device_plugin_replace_menu_item (ValentDevicePlugin *plugin,
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
   g_return_if_fail (G_IS_MENU_ITEM (item));
 
-  g_object_get (plugin, "device", &device, NULL);
-  menu = G_MENU (valent_device_get_menu (device));
+  menu = G_MENU (valent_device_get_menu (priv->device));
   value = g_menu_item_get_attribute_value (item, attribute, NULL);
 
   if (value != NULL)
@@ -515,56 +908,57 @@ valent_device_plugin_replace_menu_item (ValentDevicePlugin *plugin,
  * valent_device_plugin_enable: (virtual enable)
  * @plugin: a #ValentDevicePlugin
  *
- * Enables the plugin.
+ * Enable the plugin.
  *
  * This function is called when the plugin is enabled by the user and should
  * prepare any persistent resources it may need. Usually this means registering
  * actions, preparing the plugin settings and other data sources.
  *
- * It is guaranteed that valent_device_plugin_disable() will be called if this
- * function has been called.
+ * It is guaranteed that [method@Valent.DevicePlugin.disable] will be called if
+ * this function has been called.
  */
 void
 valent_device_plugin_enable (ValentDevicePlugin *plugin)
 {
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
 
-  VALENT_DEVICE_PLUGIN_GET_IFACE (plugin)->enable (plugin);
+  VALENT_DEVICE_PLUGIN_GET_CLASS (plugin)->enable (plugin);
 }
 
 /**
  * valent_device_plugin_disable: (virtual disable)
  * @plugin: a #ValentDevicePlugin
  *
- * Disables the plugin.
+ * Disable the plugin.
  *
  * This function is called when the plugin is disabled by the user and should
- * clean up any resources that were prepared in valent_device_plugin_enable() or
- * valent_device_plugin_update_state().
+ * clean up any resources prepared in [method@Valent.DevicePlugin.enable] or
+ * [method@Valent.DevicePlugin.update_state].
  *
  * It is guaranteed that this function will be called if
- * valent_device_plugin_enable() has been called.
+ * [method@Valent.DevicePlugin.enable] has been called.
  */
 void
 valent_device_plugin_disable (ValentDevicePlugin *plugin)
 {
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
 
-  VALENT_DEVICE_PLUGIN_GET_IFACE (plugin)->disable (plugin);
+  VALENT_DEVICE_PLUGIN_GET_CLASS (plugin)->disable (plugin);
 }
 
 /**
  * valent_device_plugin_handle_packet: (virtual handle_packet)
  * @plugin: a #ValentDevicePlugin
- * @type: the packet type
- * @packet: a #JsonNode
+ * @type: a KDE Connect packet type
+ * @packet: a KDE Connect packet
+ *
+ * Handle a packet from the device the plugin is bound to.
  *
  * This is called when the device receives a packet type included in the
- * `X-IncomingCapabilities` field of the `.plugin` file for @plugin.
+ * `X-IncomingCapabilities` field of the `.plugin` file.
  *
- * This is optional for #ValentDevicePlugin implementations which do not
- * register any incoming capabilities, such as plugins that do not provide
- * packet-based functionality.
+ * This is optional for implementations which do not register any incoming
+ * capabilities, such as plugins that do not provide packet-based functionality.
  */
 void
 valent_device_plugin_handle_packet (ValentDevicePlugin *plugin,
@@ -572,10 +966,10 @@ valent_device_plugin_handle_packet (ValentDevicePlugin *plugin,
                                     JsonNode           *packet)
 {
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
-  g_return_if_fail (type != NULL);
+  g_return_if_fail (type != NULL && *type != '\0');
   g_return_if_fail (VALENT_IS_PACKET (packet));
 
-  VALENT_DEVICE_PLUGIN_GET_IFACE (plugin)->handle_packet (plugin, type, packet);
+  VALENT_DEVICE_PLUGIN_GET_CLASS (plugin)->handle_packet (plugin, type, packet);
 }
 
 /**
@@ -583,15 +977,14 @@ valent_device_plugin_handle_packet (ValentDevicePlugin *plugin,
  * @plugin: a #ValentDevicePlugin
  * @state: a #ValentDeviceState
  *
- * Updates the plugin state.
+ * Update the plugin based on the new state of the device.
  *
- * This function is called when the device's connected or paired state changes
- * and may be used to prepare or release resources needed for packet exchange.
- * Usually this means configuring actions and event handler that may trigger
- * outgoing packets and exchanging connect-time data from the device.
+ * This function is called when the connected or paired state of the device
+ * changes. This may be used to configure actions, event handlers that may
+ * trigger outgoing packets and exchange connect-time data with the device.
  *
- * This is an optional for #ValentDevicePlugin implementations as plugins aren't
- * required to be dependent on the device state.
+ * This is optional for all implementations as plugins aren't required to be
+ * dependent on the device state.
  */
 void
 valent_device_plugin_update_state (ValentDevicePlugin *plugin,
@@ -599,6 +992,6 @@ valent_device_plugin_update_state (ValentDevicePlugin *plugin,
 {
   g_return_if_fail (VALENT_IS_DEVICE_PLUGIN (plugin));
 
-  VALENT_DEVICE_PLUGIN_GET_IFACE (plugin)->update_state (plugin, state);
+  VALENT_DEVICE_PLUGIN_GET_CLASS (plugin)->update_state (plugin, state);
 }
 

--- a/src/libvalent/core/valent-device-plugin.h
+++ b/src/libvalent/core/valent-device-plugin.h
@@ -27,80 +27,79 @@ typedef struct
 #define VALENT_TYPE_DEVICE_PLUGIN (valent_device_plugin_get_type ())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_INTERFACE (ValentDevicePlugin, valent_device_plugin, VALENT, DEVICE_PLUGIN, GObject)
+G_DECLARE_DERIVABLE_TYPE (ValentDevicePlugin, valent_device_plugin, VALENT, DEVICE_PLUGIN, ValentObject)
 
-struct _ValentDevicePluginInterface
+struct _ValentDevicePluginClass
 {
-  GTypeInterface   g_iface;
+  ValentObjectClass   parent_class;
 
   /* virtual functions */
-  void             (*disable)       (ValentDevicePlugin *plugin);
-  void             (*enable)        (ValentDevicePlugin *plugin);
-  void             (*handle_packet) (ValentDevicePlugin *plugin,
-                                     const char         *type,
-                                     JsonNode           *packet);
-  void             (*update_state)  (ValentDevicePlugin *plugin,
-                                     ValentDeviceState   state);
+  void                (*disable)       (ValentDevicePlugin *plugin);
+  void                (*enable)        (ValentDevicePlugin *plugin);
+  void                (*handle_packet) (ValentDevicePlugin *plugin,
+                                        const char         *type,
+                                        JsonNode           *packet);
+  void                (*update_state)  (ValentDevicePlugin *plugin,
+                                        ValentDeviceState   state);
 };
 
-/* Core Interface */
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_disable             (ValentDevicePlugin    *plugin);
+void           valent_device_plugin_disable             (ValentDevicePlugin    *plugin);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_enable              (ValentDevicePlugin    *plugin);
+void           valent_device_plugin_enable              (ValentDevicePlugin    *plugin);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_handle_packet       (ValentDevicePlugin    *plugin,
-                                                      const char            *type,
-                                                      JsonNode              *packet);
+void           valent_device_plugin_handle_packet       (ValentDevicePlugin    *plugin,
+                                                         const char            *type,
+                                                         JsonNode              *packet);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_update_state        (ValentDevicePlugin    *plugin,
-                                                      ValentDeviceState      state);
+void           valent_device_plugin_update_state        (ValentDevicePlugin    *plugin,
+                                                         ValentDeviceState      state);
+VALENT_AVAILABLE_IN_1_0
+ValentDevice * valent_device_plugin_get_device          (ValentDevicePlugin    *plugin);
+VALENT_AVAILABLE_IN_1_0
+void           valent_device_plugin_queue_packet        (ValentDevicePlugin    *plugin,
+                                                         JsonNode              *packet);
+VALENT_AVAILABLE_IN_1_0
+void           valent_device_plugin_show_notification   (ValentDevicePlugin    *plugin,
+                                                         const char            *id,
+                                                         GNotification         *notification);
+VALENT_AVAILABLE_IN_1_0
+void           valent_device_plugin_hide_notification   (ValentDevicePlugin    *plugin,
+                                                         const char            *id);
+VALENT_AVAILABLE_IN_1_0
+void           valent_device_plugin_toggle_actions      (ValentDevicePlugin    *plugin,
+                                                         gboolean               enabled);
 
-/* Utility Functions */
+/* Utilities */
 VALENT_AVAILABLE_IN_1_0
-GSettings * valent_device_plugin_new_settings        (const char            *device_id,
-                                                      const char            *module_name);
+GStrv          valent_device_plugin_get_incoming        (PeasPluginInfo        *info);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_register_actions    (ValentDevicePlugin    *plugin,
-                                                      const GActionEntry    *entries,
-                                                      int                    n_entries);
+GStrv          valent_device_plugin_get_outgoing        (PeasPluginInfo        *info);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_unregister_actions  (ValentDevicePlugin    *plugin,
-                                                      const GActionEntry    *entries,
-                                                      int                    n_entries);
-VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_toggle_actions      (ValentDevicePlugin    *plugin,
-                                                      const GActionEntry    *actions,
-                                                      int                    n_entries,
-                                                      gboolean               state);
+GSettings *    valent_device_plugin_new_settings        (const char            *device_id,
+                                                         const char            *module_name);
 
 /* TODO: GMenuModel XML */
 VALENT_AVAILABLE_IN_1_0
-int          valent_device_plugin_find_menu_item     (ValentDevicePlugin    *plugin,
-                                                      const char            *attribute,
-                                                      const GVariant        *value);
+int             valent_device_plugin_find_menu_item     (ValentDevicePlugin    *plugin,
+                                                         const char            *attribute,
+                                                         const GVariant        *value);
 VALENT_AVAILABLE_IN_1_0
-int          valent_device_plugin_remove_menu_item   (ValentDevicePlugin    *plugin,
-                                                      const char            *attribute,
-                                                      const GVariant        *value);
+int             valent_device_plugin_remove_menu_item   (ValentDevicePlugin    *plugin,
+                                                         const char            *attribute,
+                                                         const GVariant        *value);
 VALENT_AVAILABLE_IN_1_0
-void         valent_device_plugin_replace_menu_item  (ValentDevicePlugin    *plugin,
-                                                      GMenuItem             *item,
-                                                      const char            *attribute);
+void            valent_device_plugin_replace_menu_item  (ValentDevicePlugin    *plugin,
+                                                         GMenuItem             *item,
+                                                         const char            *attribute);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_add_menu_entries    (ValentDevicePlugin    *plugin,
-                                                      const ValentMenuEntry *entries,
-                                                      int                    n_entries);
+void           valent_device_plugin_add_menu_entries    (ValentDevicePlugin    *plugin,
+                                                         const ValentMenuEntry *entries,
+                                                         int                    n_entries);
 VALENT_AVAILABLE_IN_1_0
-void        valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
-                                                      const ValentMenuEntry *entries,
-                                                      int                    n_entries);
-
-/* Plugin Info Helpers */
-VALENT_AVAILABLE_IN_1_0
-GStrv       valent_device_plugin_get_incoming        (PeasPluginInfo        *info);
-VALENT_AVAILABLE_IN_1_0
-GStrv       valent_device_plugin_get_outgoing        (PeasPluginInfo        *info);
+void           valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
+                                                         const ValentMenuEntry *entries,
+                                                         int                    n_entries);
 
 G_END_DECLS
 

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -26,49 +26,46 @@
 
 
 /**
- * SECTION:valentdevice
- * @short_description: An object representing a remote device
- * @title: ValentDevice
- * @stability: Unstable
- * @include: libvalent-core.h
+ * ValentDevice:
  *
- * The #ValentDevice object represents a remote device such as a smartphone,
- * tablet or desktop.
+ * A class representing a remote device, such as a smartphone or desktop.
  *
- * #ValentDevice implements #GActionGroup and #GActionMap, while providing a
- * #GMenu. #ValentDevicePlugin implementations can add #GActions and #GMenuItems
- * to expose plugin activities.
+ * Device functionality is limited to pairing and sending packets, while other
+ * functionality is delegated to [class@Valent.DevicePlugin] extensions.
+ *
+ * #ValentDevice implements the [iface@Gio.ActionGroup] interface, acting as an
+ * aggregate action group for plugins. Plugin actions are automatically included
+ * in the device action group with the plugin module name as a prefix
+ * (eg. `share.files`).
  */
 
 struct _ValentDevice
 {
-  ValentObject         parent_instance;
+  ValentObject    parent_instance;
 
-  ValentData          *data;
-  GSettings           *settings;
+  ValentData     *data;
+  GSettings      *settings;
 
-  /* Device Properties */
-  char                *icon_name;
-  char                *id;
-  char                *name;
-  char                *type;
-  char               **incoming_capabilities;
-  char               **outgoing_capabilities;
+  /* Properties */
+  char           *icon_name;
+  char           *id;
+  char           *name;
+  char           *type;
+  char          **incoming_capabilities;
+  char          **outgoing_capabilities;
 
   /* State */
-  ValentChannel       *channel;
-  gboolean             paired;
-  unsigned int         incoming_pair;
-  unsigned int         outgoing_pair;
+  ValentChannel  *channel;
+  gboolean        paired;
+  unsigned int    incoming_pair;
+  unsigned int    outgoing_pair;
 
   /* Plugins */
-  PeasEngine          *engine;
-  GHashTable          *plugins;
-  GHashTable          *handlers;
-
-  /* Actions & Menu */
-  GSimpleActionGroup  *actions;
-  GMenu               *menu;
+  PeasEngine     *engine;
+  GHashTable     *plugins;
+  GHashTable     *handlers;
+  GHashTable     *actions;
+  GMenu          *menu;
 };
 
 static void       valent_device_reload_plugins  (ValentDevice   *device);
@@ -76,7 +73,10 @@ static void       valent_device_update_plugins  (ValentDevice   *device);
 static gboolean   valent_device_supports_plugin (ValentDevice   *device,
                                                  PeasPluginInfo *info);
 
-G_DEFINE_TYPE (ValentDevice, valent_device, VALENT_TYPE_OBJECT)
+static void   g_action_group_iface_init     (GActionGroupInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (ValentDevice, valent_device, VALENT_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_ACTION_GROUP, g_action_group_iface_init))
 
 
 enum {
@@ -101,6 +101,95 @@ enum {
 };
 
 static guint signals[N_SIGNALS] = { 0, };
+
+
+/*
+ * GActionGroup
+ */
+static void
+valent_device_activate_action (GActionGroup *action_group,
+                               const char   *action_name,
+                               GVariant     *parameter)
+{
+  ValentDevice *self = VALENT_DEVICE (action_group);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (self->actions, action_name)) != NULL)
+    g_action_activate (action, parameter);
+}
+
+static void
+valent_device_change_action_state (GActionGroup *action_group,
+                                   const char   *action_name,
+                                   GVariant     *value)
+{
+  ValentDevice *self = VALENT_DEVICE (action_group);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (self->actions, action_name)) != NULL)
+    g_action_change_state (action, value);
+}
+
+static char **
+valent_device_list_actions (GActionGroup *action_group)
+{
+  ValentDevice *self = VALENT_DEVICE (action_group);
+  g_auto (GStrv) actions = NULL;
+  GHashTableIter iter;
+  gpointer key;
+  unsigned int i = 0;
+
+  actions = g_new0 (char *, g_hash_table_size (self->actions) + 1);
+
+  g_hash_table_iter_init (&iter, self->actions);
+
+  while (g_hash_table_iter_next (&iter, &key, NULL))
+    actions[i++] = g_strdup (key);
+
+  return g_steal_pointer (&actions);
+}
+
+static gboolean
+valent_device_query_action (GActionGroup        *action_group,
+                            const char          *action_name,
+                            gboolean            *enabled,
+                            const GVariantType **parameter_type,
+                            const GVariantType **state_type,
+                            GVariant           **state_hint,
+                            GVariant           **state)
+{
+  ValentDevice *self = VALENT_DEVICE (action_group);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (self->actions, action_name)) == NULL)
+    return FALSE;
+
+  if (enabled)
+    *enabled = g_action_get_enabled (action);
+
+  if (parameter_type)
+    *parameter_type = g_action_get_parameter_type (action);
+
+  if (state_type)
+    *state_type = g_action_get_state_type (action);
+
+  if (state_hint)
+    *state_hint = g_action_get_state_hint (action);
+
+  if (state)
+    *state = g_action_get_state (action);
+
+  return TRUE;
+}
+
+static void
+g_action_group_iface_init (GActionGroupInterface *iface)
+{
+  iface->activate_action = valent_device_activate_action;
+  iface->change_action_state = valent_device_change_action_state;
+  iface->list_actions = valent_device_list_actions;
+  iface->query_action = valent_device_query_action;
+}
 
 
 /*
@@ -131,9 +220,79 @@ device_plugin_free (gpointer data)
 }
 
 static void
+on_plugin_action_added (GActionGroup *action_group,
+                        const char   *action_name,
+                        DevicePlugin *plugin)
+{
+  ValentDevice *self = VALENT_DEVICE (plugin->device);
+  g_autofree char *full_name = NULL;
+  GAction *action;
+
+  full_name = g_strdup_printf ("%s.%s",
+                               peas_plugin_info_get_module_name (plugin->info),
+                               action_name);
+  action = g_action_map_lookup_action (G_ACTION_MAP (action_group),
+                                       action_name);
+
+  g_hash_table_replace (self->actions,
+                        g_strdup (full_name),
+                        g_object_ref (action));
+  g_action_group_action_added (G_ACTION_GROUP (plugin->device), full_name);
+}
+
+static void
+on_plugin_action_enabled_changed (GActionGroup *action_group,
+                                  const char   *action_name,
+                                  gboolean      enabled,
+                                  DevicePlugin *plugin)
+{
+  g_autofree char *full_name = NULL;
+
+  full_name = g_strdup_printf ("%s.%s",
+                               peas_plugin_info_get_module_name (plugin->info),
+                               action_name);
+  g_action_group_action_enabled_changed (G_ACTION_GROUP (plugin->device),
+                                         full_name,
+                                         enabled);
+}
+
+static void
+on_plugin_action_removed (GActionGroup *action_group,
+                          const char   *action_name,
+                          DevicePlugin *plugin)
+{
+  ValentDevice *self = VALENT_DEVICE (plugin->device);
+  g_autofree char *full_name = NULL;
+
+  full_name = g_strdup_printf ("%s.%s",
+                               peas_plugin_info_get_module_name (plugin->info),
+                               action_name);
+
+  g_action_group_action_removed (G_ACTION_GROUP (plugin->device), full_name);
+  g_hash_table_remove (self->actions, full_name);
+}
+
+static void
+on_plugin_action_state_changed (GActionGroup *action_group,
+                                const char   *action_name,
+                                GVariant     *value,
+                                DevicePlugin *plugin)
+{
+  g_autofree char *full_name = NULL;
+
+  full_name = g_strdup_printf ("%s.%s",
+                               peas_plugin_info_get_module_name (plugin->info),
+                               action_name);
+  g_action_group_action_state_changed (G_ACTION_GROUP (plugin->device),
+                                       full_name,
+                                       value);
+}
+
+static void
 valent_device_enable_plugin (ValentDevice *device,
                              DevicePlugin *plugin)
 {
+  g_auto (GStrv) actions = NULL;
   g_auto (GStrv) incoming = NULL;
   unsigned int n_capabilities = 0;
 
@@ -159,6 +318,33 @@ valent_device_enable_plugin (ValentDevice *device,
                            plugin->extension);
     }
 
+  /* Register plugin actions */
+  actions = g_action_group_list_actions (G_ACTION_GROUP (plugin->extension));
+
+  for (unsigned int i = 0; actions[i] != NULL; i++)
+    {
+      on_plugin_action_added (G_ACTION_GROUP (plugin->extension),
+                              actions[i],
+                              plugin);
+    }
+
+  g_signal_connect (plugin->extension,
+                    "action-added",
+                    G_CALLBACK (on_plugin_action_added),
+                    plugin);
+  g_signal_connect (plugin->extension,
+                    "action-enabled-changed",
+                    G_CALLBACK (on_plugin_action_enabled_changed),
+                    plugin);
+  g_signal_connect (plugin->extension,
+                    "action-removed",
+                    G_CALLBACK (on_plugin_action_removed),
+                    plugin);
+  g_signal_connect (plugin->extension,
+                    "action-state-changed",
+                    G_CALLBACK (on_plugin_action_state_changed),
+                    plugin);
+
   /* Bootstrap the newly instantiated plugin */
   valent_device_plugin_enable (VALENT_DEVICE_PLUGIN (plugin->extension));
   valent_device_plugin_update_state (VALENT_DEVICE_PLUGIN (plugin->extension),
@@ -169,12 +355,24 @@ static void
 valent_device_disable_plugin (ValentDevice *device,
                               DevicePlugin *plugin)
 {
+  g_auto (GStrv) actions = NULL;
   g_auto (GStrv) incoming = NULL;
   unsigned int len;
 
   g_assert (VALENT_IS_DEVICE (device));
   g_assert (plugin != NULL);
   g_return_if_fail (PEAS_IS_EXTENSION (plugin->extension));
+
+  /* Unregister actions */
+  g_signal_handlers_disconnect_by_data (plugin->extension, plugin);
+  actions = g_action_group_list_actions (G_ACTION_GROUP (plugin->extension));
+
+  for (unsigned int i = 0; actions[i]; i++)
+    {
+      on_plugin_action_removed (G_ACTION_GROUP (plugin->extension),
+                                actions[i],
+                                plugin);
+    }
 
   /* Unregister packet handlers */
   incoming = valent_device_plugin_get_incoming (plugin->info);
@@ -211,10 +409,18 @@ static gboolean
 valent_device_reset_pair (gpointer object)
 {
   ValentDevice *device = VALENT_DEVICE (object);
+  GApplication *application = g_application_get_default ();
 
   g_assert (VALENT_IS_DEVICE (device));
 
-  valent_device_hide_notification (device, PAIR_REQUEST_ID);
+  if (application != NULL)
+    {
+      g_autofree char *notification_id = NULL;
+
+      notification_id = g_strdup_printf ("%s::%s", device->id, PAIR_REQUEST_ID);
+      g_application_withdraw_notification (application, notification_id);
+    }
+
   g_clear_handle_id (&device->incoming_pair, g_source_remove);
   g_clear_handle_id (&device->outgoing_pair, g_source_remove);
 
@@ -283,42 +489,51 @@ valent_device_send_pair (ValentDevice *device,
 static void
 valent_device_notify_pair (ValentDevice *device)
 {
-  g_autoptr (GNotification) notification = NULL;
-  g_autoptr (GIcon) icon = NULL;
-  g_autofree char *title = NULL;
-  const char *body;
+  GApplication *application = g_application_get_default ();
 
   g_assert (VALENT_IS_DEVICE (device));
 
-  title = g_strdup_printf (_("Pairing request from %s"), device->name);
-  notification = g_notification_new (title);
+  if (application != NULL)
+    {
+      g_autofree char *notification_id = NULL;
+      g_autoptr (GNotification) notification = NULL;
+      g_autoptr (GIcon) icon = NULL;
+      g_autofree char *title = NULL;
+      const char *body;
 
-  if ((body = valent_channel_get_verification_key (device->channel)) != NULL)
-    g_notification_set_body (notification, body);
+      title = g_strdup_printf (_("Pairing request from %s"), device->name);
+      notification = g_notification_new (title);
 
-  icon = g_themed_icon_new (APPLICATION_ID);
-  g_notification_set_icon (notification, icon);
+      if ((body = valent_channel_get_verification_key (device->channel)) != NULL)
+        g_notification_set_body (notification, body);
 
-  g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_URGENT);
+      icon = g_themed_icon_new (APPLICATION_ID);
+      g_notification_set_icon (notification, icon);
 
-  g_notification_add_button_with_target (notification, _("Reject"), "app.device",
-                                         "(ssav)",
-                                         device->id,
-                                         "unpair",
-                                         NULL);
+      g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_URGENT);
 
-  g_notification_add_button_with_target (notification, _("Accept"), "app.device",
-                                         "(ssav)",
-                                         device->id,
-                                         "pair",
-                                         NULL);
+      g_notification_add_button_with_target (notification, _("Reject"), "app.device",
+                                             "(ssav)",
+                                             device->id,
+                                             "unpair",
+                                             NULL);
 
-  /* Show the pairing notification and set a timeout for 30s */
-  valent_device_show_notification (device, PAIR_REQUEST_ID, notification);
+      g_notification_add_button_with_target (notification, _("Accept"), "app.device",
+                                             "(ssav)",
+                                             device->id,
+                                             "pair",
+                                             NULL);
+
+      /* Show the pairing notification and set a timeout for 30s */
+      notification_id = g_strdup_printf ("%s::%s", device->id, PAIR_REQUEST_ID);
+      g_application_send_notification (application,
+                                       notification_id,
+                                       notification);
+    }
+
   device->incoming_pair = g_timeout_add_seconds (PAIR_REQUEST_TIMEOUT,
                                                  valent_device_reset_pair,
                                                  device);
-
   valent_object_notify_by_pspec (G_OBJECT (device), properties [PROP_STATE]);
 }
 
@@ -571,12 +786,6 @@ unpair_action (GSimpleAction *action,
   valent_device_set_paired (device, FALSE);
 }
 
-static const GActionEntry actions[] = {
-  { "pair",   pair_action,   NULL, NULL, NULL },
-  { "unpair", unpair_action, NULL, NULL, NULL },
-};
-
-
 /*
  * GObject
  */
@@ -632,13 +841,15 @@ valent_device_dispose (GObject *object)
 {
   ValentDevice *self = VALENT_DEVICE (object);
 
+  /* State */
   valent_device_reset_pair (self);
   valent_device_set_channel (self, NULL);
 
   /* Plugins */
   g_signal_handlers_disconnect_by_data (self->engine, self);
-  g_clear_pointer (&self->handlers, g_hash_table_unref);
-  g_clear_pointer (&self->plugins, g_hash_table_unref);
+  g_hash_table_remove_all (self->plugins);
+  g_hash_table_remove_all (self->actions);
+  g_hash_table_remove_all (self->handlers);
 
   G_OBJECT_CLASS (valent_device_parent_class)->dispose (object);
 }
@@ -648,7 +859,10 @@ valent_device_finalize (GObject *object)
 {
   ValentDevice *self = VALENT_DEVICE (object);
 
-  /* Device Properties */
+  g_clear_object (&self->data);
+  g_clear_object (&self->settings);
+
+  /* Properties */
   g_clear_pointer (&self->icon_name, g_free);
   g_clear_pointer (&self->id, g_free);
   g_clear_pointer (&self->name, g_free);
@@ -656,13 +870,13 @@ valent_device_finalize (GObject *object)
   g_clear_pointer (&self->incoming_capabilities, g_strfreev);
   g_clear_pointer (&self->outgoing_capabilities, g_strfreev);
 
-  /* Channel */
+  /* State */
   g_clear_object (&self->channel);
-  g_clear_object (&self->data);
-  g_clear_object (&self->settings);
 
-  /* GAction/GMenu */
-  g_clear_object (&self->actions);
+  /* Plugins */
+  g_clear_pointer (&self->plugins, g_hash_table_unref);
+  g_clear_pointer (&self->actions, g_hash_table_unref);
+  g_clear_pointer (&self->handlers, g_hash_table_unref);
   g_clear_object (&self->menu);
 
   G_OBJECT_CLASS (valent_device_parent_class)->finalize (object);
@@ -741,19 +955,26 @@ valent_device_set_property (GObject      *object,
 static void
 valent_device_init (ValentDevice *self)
 {
+  GSimpleAction *action;
+
   /* Plugins */
   self->engine = valent_get_engine ();
   self->plugins = g_hash_table_new_full (NULL, NULL, NULL, device_plugin_free);
   self->handlers = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-
-  /* GAction/GMenu */
-  self->actions = g_simple_action_group_new ();
+  self->actions = g_hash_table_new_full (g_str_hash,
+                                          g_str_equal,
+                                          g_free,
+                                          g_object_unref);
   self->menu = g_menu_new ();
 
-  g_action_map_add_action_entries (G_ACTION_MAP (self->actions),
-                                   actions,
-                                   G_N_ELEMENTS (actions),
-                                   self);
+  /* Stock Actions */
+  action = g_simple_action_new ("pair", NULL);
+  g_signal_connect (action, "activate", G_CALLBACK (pair_action), self);
+  g_hash_table_replace (self->actions, g_strdup ("pair"), action);
+
+  action = g_simple_action_new ("unpair", NULL);
+  g_signal_connect (action, "activate", G_CALLBACK (unpair_action), self);
+  g_hash_table_replace (self->actions, g_strdup ("unpair"), action);
 }
 
 static void
@@ -768,12 +989,13 @@ valent_device_class_init (ValentDeviceClass *klass)
   object_class->set_property = valent_device_set_property;
 
   /**
-   * ValentDevice:connected:
+   * ValentDevice:connected: (getter get_connected)
    *
-   * The "connected" property indicates whether the device is connected or not.
-   * This means an active connection that has been authenticated as being from
-   * the correct device, identities exchanged, encrypted and any other steps
-   * appropriate for the connection type.
+   * Whether the device is connected.
+   *
+   * This property indicates whether the device has an active
+   * [class@Valent.Channel] that has been authenticated. It does not imply the
+   * the device has been paired, however.
    */
   properties [PROP_CONNECTED] =
     g_param_spec_boolean ("connected",
@@ -785,9 +1007,12 @@ valent_device_class_init (ValentDeviceClass *klass)
                            G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:data:
+   * ValentDevice:data: (getter ref_data)
    *
-   * The "data" property is the #ValentData for the device.
+   * The data context for the device.
+   *
+   * This provides a relative point for files and settings, specific to the
+   * device in question.
    */
   properties [PROP_DATA] =
     g_param_spec_object ("data",
@@ -800,9 +1025,11 @@ valent_device_class_init (ValentDeviceClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:icon-name:
+   * ValentDevice:icon-name: (getter get_icon_name)
    *
-   * An icon name string for the device type.
+   * A symbolic icon name for the device.
+   *
+   * See [property@Valent.Device:type].
    */
   properties [PROP_ICON_NAME] =
     g_param_spec_string ("icon-name",
@@ -814,9 +1041,13 @@ valent_device_class_init (ValentDeviceClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:id:
+   * ValentDevice:id: (getter get_id)
    *
-   * A unique string for the device, usually the hostname.
+   * A unique ID for the device.
+   *
+   * By convention, the single source of truth for a device ID in KDE Connect is
+   * the common name of its TLS certificate. It is not well-defined how this ID
+   * is generated, however.
    */
   properties [PROP_ID] =
     g_param_spec_string ("id",
@@ -828,9 +1059,9 @@ valent_device_class_init (ValentDeviceClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:name:
+   * ValentDevice:name: (getter get_name)
    *
-   * The user-visible label for the device.
+   * A display name for the device.
    */
   properties [PROP_NAME] =
     g_param_spec_string ("name",
@@ -842,10 +1073,13 @@ valent_device_class_init (ValentDeviceClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:paired:
+   * ValentDevice:paired: (getter get_paired)
    *
-   * Whether the device is paired with regard to the KDE Connect protocol,
-   * regardless of the underlying transport protocol (eg. Bluetooth).
+   * Whether the device is paired.
+   *
+   * This property indicates whether the device is paired with respect to the
+   * KDE Connect protocol and may be unrelated to the underlying transport
+   * protocol (eg. Bluetooth).
    */
   properties [PROP_PAIRED] =
     g_param_spec_boolean ("paired",
@@ -857,9 +1091,13 @@ valent_device_class_init (ValentDeviceClass *klass)
                            G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:state:
+   * ValentDevice:state: (getter get_state)
    *
    * The state of the device.
+   *
+   * This property provides more granular information about the device state
+   * than the [property@Valent.Device:connected] or
+   * [property@Valent.Device:paired] properties.
    */
   properties [PROP_STATE] =
     g_param_spec_flags ("state",
@@ -874,12 +1112,12 @@ valent_device_class_init (ValentDeviceClass *klass)
   /**
    * ValentDevice:type:
    *
-   * A string hint, roughly describing the type of the device. It's generally
-   * only useful for things like selecting an icon since the device will
-   * describe its true capabilities by other means.
+   * A string hint, indicating the form-factor of the device.
    *
-   * The current possible values include `desktop`, `laptop`, `smartphone`,
-   * `tablet` and `tv`.
+   * Known values include `desktop`, `laptop`, `smartphone`, `tablet` and `tv`.
+   *
+   * This is generally only useful for things like selecting an icon, since the
+   * device will describe its capabilities by other means.
    */
   properties [PROP_TYPE] =
     g_param_spec_string ("type",
@@ -894,16 +1132,14 @@ valent_device_class_init (ValentDeviceClass *klass)
 
   /**
    * ValentDevice::plugin-added:
-   * @device: an #ValentDevice
-   * @info: an #PeasPluginInfo
+   * @device: a #ValentDevice
+   * @plugin_info: a #PeasPluginInfo
    *
-   * The "plugin-added" signal is emitted when a supported plugin implementing
-   * the #ValentDevicePlugin interface has been loaded by the #PeasEngine.
+   * Emitted when a supported plugin has been loaded by the device.
    *
-   * Alternatively, it may be emitted if @device sends an identity packet
-   * indicating that the plugin's capabilities are now supported. This may
-   * happen if the connection type changes, such as a Bluetooth connection where
-   * SFTP is not supported being replaced with a TCP connection.
+   * This could be a result of the [class@Peas.Engine] loading a plugin that
+   * provides a [class@Valent.DevicePlugin] extension or the device receiving an
+   * identity packet indicating the capabilities of the device have changed.
    */
   signals [PLUGIN_ADDED] =
     g_signal_new ("plugin-added",
@@ -919,14 +1155,14 @@ valent_device_class_init (ValentDeviceClass *klass)
 
   /**
    * ValentDevice::plugin-removed:
-   * @device: an #ValentDevice
-   * @info: an #PeasPluginInfo
+   * @device: a #ValentDevice
+   * @plugin_info: a #PeasPluginInfo
    *
-   * The "plugin-removed" signal is emitted when a supported plugin implementing
-   * the #ValentDevicePlugin interface has been unloaded from the #PeasEngine.
+   * Emitted when a supported plugin has been unloaded by the device.
    *
-   * Alternatively, it may be emitted if @device sends an identity packet
-   * indicating that the plugin's capabilities are not supported.
+   * This could be a result of the [class@Peas.Engine] unloading a plugin that
+   * provided a [class@Valent.DevicePlugin] extension or the device receiving an
+   * identity packet indicating the capabilities of the device have changed.
    */
   signals [PLUGIN_REMOVED] =
     g_signal_new ("plugin-removed",
@@ -943,7 +1179,7 @@ valent_device_class_init (ValentDeviceClass *klass)
 
 /**
  * valent_device_new:
- * @identity: a KDE Connect identity
+ * @identity: a KDE Connect identity packet
  *
  * Construct a new device for @identity.
  *
@@ -973,7 +1209,7 @@ valent_device_new (JsonNode *identity)
 
 /**
  * valent_device_new_full:
- * @identity: a KDE Connect identity
+ * @identity: a KDE Connect identity packet
  * @data: (nullable): the data context
  *
  * Construct a new device for @identity.
@@ -1005,9 +1241,9 @@ valent_device_new_full (JsonNode   *identity,
 }
 
 static void
-queue_packet_cb (ValentChannel *channel,
-                 GAsyncResult  *result,
-                 ValentDevice  *device)
+valent_device_queue_packet_cb (ValentChannel *channel,
+                               GAsyncResult  *result,
+                               ValentDevice  *device)
 {
   g_autoptr (GError) error = NULL;
 
@@ -1030,10 +1266,15 @@ queue_packet_cb (ValentChannel *channel,
 /**
  * valent_device_queue_packet:
  * @device: a #ValentDevice
- * @packet: a #JsonNode packet
+ * @packet: a KDE Connect packet
  *
- * Push @packet onto the outgoing packet queue for the #ValentChannel of @device.
- * For cancellable or failable packet transfer, see valent_device_send_packet().
+ * Queue a KDE Connect packet to be sent to the device.
+ *
+ * If @device is disconnected or unpaired when this method is called, a warning
+ * or critical will be logged, respectively.
+ *
+ * See [method@Valent.Device.send_packet] for a failable and cancellable variant
+ * of this method.
  */
 void
 valent_device_queue_packet (ValentDevice *device,
@@ -1068,16 +1309,16 @@ valent_device_queue_packet (ValentDevice *device,
   valent_channel_write_packet (device->channel,
                                packet,
                                NULL,
-                               (GAsyncReadyCallback)queue_packet_cb,
+                               (GAsyncReadyCallback)valent_device_queue_packet_cb,
                                g_object_ref (device));
 
   valent_object_unlock (VALENT_OBJECT (device));
 }
 
 static void
-send_packet_cb (ValentChannel *channel,
-                GAsyncResult  *result,
-                gpointer       user_data)
+valent_device_send_packet_cb (ValentChannel *channel,
+                              GAsyncResult  *result,
+                              gpointer       user_data)
 {
   g_autoptr (GTask) task = G_TASK (user_data);
   ValentDevice *device = g_task_get_source_object (task);
@@ -1105,13 +1346,18 @@ send_packet_cb (ValentChannel *channel,
 /**
  * valent_device_send_packet:
  * @device: a #ValentDevice
- * @packet: a #JsonNode packet
+ * @packet: a KDE Connect packet
  * @cancellable: (nullable): a #GCancellable
  * @callback: (scope async): a #GAsyncReadyCallback
  * @user_data: (closure): user supplied data
  *
- * Send @packet over the current packet channel. Call
- * valent_device_send_packet_finish() to get the result.
+ * Send a KDE Connect packet to the device.
+ *
+ * Call [method@Valent.Device.send_packet_finish] to get the result.
+ *
+ * If @device is disconnected or unpaired when this method is called,
+ * %G_IO_ERROR_NOT_CONNECTED or %G_IO_ERROR_PERMISSION_DENIED will be set on the
+ * result, respectively.
  */
 void
 valent_device_send_packet (ValentDevice        *device,
@@ -1158,7 +1404,7 @@ valent_device_send_packet (ValentDevice        *device,
   valent_channel_write_packet (device->channel,
                                packet,
                                cancellable,
-                               (GAsyncReadyCallback)send_packet_cb,
+                               (GAsyncReadyCallback)valent_device_send_packet_cb,
                                g_steal_pointer (&task));
 
   valent_object_unlock (VALENT_OBJECT (device));
@@ -1170,7 +1416,7 @@ valent_device_send_packet (ValentDevice        *device,
  * @result: a #GAsyncResult
  * @error: (nullable): a #GError
  *
- * Finish an operation started with valent_device_send_packet().
+ * Finish an operation started with [method@Valent.Device.send_packet].
  *
  * Returns: %TRUE if successful, or %FALSE with @error set
  */
@@ -1187,82 +1433,10 @@ valent_device_send_packet_finish (ValentDevice  *device,
 }
 
 /**
- * valent_device_show_notification:
- * @device: a #ValentDevice
- * @id: an id for the notification
- * @notification: a #GNotification
- *
- * A simple convenience function for showing a local #GNotification with @id
- * prepended with the device id, to allow ostensibly the same notification for a
- * specific device to be shown.
- */
-void
-valent_device_show_notification (ValentDevice  *device,
-                                 const char    *id,
-                                 GNotification *notification)
-{
-  GApplication *application = g_application_get_default ();
-  g_autofree char *notification_id = NULL;
-
-  g_return_if_fail (VALENT_IS_DEVICE (device));
-  g_return_if_fail (id != NULL);
-  g_return_if_fail (G_IS_NOTIFICATION (notification));
-
-  if G_UNLIKELY (application == NULL)
-    return;
-
-  /* Prefix the GNotification Id with the deviceId */
-  notification_id = g_strdup_printf ("%s|%s", device->id, id);
-  g_application_send_notification (application, notification_id, notification);
-}
-
-/**
- * valent_device_hide_notification:
- * @device: a #ValentDevice
- * @id: an id for the notification
- *
- * A simple convenience function for hiding a local #GNotification with @id
- * prepended with the device id, to allow ostensibly the same notification for a
- * specific device to be hidden.
- */
-void
-valent_device_hide_notification (ValentDevice *device,
-                                 const char   *id)
-{
-  GApplication *application = g_application_get_default ();
-  g_autofree char *notification_id = NULL;
-
-  g_return_if_fail (VALENT_IS_DEVICE (device));
-  g_return_if_fail (id != NULL);
-
-  if G_UNLIKELY (application == NULL)
-    return;
-
-  notification_id = g_strdup_printf ("%s|%s", device->id, id);
-  g_application_withdraw_notification (application, notification_id);
-}
-
-/**
- * valent_device_get_actions:
- * @device: a #ValentDevice
- *
- * Get the action group for the device.
- *
- * Returns: (transfer none): the #GActionGroup
- */
-GActionGroup *
-valent_device_get_actions (ValentDevice *device)
-{
-  g_return_val_if_fail (VALENT_IS_DEVICE (device), NULL);
-
-  return G_ACTION_GROUP (device->actions);
-}
-
-/**
  * valent_device_ref_channel:
  * @device: a #ValentDevice
  *
- * Get the device #ValentChannel if connected, or %NULL if disconnected.
+ * Get the active packet exchange channel, or %NULL if disconnected.
  *
  * Returns: (transfer full) (nullable): a #ValentChannel
  */
@@ -1324,7 +1498,7 @@ read_packet_cb (ValentChannel *channel,
  * @device: A #ValentDevice
  * @channel: (nullable): A #ValentChannel
  *
- * Sets the active packet exchange channel for @device to @channel.
+ * Sets the active packet exchange channel to @channel.
  */
 void
 valent_device_set_channel (ValentDevice  *device,
@@ -1380,10 +1554,10 @@ valent_device_set_channel (ValentDevice  *device,
 }
 
 /**
- * valent_device_get_connected:
+ * valent_device_get_connected: (get-property connected)
  * @device: a #ValentDevice
  *
- * Whether the device is connected.
+ * Get whether the device is connected.
  *
  * Returns: %TRUE if the device has an active connection.
  */
@@ -1402,10 +1576,10 @@ valent_device_get_connected (ValentDevice *device)
 }
 
 /**
- * valent_device_ref_data:
+ * valent_device_ref_data: (get-property data)
  * @device: a #ValentDevice
  *
- * Gets the #ValentData for @device.
+ * Get the data context for the device.
  *
  * Returns: (transfer full): a #ValentData
  */
@@ -1425,10 +1599,10 @@ valent_device_ref_data (ValentDevice *device)
 }
 
 /**
- * valent_device_get_icon_name:
+ * valent_device_get_icon_name: (get-property icon-name)
  * @device: a #ValentDevice
  *
- * Gets the symbolic icon name of the device.
+ * Get the symbolic icon name of the device.
  *
  * Returns: (transfer none): the icon name.
  */
@@ -1441,10 +1615,10 @@ valent_device_get_icon_name (ValentDevice *device)
 }
 
 /**
- * valent_device_get_id:
+ * valent_device_get_id: (get-property id)
  * @device: a #ValentDevice
  *
- * Gets the unique id of the device.
+ * Get the unique ID of the device.
  *
  * Returns: (transfer none): the device id.
  */
@@ -1461,9 +1635,10 @@ valent_device_get_id (ValentDevice *device)
  * valent_device_get_menu:
  * @device: a #ValentDevice
  *
- * Get the #GMenuModel for @device. Plugins may add items and submenus to this
- * when they want to expose actions with presentation details like a label or
- * icon.
+ * Get the [class@Gio.MenuModel] of the device.
+ *
+ * Plugins may add items and submenus to this when they want to expose actions
+ * with presentation details like a label or icon.
  *
  * Returns: (transfer none): a #GMenuModel
  */
@@ -1479,9 +1654,9 @@ valent_device_get_menu (ValentDevice *device)
  * valent_device_get_name:
  * @device: a #ValentDevice
  *
- * Gets the name of the device, or %NULL if unset.
+ * Get the display name of the device.
  *
- * Returns: (transfer none) (nullable): the name, or %NULL.
+ * Returns: (transfer none) (nullable): a display name, or %NULL if unset.
  */
 const char *
 valent_device_get_name (ValentDevice *device)
@@ -1492,10 +1667,10 @@ valent_device_get_name (ValentDevice *device)
 }
 
 /**
- * valent_device_get_paired:
+ * valent_device_get_paired: (get-property paired)
  * @device: a #ValentDevice
  *
- * Whether the device is paired.
+ * Get whether the device is paired.
  *
  * Returns: %TRUE if the device is paired.
  */
@@ -1514,11 +1689,11 @@ valent_device_get_paired (ValentDevice *device)
 }
 
 /**
- * valent_device_set_paired:
+ * valent_device_set_paired: (set-property paired)
  * @device: a #ValentDevice
  * @paired: boolean
  *
- * Set the paired state for @device.
+ * Set the paired state of the device.
  *
  * NOTE: since valent_device_update_plugins() will be called as a side effect,
  * this must be called after valent_device_send_pair().
@@ -1561,7 +1736,7 @@ valent_device_set_paired (ValentDevice *device,
  * valent_device_get_plugins:
  * @device: a #ValentDevice
  *
- * Get a list of the loaded plugins for @device.
+ * Get a list of the loaded plugins.
  *
  * Returns: (transfer container) (element-type Peas.PluginInfo): a #GPtrArray
  */
@@ -1585,7 +1760,7 @@ valent_device_get_plugins (ValentDevice *device)
 }
 
 /**
- * valent_device_get_state:
+ * valent_device_get_state: (get-property state)
  * @device: a #ValentDevice
  *
  * Get the state of the device.
@@ -1663,12 +1838,10 @@ valent_device_handle_packet (ValentDevice *device,
  * @filename: (type filename): a filename
  * @unique: whether to ensure a unique file
  *
- * Get a new #GFile for @filename in the download directory for @ device. If
- * @unique is %TRUE, the returned file is guaranteed not to be an existing
- * filename by appending `(#)`.
+ * Get a new [class@Gio.File] for in the download directory of the device.
  *
- * As a side-effect, this method will try to ensure the directory exists before
- * returning.
+ * If @unique is %TRUE, the returned file is guaranteed not to be an existing
+ * filename by appending `(#)`.
  *
  * Returns: (transfer full) (nullable): a #GFile
  */

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -19,7 +19,6 @@
 #include "valent-macros.h"
 #include "valent-object.h"
 #include "valent-packet.h"
-#include "valent-transfer.h"
 #include "valent-utils.h"
 
 #define PAIR_REQUEST_ID      "pair-request"

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -48,8 +48,6 @@ VALENT_AVAILABLE_IN_1_0
 ValentDevice      * valent_device_new_full           (JsonNode             *identity,
                                                       ValentData           *data);
 VALENT_AVAILABLE_IN_1_0
-GActionGroup      * valent_device_get_actions        (ValentDevice         *device);
-VALENT_AVAILABLE_IN_1_0
 ValentChannel     * valent_device_ref_channel        (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
 ValentData        * valent_device_ref_data           (ValentDevice         *device);
@@ -82,13 +80,6 @@ VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_send_packet_finish (ValentDevice         *device,
                                                       GAsyncResult         *result,
                                                       GError              **error);
-VALENT_AVAILABLE_IN_1_0
-void                valent_device_hide_notification  (ValentDevice         *device,
-                                                      const char           *id);
-VALENT_AVAILABLE_IN_1_0
-void                valent_device_show_notification  (ValentDevice         *device,
-                                                      const char           *id,
-                                                      GNotification        *notification);
 VALENT_AVAILABLE_IN_1_0
 GFile             * valent_device_new_download_file  (ValentDevice         *device,
                                                       const char           *filename,

--- a/src/libvalent/ui/valent-application.c
+++ b/src/libvalent/ui/valent-application.c
@@ -81,12 +81,7 @@ device_action (GSimpleAction *action,
   device = valent_device_manager_get_device (self->manager, device_id);
 
   if (device != NULL)
-    {
-      GActionGroup *actions;
-
-      actions = valent_device_get_actions (device);
-      g_action_group_activate_action (actions, name, target);
-    }
+    g_action_group_activate_action (G_ACTION_GROUP (device), name, target);
 }
 
 static void

--- a/src/libvalent/ui/valent-device-panel.c
+++ b/src/libvalent/ui/valent-device-panel.c
@@ -305,7 +305,6 @@ valent_device_panel_constructed (GObject *object)
   ValentDevicePanel *self = VALENT_DEVICE_PANEL (object);
   g_autofree char *path = NULL;
   g_autoptr (GPtrArray) plugins = NULL;
-  GActionGroup *actions;
   GMenuModel *menu;
 
   g_object_bind_property (self->device,
@@ -315,8 +314,9 @@ valent_device_panel_constructed (GObject *object)
                           G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE);
 
   /* Actions & Menu */
-  actions = valent_device_get_actions (self->device);
-  gtk_widget_insert_action_group (GTK_WIDGET (self), "device", actions);
+  gtk_widget_insert_action_group (GTK_WIDGET (self),
+                                  "device",
+                                  G_ACTION_GROUP (self->device));
 
   menu = valent_device_get_menu (self->device);
   valent_menu_stack_set_menu_model (self->menu_actions, menu);

--- a/src/plugins/battery/valent-battery-plugin.h
+++ b/src/plugins/battery/valent-battery-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_BATTERY_PLUGIN (valent_battery_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentBatteryPlugin, valent_battery_plugin, VALENT, BATTERY_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentBatteryPlugin, valent_battery_plugin, VALENT, BATTERY_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/clipboard/valent-clipboard-plugin.h
+++ b/src/plugins/clipboard/valent-clipboard-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CLIPBOARD_PLUGIN (valent_clipboard_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentClipboardPlugin, valent_clipboard_plugin, VALENT, CLIPBOARD_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentClipboardPlugin, valent_clipboard_plugin, VALENT, CLIPBOARD_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/contacts/valent-contacts-plugin.h
+++ b/src/plugins/contacts/valent-contacts-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CONTACTS_PLUGIN (valent_contacts_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentContactsPlugin, valent_contacts_plugin, VALENT, CONTACTS_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentContactsPlugin, valent_contacts_plugin, VALENT, CONTACTS_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/findmyphone/valent-findmyphone-plugin.h
+++ b/src/plugins/findmyphone/valent-findmyphone-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_FINDMYPHONE_PLUGIN (valent_findmyphone_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentFindmyphonePlugin, valent_findmyphone_plugin, VALENT, FINDMYPHONE_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentFindmyphonePlugin, valent_findmyphone_plugin, VALENT, FINDMYPHONE_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/lock/valent-lock-plugin.h
+++ b/src/plugins/lock/valent-lock-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_LOCK_PLUGIN (valent_lock_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentLockPlugin, valent_lock_plugin, VALENT, LOCK_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentLockPlugin, valent_lock_plugin, VALENT, LOCK_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/mousepad/valent-mousepad-plugin.h
+++ b/src/plugins/mousepad/valent-mousepad-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_MOUSEPAD_PLUGIN (valent_mousepad_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentMousepadPlugin, valent_mousepad_plugin, VALENT, MOUSEPAD_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentMousepadPlugin, valent_mousepad_plugin, VALENT, MOUSEPAD_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/mpris/valent-mpris-plugin.h
+++ b/src/plugins/mpris/valent-mpris-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_MPRIS_PLUGIN (valent_mpris_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentMprisPlugin, valent_mpris_plugin, VALENT, MPRIS_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentMprisPlugin, valent_mpris_plugin, VALENT, MPRIS_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/notification/valent-notification-plugin.h
+++ b/src/plugins/notification/valent-notification-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_NOTIFICATION_PLUGIN (valent_notification_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentNotificationPlugin, valent_notification_plugin, VALENT, NOTIFICATION_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentNotificationPlugin, valent_notification_plugin, VALENT, NOTIFICATION_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -14,21 +14,10 @@
 
 struct _ValentPhotoPlugin
 {
-  PeasExtensionBase  parent_instance;
-
-  ValentDevice      *device;
+  ValentDevicePlugin  parent_instance;
 };
 
-static void valent_device_plugin_iface_init (ValentDevicePluginInterface *iface);
-
-G_DEFINE_TYPE_WITH_CODE (ValentPhotoPlugin, valent_photo_plugin, PEAS_TYPE_EXTENSION_BASE,
-                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_PLUGIN, valent_device_plugin_iface_init))
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
+G_DEFINE_TYPE (ValentPhotoPlugin, valent_photo_plugin, VALENT_TYPE_DEVICE_PLUGIN)
 
 
 /**
@@ -58,20 +47,24 @@ transfer_cb (ValentTransfer    *transfer,
       g_autoptr (GIcon) icon = NULL;
       g_autofree char *body = NULL;
       g_autofree char *filename = NULL;
+      ValentDevice *device;
 
       g_warning ("Transfer failed: %s", error->message);
 
+      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
       filename = g_file_get_basename (op->file);
       icon = g_themed_icon_new ("dialog-error-symbolic");
       body = g_strdup_printf (_("Failed to receive “%s” from %s"),
                               filename,
-                              valent_device_get_name (self->device));
+                              valent_device_get_name (device));
 
       notification = g_notification_new (_("Transfer Failed"));
       g_notification_set_body (notification, body);
       g_notification_set_icon (notification, icon);
 
-      valent_device_show_notification (self->device, "photo", notification);
+      valent_device_plugin_show_notification (VALENT_DEVICE_PLUGIN (self),
+                                              "photo",
+                                              notification);
     }
 
   g_clear_object (&op->plugin);
@@ -84,6 +77,7 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
                                   JsonNode          *packet)
 {
   g_autoptr (ValentTransfer) transfer = NULL;
+  ValentDevice *device;
   DownloadOperation *op;
   const char *filename;
 
@@ -103,12 +97,14 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
       return;
     }
 
+  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+
   op = g_new0 (DownloadOperation, 1);
   op->plugin = g_object_ref (self);
-  op->file = valent_device_new_download_file (self->device, filename, TRUE);
+  op->file = valent_device_new_download_file (device, filename, TRUE);
 
   /* Create a new transfer */
-  transfer = valent_transfer_new (self->device);
+  transfer = valent_transfer_new (device);
   valent_transfer_add_file (transfer, packet, op->file);
   valent_transfer_execute (transfer,
                            NULL,
@@ -143,7 +139,7 @@ photo_action (GSimpleAction *action,
   builder = valent_packet_start ("kdeconnect.photo.request");
   packet = valent_packet_finish (builder);
 
-  valent_device_queue_packet (self->device, packet);
+  valent_device_plugin_queue_packet (VALENT_DEVICE_PLUGIN (self), packet);
 }
 
 static const GActionEntry actions[] = {
@@ -151,7 +147,7 @@ static const GActionEntry actions[] = {
 };
 
 static const ValentMenuEntry items[] = {
-    {N_("Take Photo"), "device.photo", "camera-photo-symbolic"}
+    {N_("Take Photo"), "device.photo.photo", "camera-photo-symbolic"}
 };
 
 /*
@@ -162,9 +158,10 @@ valent_photo_plugin_enable (ValentDevicePlugin *plugin)
 {
   g_assert (VALENT_IS_PHOTO_PLUGIN (plugin));
 
-  valent_device_plugin_register_actions (plugin,
-                                         actions,
-                                         G_N_ELEMENTS (actions));
+  g_action_map_add_action_entries (G_ACTION_MAP (plugin),
+                                   actions,
+                                   G_N_ELEMENTS (actions),
+                                   plugin);
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -178,9 +175,6 @@ valent_photo_plugin_disable (ValentDevicePlugin *plugin)
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-  valent_device_plugin_unregister_actions (plugin,
-                                           actions,
-                                           G_N_ELEMENTS (actions));
 }
 
 static void
@@ -194,10 +188,7 @@ valent_photo_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin,
-                                       actions,
-                                       G_N_ELEMENTS (actions),
-                                       available);
+  valent_device_plugin_toggle_actions (plugin, available);
 }
 
 static void
@@ -221,65 +212,18 @@ valent_photo_plugin_handle_packet (ValentDevicePlugin *plugin,
     g_assert_not_reached ();
 }
 
-static void
-valent_device_plugin_iface_init (ValentDevicePluginInterface *iface)
-{
-  iface->enable = valent_photo_plugin_enable;
-  iface->disable = valent_photo_plugin_disable;
-  iface->handle_packet = valent_photo_plugin_handle_packet;
-  iface->update_state = valent_photo_plugin_update_state;
-}
-
-/**
+/*
  * GObject
  */
 static void
-valent_photo_plugin_get_property (GObject    *object,
-                                  guint       prop_id,
-                                  GValue     *value,
-                                  GParamSpec *pspec)
-{
-  ValentPhotoPlugin *self = VALENT_PHOTO_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_photo_plugin_set_property (GObject      *object,
-                                  guint         prop_id,
-                                  const GValue *value,
-                                  GParamSpec   *pspec)
-{
-  ValentPhotoPlugin *self = VALENT_PHOTO_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_photo_plugin_class_init (ValentPhotoPluginClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
-  object_class->get_property = valent_photo_plugin_get_property;
-  object_class->set_property = valent_photo_plugin_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
+  plugin_class->enable = valent_photo_plugin_enable;
+  plugin_class->disable = valent_photo_plugin_disable;
+  plugin_class->handle_packet = valent_photo_plugin_handle_packet;
+  plugin_class->update_state = valent_photo_plugin_update_state;
 }
 
 static void

--- a/src/plugins/photo/valent-photo-plugin.h
+++ b/src/plugins/photo/valent-photo-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_PHOTO_PLUGIN (valent_photo_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentPhotoPlugin, valent_photo_plugin, VALENT, PHOTO_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentPhotoPlugin, valent_photo_plugin, VALENT, PHOTO_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -14,21 +14,10 @@
 
 struct _ValentPingPlugin
 {
-  PeasExtensionBase  parent_instance;
-
-  ValentDevice      *device;
+  ValentDevicePlugin  parent_instance;
 };
 
-static void valent_device_plugin_iface_init (ValentDevicePluginInterface *iface);
-
-G_DEFINE_TYPE_WITH_CODE (ValentPingPlugin, valent_ping_plugin, PEAS_TYPE_EXTENSION_BASE,
-                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_PLUGIN, valent_device_plugin_iface_init))
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
+G_DEFINE_TYPE (ValentPingPlugin, valent_ping_plugin, VALENT_TYPE_DEVICE_PLUGIN)
 
 
 static void
@@ -37,6 +26,7 @@ valent_ping_plugin_handle_ping (ValentPingPlugin *self,
 {
   g_autoptr (GNotification) notification = NULL;
   const char *message;
+  ValentDevice *device;
 
   g_assert (VALENT_IS_PING_PLUGIN (self));
   g_assert (VALENT_IS_PACKET (packet));
@@ -46,9 +36,12 @@ valent_ping_plugin_handle_ping (ValentPingPlugin *self,
     message = _("Ping!");
 
   /* Show a notification */
-  notification = g_notification_new (valent_device_get_name (self->device));
+  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  notification = g_notification_new (valent_device_get_name (device));
   g_notification_set_body (notification, message);
-  valent_device_show_notification (self->device, "ping", notification);
+  valent_device_plugin_show_notification (VALENT_DEVICE_PLUGIN (self),
+                                          "ping",
+                                          notification);
 }
 
 static void
@@ -70,7 +63,7 @@ valent_ping_plugin_send_ping (ValentPingPlugin *self,
 
   packet = valent_packet_finish (builder);
 
-  valent_device_queue_packet (self->device, packet);
+  valent_device_plugin_queue_packet (VALENT_DEVICE_PLUGIN (self), packet);
 }
 
 /*
@@ -93,12 +86,12 @@ ping_action (GSimpleAction *action,
 }
 
 static const GActionEntry actions[] = {
-    {"ping",         ping_action, NULL, NULL, NULL},
-    {"ping-message", ping_action, "s",  NULL, NULL}
+    {"ping",    ping_action, NULL, NULL, NULL},
+    {"message", ping_action, "s",  NULL, NULL}
 };
 
 static const ValentMenuEntry items[] = {
-    {N_("Ping"), "device.ping", "dialog-information-symbolic"}
+    {N_("Ping"), "device.ping.ping", "dialog-information-symbolic"}
 };
 
 /**
@@ -107,9 +100,10 @@ static const ValentMenuEntry items[] = {
 static void
 valent_ping_plugin_enable (ValentDevicePlugin *plugin)
 {
-  valent_device_plugin_register_actions (plugin,
-                                         actions,
-                                         G_N_ELEMENTS (actions));
+  g_action_map_add_action_entries (G_ACTION_MAP (plugin),
+                                   actions,
+                                   G_N_ELEMENTS (actions),
+                                   plugin);
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -121,9 +115,6 @@ valent_ping_plugin_disable (ValentDevicePlugin *plugin)
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-  valent_device_plugin_unregister_actions (plugin,
-                                           actions,
-                                           G_N_ELEMENTS (actions));
 }
 
 static void
@@ -137,10 +128,7 @@ valent_ping_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin,
-                                       actions,
-                                       G_N_ELEMENTS (actions),
-                                       available);
+  valent_device_plugin_toggle_actions (plugin, available);
 }
 
 static void
@@ -160,65 +148,18 @@ valent_ping_plugin_handle_packet (ValentDevicePlugin *plugin,
     g_assert_not_reached ();
 }
 
-static void
-valent_device_plugin_iface_init (ValentDevicePluginInterface *iface)
-{
-  iface->enable = valent_ping_plugin_enable;
-  iface->disable = valent_ping_plugin_disable;
-  iface->handle_packet = valent_ping_plugin_handle_packet;
-  iface->update_state = valent_ping_plugin_update_state;
-}
-
 /*
  * GObject
  */
 static void
-valent_ping_plugin_get_property (GObject    *object,
-                                 guint       prop_id,
-                                 GValue     *value,
-                                 GParamSpec *pspec)
-{
-  ValentPingPlugin *self = VALENT_PING_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_ping_plugin_set_property (GObject      *object,
-                                 guint         prop_id,
-                                 const GValue *value,
-                                 GParamSpec   *pspec)
-{
-  ValentPingPlugin *self = VALENT_PING_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_ping_plugin_class_init (ValentPingPluginClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
-  object_class->get_property = valent_ping_plugin_get_property;
-  object_class->set_property = valent_ping_plugin_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
+  plugin_class->enable = valent_ping_plugin_enable;
+  plugin_class->disable = valent_ping_plugin_disable;
+  plugin_class->handle_packet = valent_ping_plugin_handle_packet;
+  plugin_class->update_state = valent_ping_plugin_update_state;
 }
 
 static void

--- a/src/plugins/ping/valent-ping-plugin.h
+++ b/src/plugins/ping/valent-ping-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_PING_PLUGIN (valent_ping_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentPingPlugin, valent_ping_plugin, VALENT, PING_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentPingPlugin, valent_ping_plugin, VALENT, PING_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/runcommand/valent-runcommand-plugin.h
+++ b/src/plugins/runcommand/valent-runcommand-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_RUNCOMMAND_PLUGIN (valent_runcommand_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentRuncommandPlugin, valent_runcommand_plugin, VALENT, RUNCOMMAND_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentRuncommandPlugin, valent_runcommand_plugin, VALENT, RUNCOMMAND_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/sftp/valent-sftp-plugin.h
+++ b/src/plugins/sftp/valent-sftp-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SFTP_PLUGIN (valent_sftp_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentSftpPlugin, valent_sftp_plugin, VALENT, SFTP_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentSftpPlugin, valent_sftp_plugin, VALENT, SFTP_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/share/valent-share-plugin.h
+++ b/src/plugins/share/valent-share-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SHARE_PLUGIN (valent_share_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentSharePlugin, valent_share_plugin, VALENT, SHARE_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentSharePlugin, valent_share_plugin, VALENT, SHARE_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/sms/valent-sms-plugin.h
+++ b/src/plugins/sms/valent-sms-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SMS_PLUGIN (valent_sms_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentSmsPlugin, valent_sms_plugin, VALENT, SMS_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentSmsPlugin, valent_sms_plugin, VALENT, SMS_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.h
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SYSTEMVOLUME_PLUGIN (valent_systemvolume_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentSystemvolumePlugin, valent_systemvolume_plugin, VALENT, SYSTEMVOLUME_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentSystemvolumePlugin, valent_systemvolume_plugin, VALENT, SYSTEMVOLUME_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/plugins/telephony/valent-telephony-plugin.h
+++ b/src/plugins/telephony/valent-telephony-plugin.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_TELEPHONY_PLUGIN (valent_telephony_plugin_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentTelephonyPlugin, valent_telephony_plugin, VALENT, TELEPHONY_PLUGIN, PeasExtensionBase)
+G_DECLARE_FINAL_TYPE (ValentTelephonyPlugin, valent_telephony_plugin, VALENT, TELEPHONY_PLUGIN, ValentDevicePlugin)
 
 G_END_DECLS
 

--- a/src/tests/extra/tsan.supp
+++ b/src/tests/extra/tsan.supp
@@ -16,16 +16,8 @@ race:valent_sms_store_thread
 
 
 #
-# Uninstrumented libraries (core, components, ui, plugins)
+# Uninstrumented libraries (Yes, all of these are really necessary)
 #
-called_from_lib:libglib-2
-called_from_lib:libgobject-2
-called_from_lib:libgio-2
-called_from_lib:libgnutls
-
-called_from_lib:libebackend-1.2
-called_from_lib:libedata-book
-called_from_lib:libedataserver-1.2
 
 # src/plugins/lan/valent-lan-utils.c
 # See: https://gitlab.gnome.org/GNOME/glib-networking/-/issues/89
@@ -37,35 +29,57 @@ called_from_lib:libtasn1
 # See: https://gitlab.gnome.org/GNOME/glib-networking/-/issues/184
 mutex:g_tls_certificate_gnutls_get_type_once
 
+# GTK
+called_from_lib:libadwaita-1
+called_from_lib:libcairo.so
+called_from_lib:libfontconfig
+called_from_lib:libgdk_pixbuf-2
+called_from_lib:libgtk-4
+called_from_lib:libmedia-gstreamer.so
+called_from_lib:libpango-1
+called_from_lib:libpangocairo-1
+called_from_lib:libpangoft2
 
-#
-# Indirect dependencies
-#
-
-# libgvfscommon
-mutex:g_vfs_icon_get_type_once
-
-# libpango-1
-mutex:pango_font_map_get_type_once
-race:pango_fc_font_face_data_equal
-
-# libfontconfig
-race:_FcObjectLookupOtherTypeByName
-race:IA__FcPatternReference.part.0
-
+# EDS Dependencies
+called_from_lib:libebackend-1.2
+called_from_lib:libedata-book
+called_from_lib:libedataserver-1.2
 called_from_lib:libicui18n
 called_from_lib:libicuuc
 called_from_lib:libphonenumber
 called_from_lib:libprotobuf
 called_from_lib:libsqlite3
-called_from_lib:libxcb.so
 
-# Miscellaneous
-deadlock:libEGL.so
-deadlock:libEGL_mesa.so
-mutex:libEGL.so
-mutex:libEGL_mesa.so
-race:libEGL.so
-race:libEGL_mesa.so
+# GLib
+called_from_lib:libglib-2
+called_from_lib:libgobject-2
+called_from_lib:libgio-2
+called_from_lib:libgnutls
+called_from_lib:libgvfscommon
+called_from_lib:libgvfsdbus
+
+# X.org
+called_from_lib:libX11.so
+called_from_lib:libX11-xcb
+called_from_lib:libXau
+called_from_lib:libxcb.so
+called_from_lib:libXcomposite
+called_from_lib:libXcursor
+called_from_lib:libXdamage
+called_from_lib:libXdmcp
+called_from_lib:libXext
+called_from_lib:libXfixes
+called_from_lib:libXi.so
+called_from_lib:libXrandr
+called_from_lib:libXrender
+called_from_lib:libXss
+
+# Graphics Libraries
+deadlock:libEGL
+deadlock:libGLX
+mutex:libEGL
+mutex:libGLX
+race:libEGL
+race:libGLX
 race:radeonsi_dri
 

--- a/src/tests/fixtures/packetless-plugin.c
+++ b/src/tests/fixtures/packetless-plugin.c
@@ -9,22 +9,10 @@
 
 struct _ValentPacketlessPlugin
 {
-  PeasExtensionBase  parent_instance;
-
-  ValentDevice      *device;
+  ValentDevicePlugin  parent_instance;
 };
 
-static void valent_device_plugin_iface_init (ValentDevicePluginInterface *iface);
-
-G_DEFINE_DYNAMIC_TYPE_EXTENDED (ValentPacketlessPlugin, valent_packetless_plugin, PEAS_TYPE_EXTENSION_BASE,
-                                0,
-                                G_IMPLEMENT_INTERFACE_DYNAMIC (VALENT_TYPE_DEVICE_PLUGIN, valent_device_plugin_iface_init));
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
+G_DEFINE_DYNAMIC_TYPE (ValentPacketlessPlugin, valent_packetless_plugin, VALENT_TYPE_DEVICE_PLUGIN)
 
 
 /*
@@ -38,11 +26,11 @@ packetless_action (GSimpleAction *action,
 }
 
 static const GActionEntry actions[] = {
-    {"packetless", packetless_action, NULL, NULL, NULL}
+    {"action", packetless_action, NULL, NULL, NULL}
 };
 
 static const ValentMenuEntry items[] = {
-    {"Packetless Action", "device.packetless", "dialog-information-symbolic"}
+    {"Packetless Action", "device.packetless.action", "dialog-information-symbolic"}
 };
 
 /*
@@ -53,10 +41,10 @@ valent_packetless_plugin_enable (ValentDevicePlugin *plugin)
 {
   g_assert (VALENT_IS_PACKETLESS_PLUGIN (plugin));
 
-  valent_device_plugin_register_actions (plugin,
-                                         actions,
-                                         G_N_ELEMENTS (actions));
-
+  g_action_map_add_action_entries (G_ACTION_MAP (plugin),
+                                   actions,
+                                   G_N_ELEMENTS (actions),
+                                   plugin);
   valent_device_plugin_add_menu_entries (plugin,
                                          items,
                                          G_N_ELEMENTS (items));
@@ -70,34 +58,6 @@ valent_packetless_plugin_disable (ValentDevicePlugin *plugin)
   valent_device_plugin_remove_menu_entries (plugin,
                                             items,
                                             G_N_ELEMENTS (items));
-  valent_device_plugin_unregister_actions (plugin,
-                                           actions,
-                                           G_N_ELEMENTS (actions));
-}
-
-static void
-valent_packetless_plugin_update_state (ValentDevicePlugin *plugin,
-                                       ValentDeviceState   state)
-{
-  gboolean available;
-
-  g_assert (VALENT_IS_PACKETLESS_PLUGIN (plugin));
-
-  available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
-              (state & VALENT_DEVICE_STATE_PAIRED) != 0;
-
-  valent_device_plugin_toggle_actions (plugin,
-                                       actions,
-                                       G_N_ELEMENTS (actions),
-                                       available);
-}
-
-static void
-valent_device_plugin_iface_init (ValentDevicePluginInterface *iface)
-{
-  iface->enable = valent_packetless_plugin_enable;
-  iface->disable = valent_packetless_plugin_disable;
-  iface->update_state = valent_packetless_plugin_update_state;
 }
 
 /*
@@ -109,52 +69,12 @@ valent_packetless_plugin_class_finalize (ValentPacketlessPluginClass *klass)
 }
 
 static void
-valent_packetless_plugin_get_property (GObject    *object,
-                                       guint       prop_id,
-                                       GValue     *value,
-                                       GParamSpec *pspec)
-{
-  ValentPacketlessPlugin *self = VALENT_PACKETLESS_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_packetless_plugin_set_property (GObject      *object,
-                                       guint         prop_id,
-                                       const GValue *value,
-                                       GParamSpec   *pspec)
-{
-  ValentPacketlessPlugin *self = VALENT_PACKETLESS_PLUGIN (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_packetless_plugin_class_init (ValentPacketlessPluginClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
-  object_class->get_property = valent_packetless_plugin_get_property;
-  object_class->set_property = valent_packetless_plugin_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
+  plugin_class->enable = valent_packetless_plugin_enable;
+  plugin_class->disable = valent_packetless_plugin_disable;
 }
 
 static void

--- a/src/tests/fixtures/valent-test-plugin-fixture.h
+++ b/src/tests/fixtures/valent-test-plugin-fixture.h
@@ -25,47 +25,49 @@ typedef struct
   GDestroyNotify  data_free;
 } ValentTestPluginFixture;
 
-GType          valent_test_plugin_fixture_get_type      (void) G_GNUC_CONST;
 
-void           valent_test_plugin_fixture_init          (ValentTestPluginFixture  *fixture,
-                                                         gconstpointer             user_data);
-void           valent_test_plugin_fixture_clear         (ValentTestPluginFixture  *fixture,
-                                                         gconstpointer             user_data);
+GType                     valent_test_plugin_fixture_get_type      (void) G_GNUC_CONST;
 
-void           valent_test_plugin_fixture_init_settings (ValentTestPluginFixture  *fixture,
-                                                         const char               *name);
-void           valent_test_plugin_fixture_connect       (ValentTestPluginFixture  *fixture,
-                                                         gboolean                  connected);
-void           valent_test_plugin_fixture_run           (ValentTestPluginFixture  *fixture);
-void           valent_test_plugin_fixture_quit          (ValentTestPluginFixture  *fixture);
+ValentTestPluginFixture * valent_test_plugin_fixture_new           (const char               *path);
+ValentTestPluginFixture * valent_test_plugin_fixture_ref           (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_unref         (ValentTestPluginFixture  *fixture);
 
-gpointer       valent_test_plugin_fixture_get_data      (ValentTestPluginFixture  *fixture);
-void           valent_test_plugin_fixture_set_data      (ValentTestPluginFixture  *fixture,
-                                                         gpointer                  data,
-                                                         GDestroyNotify            data_free);
-ValentDevice * valent_test_plugin_fixture_get_device    (ValentTestPluginFixture  *fixture);
-GSettings    * valent_test_plugin_fixture_get_settings  (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_init          (ValentTestPluginFixture  *fixture,
+                                                                    gconstpointer             user_data);
+void                      valent_test_plugin_fixture_init_settings (ValentTestPluginFixture  *fixture,
+                                                                    const char               *name);
+void                      valent_test_plugin_fixture_clear         (ValentTestPluginFixture  *fixture,
+                                                                    gconstpointer             user_data);
 
-JsonNode     * valent_test_plugin_fixture_expect_packet (ValentTestPluginFixture  *fixture);
-void           valent_test_plugin_fixture_handle_packet (ValentTestPluginFixture  *fixture,
-                                                         JsonNode                 *packet);
-JsonNode     * valent_test_plugin_fixture_lookup_packet (ValentTestPluginFixture  *fixture,
-                                                         const char               *name);
-gboolean       valent_test_plugin_fixture_download      (ValentTestPluginFixture  *fixture,
-                                                         JsonNode                 *packet,
-                                                         GError                  **error);
-gboolean       valent_test_plugin_fixture_upload        (ValentTestPluginFixture  *fixture,
-                                                         JsonNode                 *packet,
-                                                         GFile                    *file,
-                                                         GError                  **error);
-gboolean       valent_test_plugin_fixture_schema_fuzz   (ValentTestPluginFixture  *fixture,
-                                                         const char               *path);
+void                      valent_test_plugin_fixture_connect       (ValentTestPluginFixture  *fixture,
+                                                                    gboolean                  connected);
+void                      valent_test_plugin_fixture_run           (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_quit          (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_wait          (ValentTestPluginFixture  *fixture,
+                                                                    unsigned int              interval);
 
+gpointer                  valent_test_plugin_fixture_get_data      (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_set_data      (ValentTestPluginFixture  *fixture,
+                                                                    gpointer                  data,
+                                                                    GDestroyNotify            data_free);
+ValentDevice            * valent_test_plugin_fixture_get_device    (ValentTestPluginFixture  *fixture);
+GSettings               * valent_test_plugin_fixture_get_settings  (ValentTestPluginFixture  *fixture);
 
-ValentTestPluginFixture * valent_test_plugin_fixture_new             (const char     *path);
-ValentTestPluginFixture * valent_test_plugin_fixture_copy            (ValentTestPluginFixture  *fixture);
-void                      valent_test_plugin_fixture_free            (gpointer        data);
+JsonNode                * valent_test_plugin_fixture_expect_packet (ValentTestPluginFixture  *fixture);
+void                      valent_test_plugin_fixture_handle_packet (ValentTestPluginFixture  *fixture,
+                                                                    JsonNode                 *packet);
+JsonNode                * valent_test_plugin_fixture_lookup_packet (ValentTestPluginFixture  *fixture,
+                                                                    const char               *name);
+gboolean                  valent_test_plugin_fixture_download      (ValentTestPluginFixture  *fixture,
+                                                                    JsonNode                 *packet,
+                                                                    GError                  **error);
+gboolean                  valent_test_plugin_fixture_upload        (ValentTestPluginFixture  *fixture,
+                                                                    JsonNode                 *packet,
+                                                                    GFile                    *file,
+                                                                    GError                  **error);
+gboolean                  valent_test_plugin_fixture_schema_fuzz   (ValentTestPluginFixture  *fixture,
+                                                                    const char               *path);
 
-ValentChannel * valent_test_plugin_fixture_get_endpoint (ValentTestPluginFixture  *fixture);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (ValentTestPluginFixture, valent_test_plugin_fixture_unref)
 
 G_END_DECLS

--- a/src/tests/libvalent/core/meson.build
+++ b/src/tests/libvalent/core/meson.build
@@ -13,6 +13,7 @@ core_tests = [
   'test-data',
   'test-device',
   'test-device-manager',
+  'test-device-plugin',
   'test-object',
   'test-packet',
   'test-utils',

--- a/src/tests/libvalent/core/test-device-plugin.c
+++ b/src/tests/libvalent/core/test-device-plugin.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include <gio/gio.h>
+#include <libvalent-core.h>
+#include <libvalent-test.h>
+
+#include "valent-device-private.h"
+
+
+typedef struct
+{
+  ValentDevice  *device;
+  PeasExtension *extension;
+} DevicePluginFixture;
+
+static void
+device_fixture_set_up (DevicePluginFixture *fixture,
+                       gconstpointer        user_data)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *plugin_info;
+
+  engine = valent_get_engine ();
+  plugin_info = peas_engine_get_plugin_info (engine, "mock");
+
+  fixture->device = g_object_new (VALENT_TYPE_DEVICE,
+                                  "id", "mock-device",
+                                  NULL);
+  fixture->extension = peas_engine_create_extension (engine,
+                                                     plugin_info,
+                                                     VALENT_TYPE_DEVICE_PLUGIN,
+                                                     "device", fixture->device,
+                                                     NULL);
+}
+
+static void
+device_fixture_tear_down (DevicePluginFixture *fixture,
+                          gconstpointer  user_data)
+{
+  v_await_finalize_object (fixture->device);
+  v_await_finalize_object (fixture->extension);
+}
+
+static void
+test_device_plugin_basic (DevicePluginFixture *fixture,
+                          gconstpointer        user_data)
+{
+  g_autoptr (ValentDevice) device = NULL;
+  PeasPluginInfo *plugin_info = NULL;
+  GStrv capabilities = NULL;
+
+  /* Test properties */
+  g_object_get (fixture->extension,
+                "device",      &device,
+                "plugin-info", &plugin_info,
+                NULL);
+
+  g_assert_true (VALENT_IS_DEVICE (device));
+  g_assert_nonnull (plugin_info);
+
+  /* Capabilities */
+  capabilities = valent_device_plugin_get_incoming (plugin_info);
+  g_assert_cmpuint (g_strv_length (capabilities), ==, 2);
+  g_clear_pointer (&capabilities, g_strfreev);
+
+  capabilities = valent_device_plugin_get_outgoing (plugin_info);
+  g_assert_cmpuint (g_strv_length (capabilities), ==, 2);
+  g_clear_pointer (&capabilities, g_strfreev);
+
+  g_boxed_free (PEAS_TYPE_PLUGIN_INFO, plugin_info);
+}
+
+static void
+on_activate (GSimpleAction *action,
+             GVariant      *parameter,
+             gboolean      *activated)
+{
+  if (activated)
+    *activated = g_variant_get_boolean (parameter);
+}
+
+static void
+on_action_added (GActionGroup *action_group,
+                 const char   *action_name,
+                 gboolean     *emitted)
+{
+  g_assert_cmpstr (action_name, ==, "action");
+
+  if (emitted)
+    *emitted = TRUE;
+}
+
+static void
+on_action_enabled_changed (GActionGroup *action_group,
+                           const char   *action_name,
+                           gboolean      enabled,
+                           gboolean     *emitted)
+{
+  g_assert_cmpstr (action_name, ==, "action");
+
+  if (emitted)
+    *emitted = TRUE;
+}
+
+static void
+on_action_removed (GActionGroup *action_group,
+                   const char   *action_name,
+                   gboolean     *emitted)
+{
+  g_assert_cmpstr (action_name, ==, "action");
+
+  if (emitted)
+    *emitted = TRUE;
+}
+
+static void
+on_action_state_changed (GActionGroup *action_group,
+                         const char   *action_name,
+                         GVariant     *value,
+                         gboolean     *emitted)
+{
+  g_assert_cmpstr (action_name, ==, "state");
+
+  if (emitted)
+    *emitted = TRUE;
+}
+
+static void
+test_device_plugin_actions (DevicePluginFixture *fixture,
+                            gconstpointer        user_data)
+{
+  g_autoptr (GSimpleAction) action = NULL;
+  gboolean has_action = FALSE;
+  gboolean enabled = FALSE;
+  const GVariantType *parameter_type = NULL;
+  const GVariantType *state_type = NULL;
+  GVariant *state_hint = NULL;
+  GVariant *state = NULL;
+  gboolean emitted = FALSE;
+
+  valent_device_plugin_enable (VALENT_DEVICE_PLUGIN (fixture->extension));
+
+  g_signal_connect (fixture->extension,
+                    "action-added",
+                    G_CALLBACK (on_action_added),
+                    &emitted);
+  g_signal_connect (fixture->extension,
+                    "action-enabled-changed",
+                    G_CALLBACK (on_action_enabled_changed),
+                    &emitted);
+  g_signal_connect (fixture->extension,
+                    "action-removed",
+                    G_CALLBACK (on_action_removed),
+                    &emitted);
+  g_signal_connect (fixture->extension,
+                    "action-state-changed",
+                    G_CALLBACK (on_action_state_changed),
+                    &emitted);
+
+  /* Query */
+  has_action = g_action_group_query_action (G_ACTION_GROUP (fixture->extension),
+                                            "state",
+                                            &enabled,
+                                            &parameter_type,
+                                            &state_type,
+                                            &state_hint,
+                                            &state);
+  g_assert_true (has_action);
+  g_assert_true (enabled);
+  g_assert_null (parameter_type);
+  g_assert_true (g_variant_type_equal (state_type, G_VARIANT_TYPE_BOOLEAN));
+  g_assert_null (state_hint);
+  g_assert_true (g_variant_get_boolean (state));
+  g_clear_pointer (&state, g_variant_unref);
+
+  /* Change State */
+  g_action_group_change_action_state (G_ACTION_GROUP (fixture->extension),
+                                      "state",
+                                      g_variant_new_boolean (FALSE));
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  state = g_action_group_get_action_state (G_ACTION_GROUP (fixture->extension),
+                                           "state");
+  g_assert_false (g_variant_get_boolean (state));
+  g_clear_pointer (&state, g_variant_unref);
+
+  /* Add */
+  action = g_simple_action_new ("action", G_VARIANT_TYPE_BOOLEAN);
+  g_action_map_add_action (G_ACTION_MAP (fixture->extension),
+                           G_ACTION (action));
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  /* Enable/Disable */
+  g_simple_action_set_enabled (action, FALSE);
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  g_simple_action_set_enabled (action, TRUE);
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  /* Activate */
+  g_signal_connect (action,
+                    "activate",
+                    G_CALLBACK (on_activate),
+                    &emitted);
+  g_action_group_activate_action (G_ACTION_GROUP (fixture->extension),
+                                  "action",
+                                  g_variant_new_boolean (TRUE));
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  /* Remove */
+  g_action_map_remove_action (G_ACTION_MAP (fixture->extension), "action");
+  g_assert_true (emitted);
+  emitted = FALSE;
+
+  g_signal_handlers_disconnect_by_data (fixture->extension, &emitted);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, G_TEST_OPTION_ISOLATE_DIRS, NULL);
+
+  g_test_add ("/core/device-plugin/basic",
+              DevicePluginFixture, NULL,
+              device_fixture_set_up,
+              test_device_plugin_basic,
+              device_fixture_tear_down);
+
+  g_test_add ("/core/device-plugin/actions",
+              DevicePluginFixture, NULL,
+              device_fixture_set_up,
+              test_device_plugin_actions,
+              device_fixture_tear_down);
+
+  return g_test_run ();
+}
+

--- a/src/tests/libvalent/ui/test-device-panel.c
+++ b/src/tests/libvalent/ui/test-device-panel.c
@@ -36,7 +36,7 @@ test_device_panel_basic (void)
                              peas_engine_get_plugin_info (engine, "mock"));
 
   g_clear_object (&panel);
-  g_clear_pointer (&fixture, valent_test_plugin_fixture_free);
+  g_clear_pointer (&fixture, valent_test_plugin_fixture_unref);
 }
 
 int

--- a/src/tests/plugins/battery/test-battery-plugin.c
+++ b/src/tests/plugins/battery/test-battery-plugin.c
@@ -38,20 +38,17 @@ static void
 test_battery_plugin_actions (ValentTestPluginFixture *fixture,
                              gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   g_autoptr (GVariant) state = NULL;
   int level, charging;
   unsigned int time;
   const char *icon_name;
 
   /* Get the stateful actions */
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "battery"));
+  g_assert_true (g_action_group_has_action (actions, "battery.state"));
 
   /* Local */
-  state = g_action_group_get_action_state (actions, "battery");
+  state = g_action_group_get_action_state (actions, "battery.state");
   g_variant_get (state, "(b&siu)", &charging, &icon_name, &level, &time);
 
   g_assert_false (charging);
@@ -84,23 +81,20 @@ static void
 test_battery_plugin_handle_update (ValentTestPluginFixture *fixture,
                                    gconstpointer            user_data)
 {
-  ValentDevice *device = valent_test_plugin_fixture_get_device (fixture);
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
-  GActionGroup *actions;
   GVariant *state;
   int level, charging, time;
   const char *icon_name;
 
   /* Get the stateful actions */
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "battery"));
+  g_assert_true (g_action_group_has_action (actions, "battery.state"));
 
   /* Caution Battery */
   packet = valent_test_plugin_fixture_lookup_packet (fixture, "caution-battery");
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
-  state = g_action_group_get_action_state (actions, "battery");
+  state = g_action_group_get_action_state (actions, "battery.state");
   g_variant_get (state, "(b&siu)", &charging, &icon_name, &level, &time);
 
   g_assert_true (charging);
@@ -113,7 +107,7 @@ test_battery_plugin_handle_update (ValentTestPluginFixture *fixture,
   packet = valent_test_plugin_fixture_lookup_packet (fixture, "low-battery");
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
-  state = g_action_group_get_action_state (actions, "battery");
+  state = g_action_group_get_action_state (actions, "battery.state");
   g_variant_get (state, "(b&siu)", &charging, &icon_name, &level, &time);
 
   g_assert_true (charging);
@@ -126,7 +120,7 @@ test_battery_plugin_handle_update (ValentTestPluginFixture *fixture,
   packet = valent_test_plugin_fixture_lookup_packet (fixture, "good-battery");
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
-  state = g_action_group_get_action_state (actions, "battery");
+  state = g_action_group_get_action_state (actions, "battery.state");
   g_variant_get (state, "(b&siu)", &charging, &icon_name, &level, &time);
 
   g_assert_false (charging);
@@ -139,7 +133,7 @@ test_battery_plugin_handle_update (ValentTestPluginFixture *fixture,
   packet = valent_test_plugin_fixture_lookup_packet (fixture, "full-battery");
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
-  state = g_action_group_get_action_state (actions, "battery");
+  state = g_action_group_get_action_state (actions, "battery.state");
   g_variant_get (state, "(b&siu)", &charging, &icon_name, &level, &time);
 
   g_assert_false (charging);

--- a/src/tests/plugins/clipboard/test-clipboard-plugin.c
+++ b/src/tests/plugins/clipboard/test-clipboard-plugin.c
@@ -126,8 +126,7 @@ static void
 test_clipboard_plugin_actions (ValentTestPluginFixture *fixture,
                                gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   /* Get the stateful actions */
@@ -135,17 +134,14 @@ test_clipboard_plugin_actions (ValentTestPluginFixture *fixture,
   g_settings_set_boolean (fixture->settings, "auto-pull", FALSE);
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-
-  g_assert_true (g_action_group_get_action_enabled (actions, "clipboard-pull"));
-  g_assert_true (g_action_group_get_action_enabled (actions, "clipboard-push"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "clipboard.pull"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "clipboard.push"));
 
   /* Pull */
   packet = valent_test_plugin_fixture_lookup_packet (fixture, "clipboard-content");
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
-  g_action_group_activate_action (actions, "clipboard-pull", NULL);
+  g_action_group_activate_action (actions, "clipboard.pull", NULL);
   valent_clipboard_get_text_async (valent_clipboard_get_default (),
                                    NULL,
                                    (GAsyncReadyCallback)get_text_cb,
@@ -156,7 +152,7 @@ test_clipboard_plugin_actions (ValentTestPluginFixture *fixture,
   g_clear_pointer (&fixture->data, g_free);
 
   /* Push */
-  g_action_group_activate_action (actions, "clipboard-push", NULL);
+  g_action_group_activate_action (actions, "clipboard.push", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.clipboard");

--- a/src/tests/plugins/contacts/test-contacts-plugin.c
+++ b/src/tests/plugins/contacts/test-contacts-plugin.c
@@ -76,8 +76,8 @@ test_contacts_plugin_request_contacts (ValentTestPluginFixture *fixture,
   json_node_unref (packet);
 
   /* Expect UIDs request (GAction) */
-  g_action_group_activate_action (valent_device_get_actions (device),
-                                  "contacts-fetch",
+  g_action_group_activate_action (G_ACTION_GROUP (device),
+                                  "contacts.fetch",
                                   NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);

--- a/src/tests/plugins/findmyphone/test-findmyphone-plugin.c
+++ b/src/tests/plugins/findmyphone/test-findmyphone-plugin.c
@@ -12,12 +12,9 @@ static void
 test_findmyphone_plugin_basic (ValentTestPluginFixture *fixture,
                                gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "ring"));
+  g_assert_true (g_action_group_has_action (actions, "findmyphone.ring"));
 }
 
 static gboolean
@@ -52,17 +49,14 @@ static void
 test_findmyphone_plugin_send_request (ValentTestPluginFixture *fixture,
                                       gconstpointer            user_data)
 {
-  ValentDevice *device;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
-  GActionGroup *actions;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "ring"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "findmyphone.ring"));
 
-  g_action_group_activate_action (actions, "ring", NULL);
+  g_action_group_activate_action (actions, "findmyphone.ring", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.findmyphone.request");

--- a/src/tests/plugins/lock/test-lock-plugin.c
+++ b/src/tests/plugins/lock/test-lock-plugin.c
@@ -10,13 +10,10 @@ static void
 test_lock_plugin_basic (ValentTestPluginFixture *fixture,
                         gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "lock"));
-  g_assert_true (g_action_group_has_action (actions, "unlock"));
+  g_assert_true (g_action_group_has_action (actions, "lock.lock"));
+  g_assert_true (g_action_group_has_action (actions, "lock.unlock"));
 }
 
 static void
@@ -59,14 +56,10 @@ static void
 test_lock_plugin_send_request (ValentTestPluginFixture *fixture,
                                gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
-
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
 
   /* expect connect packet */
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -78,8 +71,8 @@ test_lock_plugin_send_request (ValentTestPluginFixture *fixture,
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
   /* lock the endpoint */
-  g_assert_true (g_action_group_get_action_enabled (actions, "lock"));
-  g_action_group_activate_action (actions, "lock", NULL);
+  g_assert_true (g_action_group_get_action_enabled (actions, "lock.lock"));
+  g_action_group_activate_action (actions, "lock.lock", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.lock.request");
@@ -90,8 +83,8 @@ test_lock_plugin_send_request (ValentTestPluginFixture *fixture,
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
   /* lock the endpoint (message) */
-  g_assert_true (g_action_group_get_action_enabled (actions, "unlock"));
-  g_action_group_activate_action (actions, "unlock", NULL);
+  g_assert_true (g_action_group_get_action_enabled (actions, "lock.unlock"));
+  g_action_group_activate_action (actions, "lock.unlock", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.lock.request");

--- a/src/tests/plugins/mousepad/test-mousepad-plugin.c
+++ b/src/tests/plugins/mousepad/test-mousepad-plugin.c
@@ -137,9 +137,8 @@ static void
 test_mousepad_plugin_send_keyboard_request (ValentTestPluginFixture *fixture,
                                             gconstpointer            user_data)
 {
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
-  ValentDevice *device;
-  GActionGroup *actions;
   GVariantDict dict;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
@@ -155,9 +154,7 @@ test_mousepad_plugin_send_keyboard_request (ValentTestPluginFixture *fixture,
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
   /* Check event action */
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "mousepad-event"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "mousepad.event"));
 
   /* Send unicode keysym */
   unsigned int keysym, mask;
@@ -170,7 +167,7 @@ test_mousepad_plugin_send_keyboard_request (ValentTestPluginFixture *fixture,
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "keysym", "u", keysym);
   g_variant_dict_insert (&dict, "mask", "u", mask);
-  g_action_group_activate_action (actions, "mousepad-event",
+  g_action_group_activate_action (actions, "mousepad.event",
                                   g_variant_dict_end (&dict));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -191,7 +188,7 @@ test_mousepad_plugin_send_keyboard_request (ValentTestPluginFixture *fixture,
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "keysym", "u", keysym);
   g_variant_dict_insert (&dict, "mask", "u", mask);
-  g_action_group_activate_action (actions, "mousepad-event",
+  g_action_group_activate_action (actions, "mousepad.event",
                                   g_variant_dict_end (&dict));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -211,7 +208,7 @@ test_mousepad_plugin_send_keyboard_request (ValentTestPluginFixture *fixture,
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "keysym", "u", keysym);
   g_variant_dict_insert (&dict, "mask", "u", mask);
-  g_action_group_activate_action (actions, "mousepad-event",
+  g_action_group_activate_action (actions, "mousepad.event",
                                   g_variant_dict_end (&dict));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -228,16 +225,13 @@ static void
 test_mousepad_plugin_send_pointer_request (ValentTestPluginFixture *fixture,
                                            gconstpointer            user_data)
 {
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
-  ValentDevice *device;
-  GActionGroup *actions;
   GVariantDict dict;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "mousepad-event"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "mousepad.event"));
 
   /* Expect remote state */
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -253,7 +247,7 @@ test_mousepad_plugin_send_pointer_request (ValentTestPluginFixture *fixture,
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "dx", "d", 1.0);
   g_variant_dict_insert (&dict, "dy", "d", 1.0);
-  g_action_group_activate_action (actions, "mousepad-event",
+  g_action_group_activate_action (actions, "mousepad.event",
                                   g_variant_dict_end (&dict));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -267,7 +261,7 @@ test_mousepad_plugin_send_pointer_request (ValentTestPluginFixture *fixture,
   g_variant_dict_insert (&dict, "dx", "d", 0.0);
   g_variant_dict_insert (&dict, "dy", "d", 1.0);
   g_variant_dict_insert (&dict, "scroll", "b", TRUE);
-  g_action_group_activate_action (actions, "mousepad-event",
+  g_action_group_activate_action (actions, "mousepad.event",
                                   g_variant_dict_end (&dict));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);

--- a/src/tests/plugins/photo/test-photo-plugin.c
+++ b/src/tests/plugins/photo/test-photo-plugin.c
@@ -10,32 +10,26 @@ static void
 test_photo_plugin_basic (ValentTestPluginFixture *fixture,
                          gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "photo"));
+  g_assert_true (g_action_group_has_action (actions, "photo.photo"));
 }
 
 static void
 test_photo_plugin_send_request (ValentTestPluginFixture *fixture,
                                 gconstpointer            user_data)
 {
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   g_autoptr (GError) error = NULL;
   g_autoptr (GFile) file = NULL;
-  ValentDevice *device;
-  GActionGroup *actions;
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "photo"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "photo.photo"));
 
   /* Request a photo from the endpoint */
-  g_action_group_activate_action (actions, "photo", NULL);
+  g_action_group_activate_action (actions, "photo.photo", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.photo.request");

--- a/src/tests/plugins/ping/test-ping-plugin.c
+++ b/src/tests/plugins/ping/test-ping-plugin.c
@@ -10,12 +10,10 @@ static void
 test_ping_plugin_basic (ValentTestPluginFixture *fixture,
                         gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "ping"));
+  g_assert_true (g_action_group_has_action (actions, "ping.ping"));
+  g_assert_true (g_action_group_has_action (actions, "ping.message"));
 }
 
 static void
@@ -39,26 +37,23 @@ static void
 test_ping_plugin_send_request (ValentTestPluginFixture *fixture,
                                gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "ping"));
-  g_assert_true (g_action_group_get_action_enabled (actions, "ping-message"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "ping.ping"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "ping.message"));
 
   /* Ping the endpoint */
-  g_action_group_activate_action (actions, "ping", NULL);
+  g_action_group_activate_action (actions, "ping.ping", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.ping");
   json_node_unref (packet);
 
   /* Ping the endpoint (message) */
-  g_action_group_activate_action (actions, "ping-message",
+  g_action_group_activate_action (actions, "ping.message",
                                   g_variant_new_string ("Test"));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);

--- a/src/tests/plugins/runcommand/test-runcommand-plugin.c
+++ b/src/tests/plugins/runcommand/test-runcommand-plugin.c
@@ -18,27 +18,21 @@ static void
 test_runcommand_plugin_basic (ValentTestPluginFixture *fixture,
                               gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "runcommand"));
+  g_assert_true (g_action_group_has_action (actions, "runcommand.execute"));
 }
 
 static void
 test_runcommand_plugin_handle_request (ValentTestPluginFixture *fixture,
                                        gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "runcommand"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "runcommand.execute"));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.runcommand");
@@ -51,7 +45,7 @@ test_runcommand_plugin_handle_request (ValentTestPluginFixture *fixture,
 
   /* Execute one of the commands */
   g_action_group_activate_action (actions,
-                                  "runcommand",
+                                  "runcommand.execute",
                                   g_variant_new_string ("command1"));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);

--- a/src/tests/plugins/sftp/test-sftp-plugin.c
+++ b/src/tests/plugins/sftp/test-sftp-plugin.c
@@ -10,30 +10,24 @@ static void
 test_sftp_plugin_basic (ValentTestPluginFixture *fixture,
                          gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "sftp-browse"));
+  g_assert_true (g_action_group_has_action (actions, "sftp.browse"));
 }
 
 static void
 test_sftp_plugin_send_request (ValentTestPluginFixture *fixture,
                                gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_get_action_enabled (actions, "sftp-browse"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "sftp.browse"));
 
   /* Request to mount the endpoint */
-  g_action_group_activate_action (actions, "sftp-browse", NULL);
+  g_action_group_activate_action (actions, "sftp.browse", NULL);
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.sftp.request");

--- a/src/tests/plugins/share/test-share-plugin.c
+++ b/src/tests/plugins/share/test-share-plugin.c
@@ -11,18 +11,14 @@ static void
 test_share_plugin_basic (ValentTestPluginFixture *fixture,
                          gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *group;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  group = valent_device_get_actions (device);
-
-  g_assert_true (g_action_group_has_action (group, "share"));
-  g_assert_true (g_action_group_has_action (group, "share-cancel"));
-  g_assert_true (g_action_group_has_action (group, "share-files"));
-  g_assert_true (g_action_group_has_action (group, "share-open"));
-  g_assert_true (g_action_group_has_action (group, "share-text"));
-  g_assert_true (g_action_group_has_action (group, "share-url"));
+  g_assert_true (g_action_group_has_action (actions, "share.share"));
+  g_assert_true (g_action_group_has_action (actions, "share.cancel"));
+  g_assert_true (g_action_group_has_action (actions, "share.files"));
+  g_assert_true (g_action_group_has_action (actions, "share.open"));
+  g_assert_true (g_action_group_has_action (actions, "share.text"));
+  g_assert_true (g_action_group_has_action (actions, "share.url"));
 }
 
 static void
@@ -57,20 +53,20 @@ static void
 test_share_plugin_send_request (ValentTestPluginFixture *fixture,
                                 gconstpointer            user_data)
 {
-  GError *error = NULL;
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
   const char * const files[] = { "file://"TEST_DATA_DIR"image.png" };
-
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
+  GError *error = NULL;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
+  g_assert_true (g_action_group_get_action_enabled (actions, "share.files"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "share.text"));
+  g_assert_true (g_action_group_get_action_enabled (actions, "share.url"));
+
   /* Share a file */
   g_action_group_activate_action (actions,
-                                  "share-files",
+                                  "share.files",
                                   g_variant_new_strv (files, 1));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -84,7 +80,7 @@ test_share_plugin_send_request (ValentTestPluginFixture *fixture,
 
   /* Share text */
   g_action_group_activate_action (actions,
-                                  "share-text",
+                                  "share.text",
                                   g_variant_new_string ("Test"));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);
@@ -94,7 +90,7 @@ test_share_plugin_send_request (ValentTestPluginFixture *fixture,
 
   /* Share a URL */
   g_action_group_activate_action (actions,
-                                  "share-url",
+                                  "share.url",
                                   g_variant_new_string ("https://www.andyholmes.ca"));
 
   packet = valent_test_plugin_fixture_expect_packet (fixture);

--- a/src/tests/plugins/sms/test-sms-plugin.c
+++ b/src/tests/plugins/sms/test-sms-plugin.c
@@ -12,8 +12,7 @@ static void
 test_sms_plugin_basic (ValentTestPluginFixture *fixture,
                        gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
@@ -23,19 +22,17 @@ test_sms_plugin_basic (ValentTestPluginFixture *fixture,
   v_assert_packet_type (packet, "kdeconnect.sms.request_conversations");
   json_node_unref (packet);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-  g_assert_true (g_action_group_has_action (actions, "messaging"));
-  g_assert_true (g_action_group_has_action (actions, "sms-fetch"));
+  g_assert_true (g_action_group_has_action (actions, "sms.messaging"));
+  g_assert_true (g_action_group_has_action (actions, "sms.fetch"));
 
   /* Expect request (thread digest) */
-  g_action_group_activate_action (actions, "sms-fetch", NULL);
+  g_action_group_activate_action (actions, "sms.fetch", NULL);
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.sms.request_conversations");
   json_node_unref (packet);
 
   /* Open window */
-  g_action_group_activate_action (actions, "messaging", NULL);
+  g_action_group_activate_action (actions, "sms.messaging", NULL);
 }
 
 static void

--- a/src/tests/plugins/telephony/test-telephony-plugin.c
+++ b/src/tests/plugins/telephony/test-telephony-plugin.c
@@ -74,13 +74,9 @@ static void
 test_telephony_plugin_basic (ValentTestPluginFixture *fixture,
                              gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
 
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
-
-  g_assert_true (g_action_group_has_action (actions, "mute-call"));
+  g_assert_true (g_action_group_has_action (actions, "telephony.mute-call"));
 }
 
 static void
@@ -187,12 +183,8 @@ static void
 test_telephony_plugin_mute_call (ValentTestPluginFixture *fixture,
                                  gconstpointer            user_data)
 {
-  ValentDevice *device;
-  GActionGroup *actions;
+  GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
-
-  device = valent_test_plugin_fixture_get_device (fixture);
-  actions = valent_device_get_actions (device);
 
   valent_test_plugin_fixture_connect (fixture, TRUE);
 
@@ -201,7 +193,7 @@ test_telephony_plugin_mute_call (ValentTestPluginFixture *fixture,
   valent_test_plugin_fixture_handle_packet (fixture, packet);
 
   /* Mute the call */
-  g_action_group_activate_action (actions, "mute-call", NULL);
+  g_action_group_activate_action (actions, "telephony.mute-call", NULL);
   packet = valent_test_plugin_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.telephony.request_mute");
   json_node_unref (packet);


### PR DESCRIPTION
This brings the plugin inline with other extension points in Valent, and
makes providing conveniences for device plugins easier.