### PR TITLE
xdp module: allow building with libportal >= 0.5 && <= 0.6

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -173,7 +173,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/libportal.git",
-                    "tag" : "0.5"
+                    "tag" : "0.6"
                 }
             ]
         },

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -160,7 +160,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/libportal.git",
-                    "tag" : "0.5"
+                    "tag" : "0.6"
                 }
             ]
         },

--- a/src/plugins/xdp/meson.build
+++ b/src/plugins/xdp/meson.build
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
 
 # Require libportal
-libportal_version = '0.5'
+libportal_version = ['>= 0.5', '<= 0.6']
 libportal_dep = dependency('libportal-gtk4',
    version: libportal_version,
   required: false,

--- a/subprojects/libportal.wrap
+++ b/subprojects/libportal.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory=libportal
 url=https://github.com/flatpak/libportal.git
-revision=0.5
+revision=0.6
 depth=1
 


### PR DESCRIPTION
libportal-0.6 didn't seem to break any ABI/API used in the XDP plugin,
so allow building with either v0.5 or v0.6.