### PR TITLE
ValentComponent: refactor and cleanup

### DIFF
--- a/src/libvalent/core/meson.build
+++ b/src/libvalent/core/meson.build
@@ -29,6 +29,7 @@ libvalent_core_public_headers = [
 ]
 
 libvalent_core_private_headers = [
+  'valent-component-private.h',
   'valent-device-impl.h',
   'valent-device-private.h',
 ]

--- a/src/libvalent/core/valent-component-private.h
+++ b/src/libvalent/core/valent-component-private.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2022 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#include <libpeas/peas.h>
+
+#include "valent-component.h"
+
+
+G_BEGIN_DECLS
+
+PeasExtension * valent_component_get_primary (ValentComponent *component);
+
+G_END_DECLS
+

--- a/src/libvalent/core/valent-component.h
+++ b/src/libvalent/core/valent-component.h
@@ -23,19 +23,16 @@ struct _ValentComponentClass
 {
   GObjectClass   parent_class;
 
-  /* signals */
-  void           (*extension_added)   (ValentComponent *component,
+  /* virtual functions */
+  void           (*enable_extension)  (ValentComponent *component,
                                        PeasExtension   *extension);
-  void           (*extension_removed) (ValentComponent *component,
+  void           (*disable_extension) (ValentComponent *component,
                                        PeasExtension   *extension);
 };
 
 VALENT_AVAILABLE_IN_1_0
-PeasExtension * valent_component_get_priority_provider (ValentComponent *component,
-                                                        const char      *key);
-VALENT_AVAILABLE_IN_1_0
-GSettings     * valent_component_new_settings          (const char      *context,
-                                                        const char      *module_name);
+GSettings * valent_component_create_settings (const char *context,
+                                              const char *module_name);
 
 G_END_DECLS
 

--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -380,7 +380,7 @@ on_load_service (PeasEngine          *engine,
   service = g_new0 (ChannelService, 1);
   service->manager = self;
   service->info = info;
-  service->settings = valent_component_new_settings ("network", module);
+  service->settings = valent_component_create_settings ("network", module);
   g_signal_connect (service->settings,
                     "changed::enabled",
                     G_CALLBACK (on_enabled_changed),

--- a/src/libvalent/notifications/valent-notifications.c
+++ b/src/libvalent/notifications/valent-notifications.c
@@ -231,8 +231,8 @@ valent_notifications_adapter_load_cb (ValentNotificationsAdapter *adapter,
  * ValentComponent
  */
 static void
-valent_notifications_extension_added (ValentComponent *component,
-                                      PeasExtension   *extension)
+valent_notifications_enable_extension (ValentComponent *component,
+                                       PeasExtension   *extension)
 {
   ValentNotifications *self = VALENT_NOTIFICATIONS (component);
   ValentNotificationsAdapter *adapter = VALENT_NOTIFICATIONS_ADAPTER (extension);
@@ -257,7 +257,7 @@ valent_notifications_extension_added (ValentComponent *component,
 }
 
 static void
-valent_notifications_extension_removed (ValentComponent *component,
+valent_notifications_disable_extension (ValentComponent *component,
                                         PeasExtension   *extension)
 {
   ValentNotifications *self = VALENT_NOTIFICATIONS (component);
@@ -292,8 +292,8 @@ valent_notifications_class_init (ValentNotificationsClass *klass)
 
   object_class->finalize = valent_notifications_finalize;
 
-  component_class->extension_added = valent_notifications_extension_added;
-  component_class->extension_removed = valent_notifications_extension_removed;
+  component_class->enable_extension = valent_notifications_enable_extension;
+  component_class->disable_extension = valent_notifications_disable_extension;
 
   /**
    * ValentNotifications::notification-added:
@@ -361,8 +361,9 @@ valent_notifications_get_default (void)
   if (default_listener == NULL)
     {
       default_listener = g_object_new (VALENT_TYPE_NOTIFICATIONS,
-                                       "plugin-context", "notifications",
-                                       "plugin-type",    VALENT_TYPE_NOTIFICATIONS_ADAPTER,
+                                       "plugin-context",  "notifications",
+                                       "plugin-priority", "NotificationsAdapterPriority",
+                                       "plugin-type",     VALENT_TYPE_NOTIFICATIONS_ADAPTER,
                                        NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_listener),

--- a/src/libvalent/ui/valent-application.c
+++ b/src/libvalent/ui/valent-application.c
@@ -134,7 +134,7 @@ on_load_plugin (PeasEngine        *engine,
   plugin = g_new0 (ApplicationPlugin, 1);
   plugin->application = G_APPLICATION (self);
   plugin->info = info;
-  plugin->settings = valent_component_new_settings ("application", module);
+  plugin->settings = valent_component_create_settings ("application", module);
   g_hash_table_insert (self->plugins, info, plugin);
 
   /* The PeasExtension is created and destroyed based on the enabled state */

--- a/src/libvalent/ui/valent-preferences-window.c
+++ b/src/libvalent/ui/valent-preferences-window.c
@@ -150,7 +150,7 @@ plugin_row_add_extensions (AdwExpanderRow *plugin_row,
       adw_action_row_add_suffix (ADW_ACTION_ROW (row), sw);
       adw_action_row_set_activatable_widget (ADW_ACTION_ROW (row), sw);
 
-      settings = valent_component_new_settings (extension.domain, module_name);
+      settings = valent_component_create_settings (extension.domain, module_name);
       g_settings_bind (settings, "enabled",
                        sw,       "active",
                        G_SETTINGS_BIND_DEFAULT);

--- a/src/tests/libvalent/contacts/test-contacts-component.c
+++ b/src/tests/libvalent/contacts/test-contacts-component.c
@@ -150,10 +150,12 @@ contacts_component_fixture_set_up (ContactsComponentFixture *fixture,
   // HACK: Wait for the adapter to be constructed, then a bit longer for
   //       valent_contacts_adapter_load_async() to resolve
   while ((fixture->adapter = valent_mock_contacts_adapter_get_instance ()) == NULL)
-    continue;
+    g_main_context_iteration (NULL, FALSE);
 
   while (g_main_context_iteration (NULL, FALSE))
     continue;
+
+  g_object_ref (fixture->adapter);
 }
 
 static void
@@ -161,6 +163,7 @@ contacts_component_fixture_tear_down (ContactsComponentFixture *fixture,
                                       gconstpointer             user_data)
 {
   v_await_finalize_object (fixture->contacts);
+  v_await_finalize_object (fixture->adapter);
   v_await_finalize_object (fixture->store);
   v_assert_finalize_object (fixture->contact);
   g_clear_pointer (&fixture->loop, g_main_loop_unref);

--- a/src/tests/libvalent/core/test-device-manager.c
+++ b/src/tests/libvalent/core/test-device-manager.c
@@ -395,7 +395,7 @@ test_manager_dispose (ManagerFixture *fixture,
     g_main_context_iteration (NULL, FALSE);
 
   /* Disable & Enabled channel service */
-  settings = valent_component_new_settings ("network", "mock");
+  settings = valent_component_create_settings ("network", "mock");
 
   g_settings_set_boolean (settings, "enabled", FALSE);
 

--- a/src/tests/libvalent/ui/test-application.c
+++ b/src/tests/libvalent/ui/test-application.c
@@ -92,7 +92,7 @@ plugins_timeout_cb (gpointer data)
 
   engine = valent_get_engine ();
   info = peas_engine_get_plugin_info (engine, "mock");
-  settings = valent_component_new_settings ("application", "mock");
+  settings = valent_component_create_settings ("application", "mock");
 
   switch (stage++)
     {

--- a/src/tests/plugins/fdo/test-fdo-notifications.c
+++ b/src/tests/plugins/fdo/test-fdo-notifications.c
@@ -45,7 +45,7 @@ fdo_notifications_fixture_set_up (FdoNotificationsFixture *fixture,
   g_autoptr (GSettings) settings = NULL;
 
   /* Disable the mock plugin */
-  settings = valent_component_new_settings ("notifications", "mock");
+  settings = valent_component_create_settings ("notifications", "mock");
   g_settings_set_boolean (settings, "enabled", FALSE);
 
   fixture->connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);

--- a/src/tests/plugins/fdo/test-fdo-session.c
+++ b/src/tests/plugins/fdo/test-fdo-session.c
@@ -24,7 +24,7 @@ fdo_session_fixture_set_up (FdoSessionFixture *fixture,
   g_autoptr (GSettings) settings = NULL;
 
   /* Disable the mock plugin */
-  settings = valent_component_new_settings ("session", "mock");
+  settings = valent_component_create_settings ("session", "mock");
   g_settings_set_boolean (settings, "enabled", FALSE);
 
   fixture->connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);

--- a/src/tests/plugins/gtk/test-gdk-clipboard.c
+++ b/src/tests/plugins/gtk/test-gdk-clipboard.c
@@ -21,7 +21,7 @@ clipboard_component_fixture_set_up (GdkClipboardFixture *fixture,
   g_autoptr (GSettings) settings = NULL;
 
   /* Disable the mock plugin */
-  settings = valent_component_new_settings ("clipboard", "mock");
+  settings = valent_component_create_settings ("clipboard", "mock");
   g_settings_set_boolean (settings, "enabled", FALSE);
 
   fixture->clipboard = valent_clipboard_get_default ();

--- a/src/tests/plugins/gtk/test-gtk-notifications.c
+++ b/src/tests/plugins/gtk/test-gtk-notifications.c
@@ -46,7 +46,7 @@ gtk_notifications_fixture_set_up (GtkNotificationsFixture *fixture,
   g_autoptr (GSettings) settings = NULL;
 
   /* Disable the mock plugin */
-  settings = valent_component_new_settings ("notifications", "mock");
+  settings = valent_component_create_settings ("notifications", "mock");
   g_settings_set_boolean (settings, "enabled", FALSE);
 
   fixture->connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, NULL);

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -39,7 +39,7 @@ mpris_adapter_fixture_set_up (MprisComponentFixture *fixture,
   g_autoptr (GSettings) settings = NULL;
 
   /* Disable the mock plugin */
-  settings = valent_component_new_settings ("media", "mock");
+  settings = valent_component_create_settings ("media", "mock");
   g_settings_set_boolean (settings, "enabled", FALSE);
 
   fixture->loop = g_main_loop_new (NULL, FALSE);

--- a/src/tests/plugins/systemvolume/test-systemvolume-plugin.c
+++ b/src/tests/plugins/systemvolume/test-systemvolume-plugin.c
@@ -20,6 +20,7 @@ mixer_info_free (gpointer data)
 
   /* NOTE: we need to finalize the mixer singleton between tests */
   v_assert_finalize_object (valent_mixer_get_default ());
+  v_await_finalize_object (info->adapter);
 
   g_clear_object (&info->sink1);
   g_clear_object (&info->sink2);
@@ -43,7 +44,7 @@ systemvolume_plugin_fixture_set_up (ValentTestFixture *fixture,
     g_main_context_iteration (NULL, FALSE);
 
   info = g_new0 (MixerInfo, 1);
-  info->adapter = adapter;
+  info->adapter = g_object_ref (adapter);
   info->sink1 = g_object_new (VALENT_TYPE_MIXER_STREAM,
                               "name",        "test_sink1",
                               "description", "Test Speakers",


### PR DESCRIPTION
* fix tear-down in component tests
* replace the `extension-added` and `extension-removed` signals with
  the virtual functions `enable_extension` and `disable_extension`
* privatize the automatic selection of the primary adapter
* rename `valent_component_new_settings()` to
  `valent_component_create_settings()`.