### PR TITLE
libvalent-ui: minor fixes

### DIFF
--- a/doc/sdk/urlmap.js
+++ b/doc/sdk/urlmap.js
@@ -11,6 +11,7 @@ baseURLs = [
     [ 'Gtk', 'https://docs.gtk.org/gtk4/' ],
     [ 'GdkPixbuf', 'https://docs.gtk.org/gdk-pixbuf/' ],
     [ 'Json', 'https://gnome.pages.gitlab.gnome.org/json-glib/'],
+    [ 'Peas', 'https://gnome.pages.gitlab.gnome.org/libpeas/libpeas-1.0/'],
     [ 'Adw', 'https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/' ],
 ]
 

--- a/doc/sdk/valent.toml.in
+++ b/doc/sdk/valent.toml.in
@@ -40,7 +40,7 @@ search_index = true
   [dependencies."Peas-1.0"]
   name = "Peas"
   description = "A GObject-based plugin engine"
-  docs_url = "https://developer-old.gnome.org/libpeas/stable/"
+  docs_url = "https://gnome.pages.gitlab.gnome.org/libpeas/libpeas-1.0/"
 
   [dependencies."EBookContacts-1.2"]
   name = "EBookContacts"

--- a/src/libvalent/ui/valent-menu-list.h
+++ b/src/libvalent/ui/valent-menu-list.h
@@ -12,8 +12,8 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (ValentMenuList, valent_menu_list, VALENT, MENU_LIST, GtkWidget)
 
 ValentMenuList * valent_menu_list_new            (GMenuModel     *model);
-GMenuModel     * valent_menu_list_get_model      (ValentMenuList *self);
-void             valent_menu_list_set_model      (ValentMenuList *self,
+GMenuModel     * valent_menu_list_get_menu_model (ValentMenuList *self);
+void             valent_menu_list_set_menu_model (ValentMenuList *self,
                                                   GMenuModel     *model);
 ValentMenuList * valent_menu_list_get_submenu_of (ValentMenuList *self);
 void             valent_menu_list_set_submenu_of (ValentMenuList *self,

--- a/src/libvalent/ui/valent-menu-stack.c
+++ b/src/libvalent/ui/valent-menu-stack.c
@@ -154,7 +154,7 @@ valent_menu_stack_get_menu_model (ValentMenuStack *stack)
   if (stack->main == NULL)
     return NULL;
 
-  return valent_menu_list_get_model (stack->main);
+  return valent_menu_list_get_menu_model (stack->main);
 }
 
 /**
@@ -184,7 +184,7 @@ valent_menu_stack_set_menu_model (ValentMenuStack *stack,
       gtk_stack_add_named (GTK_STACK (stack->stack),
                            GTK_WIDGET (stack->main),
                            "main");
-      valent_menu_list_set_model (stack->main, menu_model);
+      valent_menu_list_set_menu_model (stack->main, menu_model);
     }
 }
 

--- a/src/libvalent/ui/valent-preferences-window.ui
+++ b/src/libvalent/ui/valent-preferences-window.ui
@@ -108,7 +108,7 @@
         <property name="spacing">12</property>
         <child>
           <object class="GtkLabel">
-            <property name="label">The device name is used to identify this device to other devices on the network.</property>
+            <property name="label" translatable="yes">The device name is used to identify this device to other devices on the network.</property>
             <property name="max-width-chars">35</property>
             <property name="wrap">1</property>
             <property name="xalign">0.0</property>

--- a/src/libvalent/ui/valent-window.ui
+++ b/src/libvalent/ui/valent-window.ui
@@ -8,6 +8,23 @@
     <property name="icon-name">ca.andyholmes.Valent</property>
     <property name="width-request">360</property>
     <child>
+      <object class="GtkShortcutController">
+        <property name="scope">global</property>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">&lt;Control&gt;comma</property>
+            <property name="action">action(win.preferences)</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">&lt;Control&gt;r</property>
+            <property name="action">action(win.refresh)</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
       <object class="GtkStack" id="stack">
         <property name="transition-type">slide-left-right</property>
         <child>
@@ -29,17 +46,6 @@
                         <property name="valign">center</property>
                         <property name="action-name">win.refresh</property>
                         <property name="icon-name">view-refresh-symbolic</property>
-                        <child>
-                          <object class="GtkShortcutController">
-                            <property name='scope'>global</property>
-                            <child>
-                              <object class='GtkShortcut'>
-                                <property name='trigger'>&lt;Control&gt;r</property>
-                                <property name='action'>activate</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
                       </object>
                     </child>
                     <child type="end">
@@ -95,6 +101,12 @@
       <item>
         <attribute name="label" translatable="yes">About Valent</attribute>
         <attribute name="action">win.about</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Quit</attribute>
+        <attribute name="action">app.quit</attribute>
       </item>
     </section>
   </menu>

--- a/src/tests/plugins/runcommand/meson.build
+++ b/src/tests/plugins/runcommand/meson.build
@@ -8,6 +8,7 @@ plugin_runcommand_test_deps = [
 ]
 
 plugin_runcommand_tests = [
+  'test-runcommand-editor',
   'test-runcommand-plugin',
   'test-runcommand-preferences',
 ]

--- a/src/tests/plugins/runcommand/test-runcommand-editor.c
+++ b/src/tests/plugins/runcommand/test-runcommand-editor.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2022 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+#include "valent-runcommand-editor.h"
+
+
+static void
+test_runcommand_dialog (void)
+{
+  g_autoptr (ValentRuncommandEditor) dialog = NULL;
+
+  dialog = (ValentRuncommandEditor *)valent_runcommand_editor_new ();
+  gtk_window_present (GTK_WINDOW (dialog));
+
+  g_assert_cmpstr (valent_runcommand_editor_get_command (dialog), ==, "");
+  g_assert_cmpstr (valent_runcommand_editor_get_name (dialog), ==, "");
+  g_assert_cmpstr (valent_runcommand_editor_get_uuid (dialog), ==, "");
+
+  valent_runcommand_editor_set_command (dialog, "command");
+  valent_runcommand_editor_set_name (dialog, "name");
+  valent_runcommand_editor_set_uuid (dialog, "uuid");
+
+  g_assert_cmpstr (valent_runcommand_editor_get_command (dialog), ==, "command");
+  g_assert_cmpstr (valent_runcommand_editor_get_name (dialog), ==, "name");
+  g_assert_cmpstr (valent_runcommand_editor_get_uuid (dialog), ==, "uuid");
+
+  valent_runcommand_editor_clear (dialog);
+
+  g_assert_cmpstr (valent_runcommand_editor_get_command (dialog), ==, "");
+  g_assert_cmpstr (valent_runcommand_editor_get_name (dialog), ==, "");
+  g_assert_cmpstr (valent_runcommand_editor_get_uuid (dialog), ==, "");
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/plugins/runcommand/dialog",
+                   test_runcommand_dialog);
+
+  return g_test_run ();
+}
+


### PR DESCRIPTION
* ValentWindow
    * move shortcut controller to the root widget
    * add a primary menu item to quit Valent
* ValentPreferencesWindow: mark missed string as translatable
* ValentMenuList, ValentMenuStack
    * rename "model" property to "menu-model"
    * fix a segmentation fault with sections