### PR TITLE
cr: fix publish conditional

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Login
-        if: ${{ github.ref == 'refs/head/main' }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -37,5 +37,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: ./src/tests/extra/Dockerfile
-          push: ${{ github.ref == 'refs/head/main' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
The CI image was incorrectly checking `github.ref == 'refs/head/main'`
when it should have been `github.ref == 'refs/heads/main'`.

Regardless, change it to publish whenever the event is not a pull
request.