### PR TITLE
tests: fix Dockerfile debuginfo install

### DIFF
--- a/src/tests/extra/Dockerfile
+++ b/src/tests/extra/Dockerfile
@@ -5,7 +5,8 @@ FROM registry.fedoraproject.org/fedora:36
 
 # The packages below are roughly grouped into build tooling and build
 # dependencies (with debug symbols)
-RUN dnf install -y --enablerepo=*-debuginfo --setopt=install_weak_deps=False \
+RUN dnf install -y --enablerepo=fedora-debuginfo,updates-debuginfo \
+        --setopt=install_weak_deps=False \
         glibc-langpack-en glibc-locale-source clang gcc gettext gi-docgen git \
         graphviz libabigail libasan libtsan libubsan lld meson appstream \
         desktop-file-utils dbus-daemon lcov python-dbusmock rsync \


### PR DESCRIPTION
Explicitly install debuginfo from `fedora-debuginfo` and
`updates-debuginfo` to avoid pulling in mismatched debug packages.