### PR TITLE
tests: bump CI image to fedora:36 and use Fedora's registry

### DIFF
--- a/src/tests/extra/Dockerfile
+++ b/src/tests/extra/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: No rights reserved
 
-FROM fedora:35
+FROM registry.fedoraproject.org/fedora:36
 
 # The packages below are roughly grouped into build tooling and build
 # dependencies (with debug symbols)


### PR DESCRIPTION
The image from docker.io seems to be lagging behind the image from
registry.fedoraproject.org, which causes the image build to choke up.

Switch to Fedora's canonical registry, while bumping the image to 36.