### PR TITLE
ValentContactStore: minor API cleanups

### DIFF
--- a/src/libvalent/contacts/valent-contact-store.h
+++ b/src/libvalent/contacts/valent-contact-store.h
@@ -28,8 +28,8 @@ struct _ValentContactStoreClass
                                           GCancellable         *cancellable,
                                           GAsyncReadyCallback   callback,
                                           gpointer              user_data);
-  void                (*remove_contact)  (ValentContactStore   *store,
-                                          const char           *uid,
+  void                (*remove_contacts) (ValentContactStore   *store,
+                                          GSList               *uids,
                                           GCancellable         *cancellable,
                                           GAsyncReadyCallback   callback,
                                           gpointer              user_data);
@@ -53,72 +53,78 @@ struct _ValentContactStoreClass
 
 
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_emit_contact_added   (ValentContactStore   *store,
-                                                        EContact             *contact);
+void         valent_contact_store_emit_contact_added     (ValentContactStore   *store,
+                                                          EContact             *contact);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_emit_contact_removed (ValentContactStore   *store,
-                                                        const char           *uid);
+void         valent_contact_store_emit_contact_removed   (ValentContactStore   *store,
+                                                          const char           *uid);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_contact_store_get_name             (ValentContactStore   *store);
+const char * valent_contact_store_get_name               (ValentContactStore   *store);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_set_name             (ValentContactStore   *store,
-                                                        const char           *name);
+void         valent_contact_store_set_name               (ValentContactStore   *store,
+                                                          const char           *name);
 VALENT_AVAILABLE_IN_1_0
-ESource    * valent_contact_store_get_source           (ValentContactStore   *store);
+ESource    * valent_contact_store_get_source             (ValentContactStore   *store);
 VALENT_AVAILABLE_IN_1_0
-const char * valent_contact_store_get_uid              (ValentContactStore   *store);
+const char * valent_contact_store_get_uid                (ValentContactStore   *store);
 
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_add_contact          (ValentContactStore   *store,
-                                                        EContact             *contact,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+void         valent_contact_store_add_contact            (ValentContactStore   *store,
+                                                          EContact             *contact,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_add_contacts         (ValentContactStore   *store,
-                                                        GSList               *contacts,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+void         valent_contact_store_add_contacts           (ValentContactStore   *store,
+                                                          GSList               *contacts,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-gboolean     valent_contact_store_add_finish           (ValentContactStore   *store,
-                                                        GAsyncResult         *result,
-                                                        GError              **error);
+gboolean     valent_contact_store_add_contacts_finish    (ValentContactStore   *store,
+                                                          GAsyncResult         *result,
+                                                          GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_remove_contact       (ValentContactStore   *store,
-                                                        const char           *uid,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+void         valent_contact_store_remove_contact         (ValentContactStore   *store,
+                                                          const char           *uid,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-gboolean     valent_contact_store_remove_finish        (ValentContactStore   *store,
-                                                        GAsyncResult         *result,
-                                                        GError              **error);
+void         valent_contact_store_remove_contacts        (ValentContactStore   *store,
+                                                          GSList               *uids,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_get_contact          (ValentContactStore   *store,
-                                                        const char           *uid,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+gboolean     valent_contact_store_remove_contacts_finish (ValentContactStore   *store,
+                                                          GAsyncResult         *result,
+                                                          GError              **error);
 VALENT_AVAILABLE_IN_1_0
-EContact   * valent_contact_store_get_contact_finish   (ValentContactStore   *store,
-                                                        GAsyncResult         *result,
-                                                        GError              **error);
+void         valent_contact_store_get_contact            (ValentContactStore   *store,
+                                                          const char           *uid,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_get_contacts         (ValentContactStore   *store,
-                                                        char                **uids,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+EContact   * valent_contact_store_get_contact_finish     (ValentContactStore   *store,
+                                                          GAsyncResult         *result,
+                                                          GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void         valent_contact_store_query                (ValentContactStore   *store,
-                                                        const char           *query,
-                                                        GCancellable         *cancellable,
-                                                        GAsyncReadyCallback   callback,
-                                                        gpointer              user_data);
+void         valent_contact_store_get_contacts           (ValentContactStore   *store,
+                                                          char                **uids,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-GSList     * valent_contact_store_query_finish         (ValentContactStore   *store,
-                                                        GAsyncResult         *result,
-                                                        GError              **error);
+void         valent_contact_store_query                  (ValentContactStore   *store,
+                                                          const char           *query,
+                                                          GCancellable         *cancellable,
+                                                          GAsyncReadyCallback   callback,
+                                                          gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
+GSList     * valent_contact_store_query_finish           (ValentContactStore   *store,
+                                                          GAsyncResult         *result,
+                                                          GError              **error);
 
 G_END_DECLS

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -267,7 +267,7 @@ valent_contact_store_add_contacts_cb (ValentContactStore *store,
 {
   g_autoptr (GError) error = NULL;
 
-  if (!valent_contact_store_add_finish (store, result, &error) &&
+  if (!valent_contact_store_add_contacts_finish (store, result, &error) &&
       !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
     g_warning ("%s(): %s", G_STRFUNC, error->message);
 }

--- a/src/plugins/eds/valent-ebook-store.c
+++ b/src/plugins/eds/valent-ebook-store.c
@@ -85,35 +85,35 @@ valent_ebook_store_remove_cb (GObject      *object,
   g_autoptr (GTask) task = G_TASK (user_data);
   GError *error = NULL;
 
-  if (!e_book_client_remove_contact_by_uid_finish (client, result, &error))
+  if (!e_book_client_remove_contacts_finish (client, result, &error))
     return g_task_return_error (task, error);
 
   g_task_return_boolean (task, TRUE);
 }
 
 static void
-valent_ebook_store_remove_contact (ValentContactStore  *store,
-                                   const char          *uid,
-                                   GCancellable        *cancellable,
-                                   GAsyncReadyCallback  callback,
-                                   gpointer             user_data)
+valent_ebook_store_remove_contacts (ValentContactStore  *store,
+                                    GSList              *uids,
+                                    GCancellable        *cancellable,
+                                    GAsyncReadyCallback  callback,
+                                    gpointer             user_data)
 {
   ValentEBookStore *self = VALENT_EBOOK_STORE (store);
   g_autoptr (GTask) task = NULL;
 
   g_assert (VALENT_IS_CONTACT_STORE (store));
-  g_assert (uid != NULL);
+  g_assert (uids != NULL);
   g_assert (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
 
   task = g_task_new (store, cancellable, callback, user_data);
-  g_task_set_source_tag (task, valent_ebook_store_remove_contact);
+  g_task_set_source_tag (task, valent_ebook_store_remove_contacts);
 
-  e_book_client_remove_contact_by_uid (self->client,
-                                       uid,
-                                       E_BOOK_OPERATION_FLAG_NONE,
-                                       cancellable,
-                                       valent_ebook_store_remove_cb,
-                                       g_steal_pointer (&task));
+  e_book_client_remove_contacts (self->client,
+                                 uids,
+                                 E_BOOK_OPERATION_FLAG_NONE,
+                                 cancellable,
+                                 valent_ebook_store_remove_cb,
+                                 g_steal_pointer (&task));
 }
 
 static void
@@ -380,7 +380,7 @@ valent_ebook_store_class_init (ValentEBookStoreClass *klass)
   object_class->set_property = valent_ebook_store_set_property;
 
   store_class->add_contacts = valent_ebook_store_add_contacts;
-  store_class->remove_contact = valent_ebook_store_remove_contact;
+  store_class->remove_contacts = valent_ebook_store_remove_contacts;
   store_class->get_contact = valent_ebook_store_get_contact;
   store_class->query = valent_ebook_store_query;
 

--- a/src/tests/libvalent/contacts/test-contacts-component.c
+++ b/src/tests/libvalent/contacts/test-contacts-component.c
@@ -75,7 +75,7 @@ add_contact_cb (ValentContactStore       *store,
 {
   GError *error = NULL;
 
-  valent_contact_store_add_finish (store, result, &error);
+  valent_contact_store_add_contacts_finish (store, result, &error);
   g_assert_no_error (error);
   g_main_loop_quit (fixture->loop);
 }
@@ -111,7 +111,7 @@ remove_contact_cb (ValentContactStore       *store,
 {
   GError *error = NULL;
 
-  valent_contact_store_remove_finish (store, result, &error);
+  valent_contact_store_remove_contacts_finish (store, result, &error);
   g_assert_no_error (error);
   g_main_loop_quit (fixture->loop);
 }

--- a/src/tests/plugins/sms/test-sms-common.h
+++ b/src/tests/plugins/sms/test-sms-common.h
@@ -32,7 +32,7 @@ valent_test_contact_store_new_cb (ValentContactStore *store,
 {
   g_autoptr (GError) error = NULL;
 
-  valent_contact_store_add_finish (store, result, &error);
+  valent_contact_store_add_contacts_finish (store, result, &error);
   g_assert_no_error (error);
   done = TRUE;
 }


### PR DESCRIPTION
* add `remove_contacts()` and refact `remove_contact()` as a wrapper
* rename `add_finish()` to `add_contacts_finish()`
* rename `remove_finish()` to` `remove_contacts_finish()`