### PR TITLE
maintenance: various fixes and cleanups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Prepare QEMU
         if: ${{ matrix.arch == 'aarch64' }}
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           reuse lint
 
       - name: Spelling (codespell)
+        if: ${{ always() }}
         run: |
           codespell --config src/tests/extra/setup.cfg
 
@@ -143,7 +144,7 @@ jobs:
 
       - name: Test Report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Tests (${{ matrix.label }})
           path: _build/meson-logs/testlog.txt

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: Login
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USERNAME }}
           password: ${{ env.PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ./src/tests/extra/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}

--- a/src/libvalent/core/libvalent-core.h
+++ b/src/libvalent/core/libvalent-core.h
@@ -10,6 +10,7 @@
 #include "valent-channel.h"
 #include "valent-channel-service.h"
 #include "valent-component.h"
+#include "valent-core-enums.h"
 #include "valent-data.h"
 #include "valent-debug.h"
 #include "valent-device.h"

--- a/src/libvalent/core/valent-data.h
+++ b/src/libvalent/core/valent-data.h
@@ -24,35 +24,33 @@ struct _ValentDataClass
 };
 
 VALENT_AVAILABLE_IN_1_0
-ValentData    * valent_data_new          (const char      *context,
-                                          ValentData      *parent);
-
-/* Properties */
+ValentData    * valent_data_new          (const char *context,
+                                          ValentData *parent);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_data_get_cache_path  (ValentData      *data);
+const char * valent_data_get_cache_path  (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_data_get_config_path (ValentData      *data);
+const char * valent_data_get_config_path (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_data_get_data_path   (ValentData      *data);
+const char * valent_data_get_data_path   (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_data_get_context     (ValentData      *data);
+const char * valent_data_get_context     (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-ValentData * valent_data_get_parent      (ValentData      *data);
-
-/* Public Methods */
+ValentData * valent_data_get_parent      (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-void         valent_data_clear_cache     (ValentData      *data);
+const char * valent_data_get_uid         (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-void         valent_data_clear_data      (ValentData      *data);
+void         valent_data_clear_cache     (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-GFile      * valent_data_new_cache_file  (ValentData      *data,
-                                          const char      *filename);
+void         valent_data_clear_data      (ValentData *data);
 VALENT_AVAILABLE_IN_1_0
-GFile      * valent_data_new_config_file (ValentData      *data,
-                                          const char      *filename);
+GFile      * valent_data_new_cache_file  (ValentData *data,
+                                          const char *filename);
 VALENT_AVAILABLE_IN_1_0
-GFile      * valent_data_new_data_file   (ValentData      *data,
-                                          const char      *filename);
+GFile      * valent_data_new_config_file (ValentData *data,
+                                          const char *filename);
+VALENT_AVAILABLE_IN_1_0
+GFile      * valent_data_new_data_file   (ValentData *data,
+                                          const char *filename);
 
 /* Static Utilities */
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -771,6 +771,8 @@ valent_device_manager_dispose (GObject *object)
       g_signal_emit (G_OBJECT (self), signals [DEVICE_REMOVED], 0, device);
       g_hash_table_iter_remove (&iter);
     }
+
+  G_OBJECT_CLASS (valent_device_manager_parent_class)->dispose (object);
 }
 
 static void

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1072,6 +1072,7 @@ valent_device_class_init (ValentDeviceClass *klass)
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));
 
   /**

--- a/src/libvalent/media/libvalent-media.h
+++ b/src/libvalent/media/libvalent-media.h
@@ -7,6 +7,7 @@
 
 #include "valent-media.h"
 #include "valent-media-adapter.h"
+#include "valent-media-enums.h"
 #include "valent-media-player.h"
 
 #undef VALENT_MEDIA_INSIDE

--- a/src/libvalent/mixer/libvalent-mixer.h
+++ b/src/libvalent/mixer/libvalent-mixer.h
@@ -7,6 +7,7 @@
 
 #include "valent-mixer.h"
 #include "valent-mixer-adapter.h"
+#include "valent-mixer-enums.h"
 #include "valent-mixer-stream.h"
 
 #undef VALENT_MIXER_INSIDE

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -454,6 +454,7 @@ mousepad_remote_action (GSimpleAction *action,
   ValentMousepadPlugin *self = VALENT_MOUSEPAD_PLUGIN (user_data);
 
   g_assert (VALENT_IS_MOUSEPAD_PLUGIN (self));
+  g_assert (gtk_is_initialized ());
 
   if (self->remote == NULL)
     {

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -819,6 +819,12 @@ notification_reply_action (GSimpleAction *action,
       g_autoptr (ValentNotificationDialog) dialog = NULL;
       g_autoptr (ValentNotification) notification = NULL;
 
+      if (!gtk_is_initialized ())
+        {
+          g_warning ("%s: No display available", G_STRFUNC);
+          return;
+        }
+
       notification = valent_notification_deserialize (notificationv);
 
       if ((dialog = g_hash_table_lookup (self->dialogs, notification)) == NULL)

--- a/src/plugins/presenter/valent-presenter-plugin.c
+++ b/src/plugins/presenter/valent-presenter-plugin.c
@@ -117,6 +117,7 @@ presenter_remote_action (GSimpleAction *action,
   ValentPresenterPlugin *self = VALENT_PRESENTER_PLUGIN (user_data);
 
   g_assert (VALENT_IS_PRESENTER_PLUGIN (self));
+  g_assert (gtk_is_initialized ());
 
   if (self->remote == NULL)
     {

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -401,6 +401,12 @@ messaging_action (GSimpleAction *action,
 
   g_assert (VALENT_IS_SMS_PLUGIN (self));
 
+  if (!gtk_is_initialized ())
+    {
+      g_warning ("%s: No display available", G_STRFUNC);
+      return;
+    }
+
   if (self->window == NULL)
     {
       ValentContactStore *store;

--- a/src/tests/libvalent/meson.build
+++ b/src/tests/libvalent/meson.build
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
 
 subdir('core')
-subdir('contacts')
 subdir('clipboard')
+subdir('contacts')
 subdir('input')
 subdir('media')
 subdir('mixer')


### PR DESCRIPTION
* libvalent: add enum headers to public header
* ValentDeviceManager: fix missing chain-up in dispose
* ValentDevice: missing `G_PARAM_EXPLICIT_NOTIFY` flag on property
* add GTK initialization guards to plugins
* ci: missing `${{ always() }}` on codespell check
* ci: bump actions/upload-artifact, docker/build-push-action,
  docker/login-action, docker/setup-qemu-action
* github: add dependabot configuration
* code style cleanups