### PR TITLE
ValentDevice: relocate download-folder setting to the share plugin

### DIFF
--- a/data/gsettings/ca.andyholmes.valent.device.gschema.xml
+++ b/data/gsettings/ca.andyholmes.valent.device.gschema.xml
@@ -10,11 +10,6 @@
       <summary>Paired</summary>
       <description>Whether the device is paired</description>
     </key>
-    <key name="download-folder" type="s">
-      <default>""</default>
-      <summary>Download folder</summary>
-      <description>Where received files are stored</description>
-    </key>
   </schema>
 </schemalist>
 

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -69,6 +69,9 @@ src/plugins/sftp/valent-sftp-preferences.c
 src/plugins/sftp/valent-sftp-preferences.ui
 src/plugins/share/share.plugin.desktop.in
 src/plugins/share/valent-share-plugin.c
+src/plugins/share/valent-share-plugin.c
+src/plugins/share/valent-share-preferences.c
+src/plugins/share/valent-share-preferences.ui
 src/plugins/sms/sms.plugin.desktop.in
 src/plugins/sms/valent-contact-row.c
 src/plugins/sms/valent-date-label.c

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2022-04-13 16:52-0700\n"
+"POT-Creation-Date: 2022-06-08 19:53-0700\n"
 "PO-Revision-Date: 2022-03-28 11:21-0700\n"
 "Last-Translator: Andy Holmes <andrew.g.r.holmes@gmail.com>\n"
 "Language-Team: English <andrew.g.r.holmes@gmail.com>\n"
@@ -24,15 +24,6 @@ msgstr ""
 
 #: data/gsettings/ca.andyholmes.valent.device.gschema.xml:11
 msgid "Whether the device is paired"
-msgstr ""
-
-#: data/gsettings/ca.andyholmes.valent.device.gschema.xml:15
-msgid "Download folder"
-msgstr ""
-
-#: data/gsettings/ca.andyholmes.valent.device.gschema.xml:16
-#: src/libvalent/ui/valent-device-preferences-window.ui:22
-msgid "Where received files are stored"
 msgstr ""
 
 #: data/gsettings/ca.andyholmes.valent.gschema.xml:10
@@ -118,17 +109,17 @@ msgstr ""
 msgid "Andy Holmes"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:504
+#: src/libvalent/core/valent-device.c:506
 #, c-format
 msgid "Pairing request from %s"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:515
+#: src/libvalent/core/valent-device.c:517
 #: src/libvalent/ui/valent-device-panel.ui:139
 msgid "Reject"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:521
+#: src/libvalent/core/valent-device.c:523
 #: src/libvalent/ui/valent-device-panel.ui:152
 msgid "Accept"
 msgstr ""
@@ -141,6 +132,7 @@ msgstr ""
 #: src/libvalent/ui/valent-device-panel.ui:19
 #: src/libvalent/ui/valent-menu-list.c:534
 #: src/libvalent/ui/valent-preferences-window.c:330
+#: src/plugins/presenter/valent-presenter-remote.ui:121
 msgid "Previous"
 msgstr ""
 
@@ -162,53 +154,24 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.c:266
-msgid "Select download folder"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.c:267
-msgid "Open"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.c:268
-#: src/plugins/notification/valent-notification-dialog.ui:13
-#: src/plugins/runcommand/valent-runcommand-editor.c:65
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/runcommand/valent-runcommand-preferences.c:394
-#: src/plugins/share/valent-share-plugin.c:100
-#: src/plugins/share/valent-share-plugin.c:223
-#: src/plugins/share/valent-share-plugin.c:325
-#: src/plugins/share/valent-share-plugin.c:465
-#: src/plugins/share/valent-share-plugin.c:629
-msgid "Cancel"
-msgstr ""
-
 #: src/libvalent/ui/valent-device-preferences-window.ui:13
 msgid "Device"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:18
-msgid "General"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.ui:21
-msgid "Download directory"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.ui:52
 msgid "Plugins"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:60
+#: src/libvalent/ui/valent-device-preferences-window.ui:26
 #: src/libvalent/ui/valent-preferences-window.ui:57
 msgid "No Plugins"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:76
+#: src/libvalent/ui/valent-device-preferences-window.ui:42
 msgid "Information"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:79
+#: src/libvalent/ui/valent-device-preferences-window.ui:45
 msgid "Mark this device as untrusted"
 msgstr ""
 
@@ -216,46 +179,46 @@ msgstr ""
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:480
+#: src/libvalent/ui/valent-preferences-window.c:486
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:487
+#: src/libvalent/ui/valent-preferences-window.c:493
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:494
+#: src/libvalent/ui/valent-preferences-window.c:500
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 #: src/plugins/clipboard/valent-clipboard-preferences.ui:8
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:501
+#: src/libvalent/ui/valent-preferences-window.c:507
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/contacts/valent-contacts-preferences.ui:8
 #: src/plugins/sms/valent-contact-row.c:266
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:508
+#: src/libvalent/ui/valent-preferences-window.c:514
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:515
+#: src/libvalent/ui/valent-preferences-window.c:521
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:522
+#: src/libvalent/ui/valent-preferences-window.c:528
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:529
+#: src/libvalent/ui/valent-preferences-window.c:535
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:8
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:536
+#: src/libvalent/ui/valent-preferences-window.c:542
 msgid "Session Manager"
 msgstr ""
 
@@ -567,36 +530,39 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:27
-#: src/plugins/mousepad/valent-mousepad-plugin.c:435
+#: src/plugins/mousepad/valent-mousepad-plugin.c:516
 msgid "Remote Input"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:136
+#: src/plugins/mousepad/valent-mousepad-remote.ui:8
+msgid "Input Remote"
+msgstr ""
+
+#: src/plugins/mousepad/valent-mousepad-remote.ui:142
 msgid "Drag one finger to move"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:145
+#: src/plugins/mousepad/valent-mousepad-remote.ui:151
 msgid "Drag two fingers to scroll"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:154
+#: src/plugins/mousepad/valent-mousepad-remote.ui:160
 msgid "Tap one finger to click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:164
+#: src/plugins/mousepad/valent-mousepad-remote.ui:170
 msgid "Tap two fingers to right click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:173
+#: src/plugins/mousepad/valent-mousepad-remote.ui:179
 msgid "Tap three fingers to middle click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:182
+#: src/plugins/mousepad/valent-mousepad-remote.ui:188
 msgid "Hold one finger to grab"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:192
+#: src/plugins/mousepad/valent-mousepad-remote.ui:198
 msgid "Tap one finger to ungrab"
 msgstr ""
 
@@ -618,6 +584,20 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:10
 msgid "Notification"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:13
+#: src/plugins/presenter/valent-presenter-remote.c:91
+#: src/plugins/runcommand/valent-runcommand-editor.c:65
+#: src/plugins/runcommand/valent-runcommand-editor.ui:12
+#: src/plugins/runcommand/valent-runcommand-preferences.c:394
+#: src/plugins/share/valent-share-plugin.c:132
+#: src/plugins/share/valent-share-plugin.c:255
+#: src/plugins/share/valent-share-plugin.c:357
+#: src/plugins/share/valent-share-plugin.c:497
+#: src/plugins/share/valent-share-plugin.c:661
+#: src/plugins/share/valent-share-preferences.c:111
+msgid "Cancel"
 msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:18
@@ -658,14 +638,14 @@ msgid "Failed to receive “%s” from %s"
 msgstr ""
 
 #: src/plugins/photo/valent-photo-plugin.c:57
-#: src/plugins/share/valent-share-plugin.c:84
-#: src/plugins/share/valent-share-plugin.c:210
-#: src/plugins/share/valent-share-plugin.c:312
-#: src/plugins/share/valent-share-plugin.c:449
+#: src/plugins/share/valent-share-plugin.c:116
+#: src/plugins/share/valent-share-plugin.c:242
+#: src/plugins/share/valent-share-plugin.c:344
+#: src/plugins/share/valent-share-plugin.c:481
 msgid "Transfer Failed"
 msgstr ""
 
-#: src/plugins/photo/valent-photo-plugin.c:134
+#: src/plugins/photo/valent-photo-plugin.c:136
 msgid "Take Photo"
 msgstr ""
 
@@ -680,6 +660,53 @@ msgstr ""
 
 #: src/plugins/ping/valent-ping-plugin.c:36
 msgid "Ping!"
+msgstr ""
+
+#: src/plugins/presenter/presenter.plugin.desktop.in:7
+msgid "Presenter"
+msgstr ""
+
+#: src/plugins/presenter/presenter.plugin.desktop.in:8
+msgid "Control presentations"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-remote.ui:8
+msgid "Presentation Remote"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:89
+msgid "Select Presentation"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.ui:81
+#: src/plugins/share/valent-share-preferences.c:110
+msgid "Open"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:100
+msgid "Presentations"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:108
+msgid "All Files"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:64
+msgid "Start"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:100
+msgid "Stop"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:146
+msgid "Next"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:169
+msgid "Pointer"
 msgstr ""
 
 #: src/plugins/pulseaudio/pulseaudio.plugin.desktop.in:7
@@ -812,87 +839,108 @@ msgid "Port"
 msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
-#: src/plugins/share/valent-share-plugin.c:628
+#: src/plugins/share/valent-share-plugin.c:660
+#: src/plugins/share/valent-share-preferences.ui:8
 msgid "Share"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:66
-#: src/plugins/share/valent-share-plugin.c:431
+#: src/plugins/share/valent-share-plugin.c:98
+#: src/plugins/share/valent-share-plugin.c:463
 msgid "Transferring Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:67
-#: src/plugins/share/valent-share-plugin.c:85
+#: src/plugins/share/valent-share-plugin.c:99
+#: src/plugins/share/valent-share-plugin.c:117
 #, c-format
 msgid "Receiving one file from %1$s"
 msgid_plural "Receiving %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:75
-#: src/plugins/share/valent-share-plugin.c:306
-#: src/plugins/share/valent-share-plugin.c:440
+#: src/plugins/share/valent-share-plugin.c:107
+#: src/plugins/share/valent-share-plugin.c:338
+#: src/plugins/share/valent-share-plugin.c:472
 msgid "Transfer Complete"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:76
+#: src/plugins/share/valent-share-plugin.c:108
 #, c-format
 msgid "Received one file from %1$s"
 msgid_plural "Received %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:118
+#: src/plugins/share/valent-share-plugin.c:150
 msgid "Open Folder"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:129
+#: src/plugins/share/valent-share-plugin.c:161
 msgid "Open File"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:200
-#: src/plugins/share/valent-share-plugin.c:300
+#: src/plugins/share/valent-share-plugin.c:232
+#: src/plugins/share/valent-share-plugin.c:332
 msgid "Transferring File"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:201
-#: src/plugins/share/valent-share-plugin.c:211
+#: src/plugins/share/valent-share-plugin.c:233
+#: src/plugins/share/valent-share-plugin.c:243
 #, c-format
 msgid "Opening “%s” from %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:301
-#: src/plugins/share/valent-share-plugin.c:313
+#: src/plugins/share/valent-share-plugin.c:333
+#: src/plugins/share/valent-share-plugin.c:345
 #, c-format
 msgid "Opening “%s” on %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:307
+#: src/plugins/share/valent-share-plugin.c:339
 #, c-format
 msgid "Opened “%s” on %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:432
-#: src/plugins/share/valent-share-plugin.c:450
+#: src/plugins/share/valent-share-plugin.c:464
+#: src/plugins/share/valent-share-plugin.c:482
 #, c-format
 msgid "Sending one file to %1$s"
 msgid_plural "Sending %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:441
+#: src/plugins/share/valent-share-plugin.c:473
 #, c-format
 msgid "Sent one file to %1$s"
 msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:627
+#: src/plugins/share/valent-share-plugin.c:659
 msgid "Share Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:870
+#: src/plugins/share/valent-share-plugin.c:902
 msgid "Send Files"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.c:109
+msgid "Select download folder"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:12
+msgid "Received Files"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:13
+msgid "Control how received files are handled."
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:16
+msgid "Download directory"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:17
+msgid "Where received files are stored"
 msgstr ""
 
 #: src/plugins/sms/sms.plugin.desktop.in:7
@@ -942,13 +990,13 @@ msgid_plural "%d mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/sms/valent-sms-conversation.c:924
-#: src/plugins/sms/valent-sms-window.c:601
-#: src/plugins/sms/valent-sms-window.c:906
+#: src/plugins/sms/valent-sms-conversation.c:925
+#: src/plugins/sms/valent-sms-window.c:604
+#: src/plugins/sms/valent-sms-window.c:909
 msgid "New Conversation"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-conversation.c:941
+#: src/plugins/sms/valent-sms-conversation.c:942
 #, c-format
 msgid "%u other contact"
 msgid_plural "%u others"
@@ -963,21 +1011,21 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-plugin.c:436
+#: src/plugins/sms/valent-sms-plugin.c:442
 msgid "Messaging"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:186
+#: src/plugins/sms/valent-sms-window.c:187
 msgid "Conversations"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:311
+#: src/plugins/sms/valent-sms-window.c:312
 #, c-format
 msgid "Send to %s"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:628
-#: src/plugins/sms/valent-sms-window.c:928
+#: src/plugins/sms/valent-sms-window.c:631
+#: src/plugins/sms/valent-sms-window.c:931
 msgid "Search Messages"
 msgstr ""
 

--- a/po/valent.pot
+++ b/po/valent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2022-04-13 16:52-0700\n"
+"POT-Creation-Date: 2022-06-08 19:53-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,15 +24,6 @@ msgstr ""
 
 #: data/gsettings/ca.andyholmes.valent.device.gschema.xml:11
 msgid "Whether the device is paired"
-msgstr ""
-
-#: data/gsettings/ca.andyholmes.valent.device.gschema.xml:15
-msgid "Download folder"
-msgstr ""
-
-#: data/gsettings/ca.andyholmes.valent.device.gschema.xml:16
-#: src/libvalent/ui/valent-device-preferences-window.ui:22
-msgid "Where received files are stored"
 msgstr ""
 
 #: data/gsettings/ca.andyholmes.valent.gschema.xml:10
@@ -118,17 +109,17 @@ msgstr ""
 msgid "Andy Holmes"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:504
+#: src/libvalent/core/valent-device.c:506
 #, c-format
 msgid "Pairing request from %s"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:515
+#: src/libvalent/core/valent-device.c:517
 #: src/libvalent/ui/valent-device-panel.ui:139
 msgid "Reject"
 msgstr ""
 
-#: src/libvalent/core/valent-device.c:521
+#: src/libvalent/core/valent-device.c:523
 #: src/libvalent/ui/valent-device-panel.ui:152
 msgid "Accept"
 msgstr ""
@@ -141,6 +132,7 @@ msgstr ""
 #: src/libvalent/ui/valent-device-panel.ui:19
 #: src/libvalent/ui/valent-menu-list.c:534
 #: src/libvalent/ui/valent-preferences-window.c:330
+#: src/plugins/presenter/valent-presenter-remote.ui:121
 msgid "Previous"
 msgstr ""
 
@@ -162,53 +154,24 @@ msgstr ""
 msgid "Disconnected"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.c:266
-msgid "Select download folder"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.c:267
-msgid "Open"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.c:268
-#: src/plugins/notification/valent-notification-dialog.ui:13
-#: src/plugins/runcommand/valent-runcommand-editor.c:65
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/runcommand/valent-runcommand-preferences.c:394
-#: src/plugins/share/valent-share-plugin.c:100
-#: src/plugins/share/valent-share-plugin.c:223
-#: src/plugins/share/valent-share-plugin.c:325
-#: src/plugins/share/valent-share-plugin.c:465
-#: src/plugins/share/valent-share-plugin.c:629
-msgid "Cancel"
-msgstr ""
-
 #: src/libvalent/ui/valent-device-preferences-window.ui:13
 msgid "Device"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:18
-msgid "General"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.ui:21
-msgid "Download directory"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-preferences-window.ui:52
 msgid "Plugins"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:60
+#: src/libvalent/ui/valent-device-preferences-window.ui:26
 #: src/libvalent/ui/valent-preferences-window.ui:57
 msgid "No Plugins"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:76
+#: src/libvalent/ui/valent-device-preferences-window.ui:42
 msgid "Information"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-preferences-window.ui:79
+#: src/libvalent/ui/valent-device-preferences-window.ui:45
 msgid "Mark this device as untrusted"
 msgstr ""
 
@@ -216,46 +179,46 @@ msgstr ""
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:480
+#: src/libvalent/ui/valent-preferences-window.c:486
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:487
+#: src/libvalent/ui/valent-preferences-window.c:493
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:494
+#: src/libvalent/ui/valent-preferences-window.c:500
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 #: src/plugins/clipboard/valent-clipboard-preferences.ui:8
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:501
+#: src/libvalent/ui/valent-preferences-window.c:507
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/contacts/valent-contacts-preferences.ui:8
 #: src/plugins/sms/valent-contact-row.c:266
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:508
+#: src/libvalent/ui/valent-preferences-window.c:514
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:515
+#: src/libvalent/ui/valent-preferences-window.c:521
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:522
+#: src/libvalent/ui/valent-preferences-window.c:528
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:529
+#: src/libvalent/ui/valent-preferences-window.c:535
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:8
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:536
+#: src/libvalent/ui/valent-preferences-window.c:542
 msgid "Session Manager"
 msgstr ""
 
@@ -567,36 +530,39 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:27
-#: src/plugins/mousepad/valent-mousepad-plugin.c:435
+#: src/plugins/mousepad/valent-mousepad-plugin.c:516
 msgid "Remote Input"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:136
+#: src/plugins/mousepad/valent-mousepad-remote.ui:8
+msgid "Input Remote"
+msgstr ""
+
+#: src/plugins/mousepad/valent-mousepad-remote.ui:142
 msgid "Drag one finger to move"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:145
+#: src/plugins/mousepad/valent-mousepad-remote.ui:151
 msgid "Drag two fingers to scroll"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:154
+#: src/plugins/mousepad/valent-mousepad-remote.ui:160
 msgid "Tap one finger to click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:164
+#: src/plugins/mousepad/valent-mousepad-remote.ui:170
 msgid "Tap two fingers to right click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:173
+#: src/plugins/mousepad/valent-mousepad-remote.ui:179
 msgid "Tap three fingers to middle click"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:182
+#: src/plugins/mousepad/valent-mousepad-remote.ui:188
 msgid "Hold one finger to grab"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-dialog.ui:192
+#: src/plugins/mousepad/valent-mousepad-remote.ui:198
 msgid "Tap one finger to ungrab"
 msgstr ""
 
@@ -618,6 +584,20 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:10
 msgid "Notification"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:13
+#: src/plugins/presenter/valent-presenter-remote.c:91
+#: src/plugins/runcommand/valent-runcommand-editor.c:65
+#: src/plugins/runcommand/valent-runcommand-editor.ui:12
+#: src/plugins/runcommand/valent-runcommand-preferences.c:394
+#: src/plugins/share/valent-share-plugin.c:132
+#: src/plugins/share/valent-share-plugin.c:255
+#: src/plugins/share/valent-share-plugin.c:357
+#: src/plugins/share/valent-share-plugin.c:497
+#: src/plugins/share/valent-share-plugin.c:661
+#: src/plugins/share/valent-share-preferences.c:111
+msgid "Cancel"
 msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:18
@@ -658,14 +638,14 @@ msgid "Failed to receive “%s” from %s"
 msgstr ""
 
 #: src/plugins/photo/valent-photo-plugin.c:57
-#: src/plugins/share/valent-share-plugin.c:84
-#: src/plugins/share/valent-share-plugin.c:210
-#: src/plugins/share/valent-share-plugin.c:312
-#: src/plugins/share/valent-share-plugin.c:449
+#: src/plugins/share/valent-share-plugin.c:116
+#: src/plugins/share/valent-share-plugin.c:242
+#: src/plugins/share/valent-share-plugin.c:344
+#: src/plugins/share/valent-share-plugin.c:481
 msgid "Transfer Failed"
 msgstr ""
 
-#: src/plugins/photo/valent-photo-plugin.c:134
+#: src/plugins/photo/valent-photo-plugin.c:136
 msgid "Take Photo"
 msgstr ""
 
@@ -680,6 +660,53 @@ msgstr ""
 
 #: src/plugins/ping/valent-ping-plugin.c:36
 msgid "Ping!"
+msgstr ""
+
+#: src/plugins/presenter/presenter.plugin.desktop.in:7
+msgid "Presenter"
+msgstr ""
+
+#: src/plugins/presenter/presenter.plugin.desktop.in:8
+msgid "Control presentations"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-remote.ui:8
+msgid "Presentation Remote"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:89
+msgid "Select Presentation"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.ui:81
+#: src/plugins/share/valent-share-preferences.c:110
+msgid "Open"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:100
+msgid "Presentations"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.c:108
+msgid "All Files"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:64
+msgid "Start"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:100
+msgid "Stop"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:146
+msgid "Next"
+msgstr ""
+
+#: src/plugins/presenter/valent-presenter-remote.ui:169
+msgid "Pointer"
 msgstr ""
 
 #: src/plugins/pulseaudio/pulseaudio.plugin.desktop.in:7
@@ -812,87 +839,108 @@ msgid "Port"
 msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
-#: src/plugins/share/valent-share-plugin.c:628
+#: src/plugins/share/valent-share-plugin.c:660
+#: src/plugins/share/valent-share-preferences.ui:8
 msgid "Share"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:66
-#: src/plugins/share/valent-share-plugin.c:431
+#: src/plugins/share/valent-share-plugin.c:98
+#: src/plugins/share/valent-share-plugin.c:463
 msgid "Transferring Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:67
-#: src/plugins/share/valent-share-plugin.c:85
+#: src/plugins/share/valent-share-plugin.c:99
+#: src/plugins/share/valent-share-plugin.c:117
 #, c-format
 msgid "Receiving one file from %1$s"
 msgid_plural "Receiving %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:75
-#: src/plugins/share/valent-share-plugin.c:306
-#: src/plugins/share/valent-share-plugin.c:440
+#: src/plugins/share/valent-share-plugin.c:107
+#: src/plugins/share/valent-share-plugin.c:338
+#: src/plugins/share/valent-share-plugin.c:472
 msgid "Transfer Complete"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:76
+#: src/plugins/share/valent-share-plugin.c:108
 #, c-format
 msgid "Received one file from %1$s"
 msgid_plural "Received %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:118
+#: src/plugins/share/valent-share-plugin.c:150
 msgid "Open Folder"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:129
+#: src/plugins/share/valent-share-plugin.c:161
 msgid "Open File"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:200
-#: src/plugins/share/valent-share-plugin.c:300
+#: src/plugins/share/valent-share-plugin.c:232
+#: src/plugins/share/valent-share-plugin.c:332
 msgid "Transferring File"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:201
-#: src/plugins/share/valent-share-plugin.c:211
+#: src/plugins/share/valent-share-plugin.c:233
+#: src/plugins/share/valent-share-plugin.c:243
 #, c-format
 msgid "Opening “%s” from %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:301
-#: src/plugins/share/valent-share-plugin.c:313
+#: src/plugins/share/valent-share-plugin.c:333
+#: src/plugins/share/valent-share-plugin.c:345
 #, c-format
 msgid "Opening “%s” on %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:307
+#: src/plugins/share/valent-share-plugin.c:339
 #, c-format
 msgid "Opened “%s” on %s"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:432
-#: src/plugins/share/valent-share-plugin.c:450
+#: src/plugins/share/valent-share-plugin.c:464
+#: src/plugins/share/valent-share-plugin.c:482
 #, c-format
 msgid "Sending one file to %1$s"
 msgid_plural "Sending %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:441
+#: src/plugins/share/valent-share-plugin.c:473
 #, c-format
 msgid "Sent one file to %1$s"
 msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:627
+#: src/plugins/share/valent-share-plugin.c:659
 msgid "Share Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:870
+#: src/plugins/share/valent-share-plugin.c:902
 msgid "Send Files"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.c:109
+msgid "Select download folder"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:12
+msgid "Received Files"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:13
+msgid "Control how received files are handled."
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:16
+msgid "Download directory"
+msgstr ""
+
+#: src/plugins/share/valent-share-preferences.ui:17
+msgid "Where received files are stored"
 msgstr ""
 
 #: src/plugins/sms/sms.plugin.desktop.in:7
@@ -942,13 +990,13 @@ msgid_plural "%d mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/sms/valent-sms-conversation.c:924
-#: src/plugins/sms/valent-sms-window.c:601
-#: src/plugins/sms/valent-sms-window.c:906
+#: src/plugins/sms/valent-sms-conversation.c:925
+#: src/plugins/sms/valent-sms-window.c:604
+#: src/plugins/sms/valent-sms-window.c:909
 msgid "New Conversation"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-conversation.c:941
+#: src/plugins/sms/valent-sms-conversation.c:942
 #, c-format
 msgid "%u other contact"
 msgid_plural "%u others"
@@ -963,21 +1011,21 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-plugin.c:436
+#: src/plugins/sms/valent-sms-plugin.c:442
 msgid "Messaging"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:186
+#: src/plugins/sms/valent-sms-window.c:187
 msgid "Conversations"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:311
+#: src/plugins/sms/valent-sms-window.c:312
 #, c-format
 msgid "Send to %s"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-window.c:628
-#: src/plugins/sms/valent-sms-window.c:928
+#: src/plugins/sms/valent-sms-window.c:631
+#: src/plugins/sms/valent-sms-window.c:931
 msgid "Search Messages"
 msgstr ""
 

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -81,10 +81,6 @@ VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_send_packet_finish (ValentDevice         *device,
                                                       GAsyncResult         *result,
                                                       GError              **error);
-VALENT_AVAILABLE_IN_1_0
-GFile             * valent_device_new_download_file  (ValentDevice         *device,
-                                                      const char           *filename,
-                                                      gboolean              unique);
 
 G_END_DECLS
 

--- a/src/libvalent/ui/valent-device-preferences-window.ui
+++ b/src/libvalent/ui/valent-device-preferences-window.ui
@@ -14,40 +14,6 @@
         <property name="icon-name">phone-symbolic</property>
         <property name="vexpand">1</property>
         <child>
-          <object class="AdwPreferencesGroup" id="general_group">
-            <property name="title" translatable="yes">General</property>
-            <child>
-              <object class="AdwActionRow">
-                <property name="title" translatable="yes">Download directory</property>
-                <property name="subtitle" translatable="yes">Where received files are stored</property>
-                <property name="activatable">1</property>
-                <property name="action-name">win.select-download-folder</property>
-                <child type="suffix">
-                  <object class="GtkBox">
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="download_folder_label">
-                        <property name="ellipsize">start</property>
-                        <property name="max-width-chars">16</property>
-                        <property name="valign">center</property>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="icon-name">folder-symbolic</property>
-                        <property name="valign">center</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="AdwPreferencesGroup" id="plugin_group">
             <property name="title" translatable="yes">Plugins</property>
             <child>

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -68,6 +68,7 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
   g_autoptr (ValentTransfer) transfer = NULL;
   g_autoptr (GCancellable) cancellable = NULL;
   g_autoptr (GFile) file = NULL;
+  g_autofree char *directory = NULL;
   ValentDevice *device;
   const char *filename;
 
@@ -89,7 +90,8 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
 
   device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
   cancellable = valent_object_ref_cancellable (VALENT_OBJECT (self));
-  file = valent_device_new_download_file (device, filename, TRUE);
+  directory = valent_data_get_directory (G_USER_DIRECTORY_PICTURES);
+  file = valent_data_get_file (directory, filename, TRUE);
 
   /* Create a new transfer */
   transfer = valent_device_transfer_new_for_file (device, packet, file);

--- a/src/plugins/share/ca.andyholmes.valent.share.gschema.xml
+++ b/src/plugins/share/ca.andyholmes.valent.share.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2022 Andy Holmes <andrew.g.r.holmes@gmail.com> -->
+
+<schemalist gettext-domain="valent">
+  <schema id="ca.andyholmes.valent.share">
+    <key name="download-folder" type="s">
+      <default>""</default>
+      <summary>Download folder</summary>
+      <description>Where received files are stored</description>
+    </key>
+  </schema>
+</schemalist>
+

--- a/src/plugins/share/meson.build
+++ b/src/plugins/share/meson.build
@@ -4,7 +4,7 @@
 # Dependencies
 plugin_share_deps = [
   libvalent_core_dep,
-  gtk_dep,
+  libvalent_ui_dep,
 ]
 
 # Sources
@@ -12,6 +12,7 @@ plugin_share_sources = files([
   'share-plugin.c',
   'valent-share-download.c',
   'valent-share-plugin.c',
+  'valent-share-preferences.c',
   'valent-share-upload.c',
 ])
 
@@ -31,6 +32,11 @@ plugin_share_resources = gnome.compile_resources('share-resources',
   dependencies: [plugin_share_info],
 )
 plugin_share_sources += plugin_share_resources
+
+# Settings
+install_data('ca.andyholmes.valent.share.gschema.xml',
+  install_dir: schemadir
+)
 
 # Static Build
 plugin_share = static_library('plugin-share',

--- a/src/plugins/share/share-plugin.c
+++ b/src/plugins/share/share-plugin.c
@@ -7,6 +7,7 @@
 #include <libvalent-core.h>
 
 #include "valent-share-plugin.h"
+#include "valent-share-preferences.h"
 
 
 G_MODULE_EXPORT void
@@ -15,5 +16,8 @@ valent_share_plugin_register_types (PeasObjectModule *module)
   peas_object_module_register_extension_type (module,
                                               VALENT_TYPE_DEVICE_PLUGIN,
                                               VALENT_TYPE_SHARE_PLUGIN);
+  peas_object_module_register_extension_type (module,
+                                              VALENT_TYPE_DEVICE_PREFERENCES_PAGE,
+                                              VALENT_TYPE_SHARE_PREFERENCES);
 }
 

--- a/src/plugins/share/share.gresource.xml
+++ b/src/plugins/share/share.gresource.xml
@@ -6,6 +6,7 @@
 <gresources>
   <gresource prefix="/plugins/share">
     <file>share.plugin</file>
+    <file preprocess="xml-stripblanks">valent-share-preferences.ui</file>
   </gresource>
   <gresource prefix="/ca/andyholmes/Valent/icons">
     <file preprocess="xml-stripblanks" alias="scalable/actions/document-send-symbolic.svg">data/document-send-symbolic.svg</file>

--- a/src/plugins/share/valent-share-preferences.c
+++ b/src/plugins/share/valent-share-preferences.c
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#define G_LOG_DOMAIN "valent-share-preferences"
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+#include <libvalent-core.h>
+#include <libvalent-ui.h>
+
+#include "valent-share-preferences.h"
+
+
+struct _ValentSharePreferences
+{
+  AdwPreferencesPage   parent_instance;
+
+  char                *device_id;
+  PeasPluginInfo      *plugin_info;
+  GSettings           *settings;
+
+  /* Template widgets */
+  AdwPreferencesGroup *download_group;
+  GtkLabel            *download_folder_label;
+};
+
+/* Interfaces */
+static void valent_device_preferences_page_iface_init (ValentDevicePreferencesPageInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (ValentSharePreferences, valent_share_preferences, ADW_TYPE_PREFERENCES_PAGE,
+                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_PREFERENCES_PAGE, valent_device_preferences_page_iface_init))
+
+
+enum {
+  PROP_0,
+  PROP_DEVICE_ID,
+  PROP_PLUGIN_INFO,
+  N_PROPERTIES
+};
+
+
+/*
+ * ValentDevicePreferencesPage
+ */
+static void
+valent_device_preferences_page_iface_init (ValentDevicePreferencesPageInterface *iface)
+{
+}
+
+/*
+ * Download Folder
+ */
+static gboolean
+on_download_folder_changed (GValue   *value,
+                            GVariant *variant,
+                            gpointer  user_data)
+{
+  const char *label;
+  g_autofree char *basename = NULL;
+  g_autofree char *result = NULL;
+
+  label = g_variant_get_string (variant, NULL);
+  basename = g_path_get_basename (label);
+  result = g_strdup_printf ("…/%s", basename);
+
+  g_value_set_string (value, result);
+
+  return TRUE;
+}
+
+static void
+on_download_folder_response (GtkNativeDialog        *dialog,
+                             int                     response_id,
+                             ValentSharePreferences *self)
+{
+  g_autoptr (GFile) file = NULL;
+
+  g_assert (VALENT_IS_SHARE_PREFERENCES (self));
+
+  if (response_id == GTK_RESPONSE_ACCEPT)
+    {
+      const char *path;
+
+      file = gtk_file_chooser_get_file (GTK_FILE_CHOOSER (dialog));
+      path = g_file_peek_path (file);
+      g_settings_set_string (self->settings, "download-folder", path);
+    }
+
+  gtk_native_dialog_destroy (dialog);
+}
+
+/*
+ * GActions
+ */
+static void
+select_download_folder_action (GtkWidget  *widget,
+                               const char *action_name,
+                               GVariant   *parameter)
+{
+  ValentSharePreferences *self = VALENT_SHARE_PREFERENCES (widget);
+  GtkNativeDialog *dialog;
+  g_autofree char *path = NULL;
+
+  g_assert (VALENT_IS_SHARE_PREFERENCES (self));
+
+  dialog = g_object_new (GTK_TYPE_FILE_CHOOSER_NATIVE,
+                         "action",        GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+                         "title",         _("Select download folder"),
+                         "accept-label",  _("Open"),
+                         "cancel-label",  _("Cancel"),
+                         "modal",         TRUE,
+                         "transient-for", gtk_widget_get_root (widget),
+                         NULL);
+
+  path = g_settings_get_string (self->settings, "download-folder");
+
+  if (strlen (path) > 0)
+    {
+      g_autoptr (GFile) file = NULL;
+
+      file = g_file_new_for_path (path);
+      gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog),
+                                           file, NULL);
+    }
+
+  g_signal_connect (dialog,
+                    "response",
+                    G_CALLBACK (on_download_folder_response),
+                    self);
+
+  gtk_native_dialog_show (dialog);
+}
+
+/*
+ * GObject
+ */
+static void
+valent_share_preferences_constructed (GObject *object)
+{
+  ValentSharePreferences *self = VALENT_SHARE_PREFERENCES (object);
+  g_autofree char *download_folder = NULL;
+
+  /* Setup GSettings */
+  self->settings = valent_device_plugin_new_settings (self->device_id, "share");
+  download_folder = g_settings_get_string (self->settings, "download-folder");
+
+  if (strlen (download_folder) == 0)
+    {
+      g_clear_pointer (&download_folder, g_free);
+      download_folder = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
+      g_settings_set_string (self->settings, "download-folder", download_folder);
+    }
+
+  g_settings_bind_with_mapping (self->settings,              "download-folder",
+                                self->download_folder_label, "label",
+                                G_SETTINGS_BIND_GET,
+                                on_download_folder_changed,
+                                NULL,
+                                NULL, NULL);
+
+  G_OBJECT_CLASS (valent_share_preferences_parent_class)->constructed (object);
+}
+
+static void
+valent_share_preferences_finalize (GObject *object)
+{
+  ValentSharePreferences *self = VALENT_SHARE_PREFERENCES (object);
+
+  g_clear_pointer (&self->device_id, g_free);
+  g_clear_object (&self->settings);
+
+  G_OBJECT_CLASS (valent_share_preferences_parent_class)->finalize (object);
+}
+
+static void
+valent_share_preferences_get_property (GObject    *object,
+                                           guint       prop_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  ValentSharePreferences *self = VALENT_SHARE_PREFERENCES (object);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE_ID:
+      g_value_set_string (value, self->device_id);
+      break;
+
+    case PROP_PLUGIN_INFO:
+      g_value_set_boxed (value, self->plugin_info);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_share_preferences_set_property (GObject      *object,
+                                           guint         prop_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  ValentSharePreferences *self = VALENT_SHARE_PREFERENCES (object);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE_ID:
+      self->device_id = g_value_dup_string (value);
+      break;
+
+    case PROP_PLUGIN_INFO:
+      self->plugin_info = g_value_get_boxed (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_share_preferences_class_init (ValentSharePreferencesClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->constructed = valent_share_preferences_constructed;
+  object_class->finalize = valent_share_preferences_finalize;
+  object_class->get_property = valent_share_preferences_get_property;
+  object_class->set_property = valent_share_preferences_set_property;
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/plugins/share/valent-share-preferences.ui");
+  gtk_widget_class_bind_template_child (widget_class, ValentSharePreferences, download_group);
+  gtk_widget_class_bind_template_child (widget_class, ValentSharePreferences, download_folder_label);
+  gtk_widget_class_install_action (widget_class, "preferences.select-download-folder", NULL, select_download_folder_action);
+
+  g_object_class_override_property (object_class, PROP_DEVICE_ID, "device-id");
+  g_object_class_override_property (object_class, PROP_PLUGIN_INFO, "plugin-info");
+}
+
+static void
+valent_share_preferences_init (ValentSharePreferences *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+}
+

--- a/src/plugins/share/valent-share-preferences.h
+++ b/src/plugins/share/valent-share-preferences.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#include <gtk/gtk.h>
+#include <libvalent-core.h>
+#include <libvalent-ui.h>
+
+G_BEGIN_DECLS
+
+#define VALENT_TYPE_SHARE_PREFERENCES (valent_share_preferences_get_type())
+
+G_DECLARE_FINAL_TYPE (ValentSharePreferences, valent_share_preferences, VALENT, SHARE_PREFERENCES, AdwPreferencesPage)
+
+G_END_DECLS

--- a/src/plugins/share/valent-share-preferences.ui
+++ b/src/plugins/share/valent-share-preferences.ui
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com> -->
+
+<interface domain="valent">
+  <template class="ValentSharePreferences" parent="AdwPreferencesPage">
+    <property name="title" translatable="yes">Share</property>
+    <property name="icon-name">valent-share-plugin-symbolic</property>
+    <child>
+      <object class="AdwPreferencesGroup" id="download_group">
+        <property name="title" translatable="yes">Received Files</property>
+        <property name="description" translatable="yes">Control how received files are handled.</property>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Download directory</property>
+            <property name="subtitle" translatable="yes">Where received files are stored</property>
+            <property name="activatable">1</property>
+            <property name="action-name">preferences.select-download-folder</property>
+            <child type="suffix">
+              <object class="GtkBox">
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="download_folder_label">
+                    <property name="ellipsize">start</property>
+                    <property name="max-width-chars">16</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkImage">
+                    <property name="icon-name">folder-symbolic</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/tests/libvalent/core/test-device-transfer.c
+++ b/src/tests/libvalent/core/test-device-transfer.c
@@ -14,6 +14,7 @@ test_device_transfer (ValentTestFixture *fixture,
   g_autoptr (GFileInfo) src_info = NULL;
   g_autoptr (GFile) dest = NULL;
   g_autoptr (GFileInfo) dest_info = NULL;
+  g_autofree char *dest_dir = NULL;
   JsonNode *packet = NULL;
   guint64 src_btime_s, src_mtime_s, dest_mtime_s;
   guint32 src_btime_us, src_mtime_us, dest_mtime_us;
@@ -57,7 +58,8 @@ test_device_transfer (ValentTestFixture *fixture,
   /* Ensure the download task has time to set the file mtime */
   valent_test_fixture_wait (fixture, 1);
 
-  dest = valent_device_new_download_file (fixture->device, "image.png", FALSE);
+  dest_dir = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
+  dest = valent_data_get_file (dest_dir, "image.png", FALSE);
   dest_info = g_file_query_info (dest,
                                  G_FILE_ATTRIBUTE_TIME_MODIFIED","
                                  G_FILE_ATTRIBUTE_TIME_MODIFIED_USEC","

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -122,8 +122,6 @@ static void
 test_device_new (void)
 {
   ValentDevice *device = NULL;
-  g_autoptr (GFile) file = NULL;
-  g_autofree char *basename = NULL;
   g_autofree char *icon_name = NULL;
   g_autofree char *id = NULL;
   g_autofree char *name = NULL;
@@ -163,13 +161,6 @@ test_device_new (void)
   plugins = valent_device_get_plugins (device);
   g_assert_cmpuint (plugins->len, ==, 1);
   g_ptr_array_unref (plugins);
-
-  /* Download files should be creatable */
-  file = valent_device_new_download_file (device, "test-file", FALSE);
-  g_assert_true (G_IS_FILE (file));
-
-  basename = g_file_get_basename (file);
-  g_assert_cmpstr (basename, ==, "test-file");
 
   v_assert_finalize_object (device);
 }

--- a/src/tests/libvalent/ui/test-device-preferences-window.c
+++ b/src/tests/libvalent/ui/test-device-preferences-window.c
@@ -75,34 +75,6 @@ test_device_preference_window_navigation (ValentTestFixture *fixture,
   g_assert_null (window);
 }
 
-static void
-test_device_preference_window_select_download_folder (ValentTestFixture *fixture,
-                                                      gconstpointer      user_data)
-{
-  GtkWindow *window;
-
-  g_test_skip ("Settings schema 'org.gtk.gtk4.Settings.FileChooser' is not installed");
-  return;
-
-  window = g_object_new (VALENT_TYPE_DEVICE_PREFERENCES_WINDOW,
-                         "device", fixture->device,
-                         NULL);
-  g_assert_true (VALENT_IS_DEVICE_PREFERENCES_WINDOW (window));
-
-  gtk_window_present (window);
-
-  while (g_main_context_iteration (NULL, FALSE))
-    continue;
-
-  /* Rename Dialog */
-  gtk_widget_activate_action (GTK_WIDGET (window), "win.select-download-folder", NULL);
-
-  while (g_main_context_iteration (NULL, FALSE))
-    continue;
-
-  g_clear_pointer (&window, gtk_window_destroy);
-}
-
 int
 main (int   argc,
       char *argv[])
@@ -121,12 +93,6 @@ main (int   argc,
               ValentTestFixture, path,
               valent_test_fixture_init,
               test_device_preference_window_navigation,
-              valent_test_fixture_clear);
-
-  g_test_add ("/libvalent/ui/device-preferences-window/select-download-folder",
-              ValentTestFixture, path,
-              valent_test_fixture_init,
-              test_device_preference_window_select_download_folder,
               valent_test_fixture_clear);
 
   return g_test_run ();

--- a/src/tests/plugins/share/meson.build
+++ b/src/tests/plugins/share/meson.build
@@ -10,6 +10,7 @@ plugin_share_test_deps = [
 plugin_runcommand_tests = [
   'test-share-download',
   'test-share-plugin',
+  'test-share-preferences',
   'test-share-upload',
 ]
 

--- a/src/tests/plugins/share/test-share-download.c
+++ b/src/tests/plugins/share/test-share-download.c
@@ -13,12 +13,18 @@ static void
 test_share_download_single (ValentTestFixture *fixture,
                             gconstpointer      user_data)
 {
+  g_autoptr (GSettings) settings = NULL;
   g_autoptr (GFile) file = NULL;
   g_autoptr (GFile) dest = NULL;
+  g_autofree char *dest_dir = NULL;
   JsonNode *packet = NULL;
   GError *error = NULL;
 
   valent_test_fixture_connect (fixture, TRUE);
+
+  /* Ensure the download directory is at it's default */
+  settings = valent_device_plugin_new_settings ("test-device", "share");
+  g_settings_reset (settings, "download-folder");
 
   file = g_file_new_for_uri (test_file);
   packet = valent_test_fixture_lookup_packet (fixture, "share-file");
@@ -29,7 +35,8 @@ test_share_download_single (ValentTestFixture *fixture,
   /* Ensure the download task has an opportunity to finish completely */
   valent_test_fixture_wait (fixture, 1);
 
-  dest = valent_device_new_download_file (fixture->device, "image.png", FALSE);
+  dest_dir = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
+  dest = valent_data_get_file (dest_dir, "image.png", FALSE);
   g_assert_true (g_file_query_exists (dest, NULL));
 }
 
@@ -37,12 +44,18 @@ static void
 test_share_download_multiple (ValentTestFixture *fixture,
                               gconstpointer      user_data)
 {
+  g_autoptr (GSettings) settings = NULL;
   g_autoptr (GFile) file = NULL;
   g_autoptr (GFile) dest = NULL;
+  g_autofree char *dest_dir = NULL;
   JsonNode *packet = NULL;
   GError *error = NULL;
 
   valent_test_fixture_connect (fixture, TRUE);
+
+  /* Ensure the download directory is at it's default */
+  settings = valent_device_plugin_new_settings ("test-device", "share");
+  g_settings_reset (settings, "download-folder");
 
   file = g_file_new_for_uri (test_file);
 
@@ -66,15 +79,17 @@ test_share_download_multiple (ValentTestFixture *fixture,
   g_assert_no_error (error);
 
   /* Check the received files */
-  dest = valent_device_new_download_file (fixture->device, "image.png", FALSE);
+  dest_dir = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
+
+  dest = valent_data_get_file (dest_dir, "image.png", FALSE);
   g_assert_true (g_file_query_exists (dest, NULL));
   g_clear_object (&dest);
 
-  dest = valent_device_new_download_file (fixture->device, "image.png (1)", FALSE);
+  dest = valent_data_get_file (dest_dir, "image.png (1)", FALSE);
   g_assert_true (g_file_query_exists (dest, NULL));
   g_clear_object (&dest);
 
-  dest = valent_device_new_download_file (fixture->device, "image.png (2)", FALSE);
+  dest = valent_data_get_file (dest_dir, "image.png (2)", FALSE);
   g_assert_true (g_file_query_exists (dest, NULL));
   g_clear_object (&dest);
 }

--- a/src/tests/plugins/share/test-share-preferences.c
+++ b/src/tests/plugins/share/test-share-preferences.c
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include <libvalent-test.h>
+#include <libvalent-ui.h>
+
+
+static void
+test_share_plugin_preferences (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+  g_autofree char *device_id = NULL;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "share");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_DEVICE_PREFERENCES_PAGE,
+                                        "device-id", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  g_object_get (prefs, "device-id", &device_id, NULL);
+  g_assert_cmpstr (device_id, ==, "test-device");
+
+  g_object_unref (prefs);
+}
+
+static void
+test_share_plugin_download_folder (void)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *info;
+  PeasExtension *prefs;
+
+  g_test_skip ("Settings schema 'org.gtk.gtk4.Settings.FileChooser' is not installed");
+  return;
+
+  engine = valent_get_engine ();
+  info = peas_engine_get_plugin_info (engine, "share");
+  prefs = peas_engine_create_extension (engine,
+                                        info,
+                                        VALENT_TYPE_DEVICE_PREFERENCES_PAGE,
+                                        "device-id", "test-device",
+                                        NULL);
+  g_object_ref_sink (prefs);
+
+  while (g_main_context_iteration (NULL, FALSE))
+    continue;
+
+  /* FileChooser Dialog */
+  gtk_widget_activate_action (GTK_WIDGET (prefs),
+                              "preferences.select-download-folder",
+                              NULL);
+
+  while (g_main_context_iteration (NULL, FALSE))
+    continue;
+
+  g_object_unref (prefs);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_ui_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/plugins/share/preferences",
+                   test_share_plugin_preferences);
+
+  g_test_add_func ("/plugins/share/select-download-folder",
+                   test_share_plugin_download_folder);
+
+  return g_test_run ();
+}
+


### PR DESCRIPTION
Although ostensibly convenient for third-party plugins, the download
folder setting makes more sense as a part of the share plugin; as it is
in KDE Connect.