### PR TITLE
test: cleanup CI image

### DIFF
--- a/src/tests/extra/Dockerfile
+++ b/src/tests/extra/Dockerfile
@@ -5,12 +5,11 @@ FROM registry.fedoraproject.org/fedora:36
 
 # The packages below are roughly grouped into build tooling and build
 # dependencies (with debug symbols)
-RUN dnf install -y --enablerepo=*-debuginfo \
+RUN dnf install -y --enablerepo=*-debuginfo --setopt=install_weak_deps=False \
         glibc-langpack-en glibc-locale-source clang gcc gettext gi-docgen git \
         graphviz libabigail libasan libtsan libubsan lld meson appstream \
         desktop-file-utils dbus-daemon lcov python-dbusmock rsync \
         xorg-x11-server-Xvfb \
-        alsa-lib-devel                alsa-lib-debuginfo \
         evolution-data-server-devel   evolution-data-server-debuginfo \
         glib2-devel                   glib2-debuginfo \
         gnutls-devel                  gnutls-debuginfo \


### PR DESCRIPTION
Remove `alsa-lib-devel` and don't install weak dependencies.