### PR TITLE
ci: move REUSE compliance to a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,7 @@ jobs:
       - name: Setup Linters
         run: |
           python -m pip install --upgrade pip
-          pip install codespell mypy pylint reuse yamllint
-
-      - name: Licensing (reuse)
-        if: ${{ always() }}
-        run: |
-          reuse lint
+          pip install codespell mypy pylint yamllint
 
       - name: Spelling (codespell)
         if: ${{ always() }}
@@ -47,6 +42,20 @@ jobs:
         run: |
           yamllint --config-file src/tests/extra/yamllint.yml \
                    $(git ls-files '*.yml')
+
+  reuse:
+    name: REUSE Compliance
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint
+        uses: fsfe/reuse-action@v1
+        with:
+          args: lint
 
   abicheck:
     name: ABI Compliance


### PR DESCRIPTION
There's no reason to avoid running tests for missing licensing, since
that can be fixed before merge. Allow tests to run in spite of a license
exception by running the REUSE check in parallel instead of part of the
linter check.