### PR TITLE
ValentBattery: refactor and handle UPower states more thoroughly

### DIFF
--- a/src/plugins/battery/valent-battery.h
+++ b/src/plugins/battery/valent-battery.h
@@ -11,10 +11,10 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ValentBattery, valent_battery, VALENT, BATTERY, GObject)
 
-ValentBattery * valent_battery_get_default   (void);
-int             valent_battery_get_level     (ValentBattery *battery);
-gboolean        valent_battery_get_charging  (ValentBattery *battery);
-unsigned int    valent_battery_get_threshold (ValentBattery *battery);
+ValentBattery * valent_battery_get_default     (void);
+int             valent_battery_current_charge  (ValentBattery *battery);
+gboolean        valent_battery_is_charging     (ValentBattery *battery);
+unsigned int    valent_battery_threshold_event (ValentBattery *battery);
 
 G_END_DECLS
 

--- a/src/tests/plugins/battery/mock_upower.py
+++ b/src/tests/plugins/battery/mock_upower.py
@@ -48,6 +48,7 @@ class UPowerTestFixture(glibtest.GLibTestCase, dbusmock.DBusTestCase):
         self.dbusmock.SetDeviceProperties(
             '/org/freedesktop/UPower/devices/DisplayDevice',
             {
+                'IsPresent': dbus.Boolean(True, variant_level=1),
                 'Type': dbus.UInt32(2, variant_level=1)
             })
 


### PR DESCRIPTION
Refactor the UPower abstraction used by the battery plugin to better
abstract UPower particulars to the simple values KDE Connect uses.

* drop GObject properties
* use getters that reflect `kdeconnect.battery` packet fields
* handle `State` and `WarningLevel` properties thoroughly
* handle changes to the `IsPresent` property