### PR TITLE
tests: update Dockerfile for changes in fedora:36

### DIFF
--- a/src/tests/extra/Dockerfile
+++ b/src/tests/extra/Dockerfile
@@ -3,13 +3,9 @@
 
 FROM registry.fedoraproject.org/fedora:36
 
-# See: https://github.com/andyholmes/copr/tree/main/glib2
-RUN dnf install -y 'dnf-command(copr)' && \
-    dnf copr -y enable andyholmes/main
-
 # The packages below are roughly grouped into build tooling and build
 # dependencies (with debug symbols)
-RUN dnf install -y --enablerepo=fedora-debuginfo,updates-debuginfo \
+RUN dnf install -y --enablerepo=*-debuginfo \
         glibc-langpack-en glibc-locale-source clang gcc gettext gi-docgen git \
         graphviz libabigail libasan libtsan libubsan meson appstream \
         desktop-file-utils dbus-daemon lcov python-dbusmock rsync \


### PR DESCRIPTION
* remove the COPR repository for glib2

    The `EPERM` patch has been added upstream, so we don't need to carry
    a custom package build anymore.

* add a wildcard for debuginfo repositories

    Some debuginfo's seem to be hanging around in updates-testing for
    now, causing the ASAN job to fail.