### PR TITLE
ValentDevice: use strcmp() in hot path

### DIFF
--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -514,9 +514,7 @@ valent_device_manager_ensure_device (ValentDeviceManager *manager,
       return NULL;
     }
 
-  device = g_hash_table_lookup (manager->devices, device_id);
-
-  if (device == NULL)
+  if ((device = g_hash_table_lookup (manager->devices, device_id)) == NULL)
     {
       g_autoptr (ValentData) data = NULL;
 

--- a/src/libvalent/core/valent-device-private.h
+++ b/src/libvalent/core/valent-device-private.h
@@ -8,14 +8,15 @@
 
 #include "valent-device.h"
 
-
 G_BEGIN_DECLS
 
-void     valent_device_handle_packet   (ValentDevice   *device,
-                                        JsonNode       *packet);
-void     valent_device_set_channel     (ValentDevice   *device,
-                                        ValentChannel  *channel);
-void     valent_device_set_paired      (ValentDevice   *device,
-                                        gboolean        paired);
+ValentDevice * valent_device_new_full      (JsonNode      *identity,
+                                            ValentData    *data);
+void           valent_device_handle_packet (ValentDevice  *device,
+                                            JsonNode      *packet);
+void           valent_device_set_channel   (ValentDevice  *device,
+                                            ValentChannel *channel);
+void           valent_device_set_paired    (ValentDevice  *device,
+                                            gboolean       paired);
 
 G_END_DECLS

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1203,46 +1203,32 @@ valent_device_class_init (ValentDeviceClass *klass)
 
 /**
  * valent_device_new:
- * @identity: a KDE Connect identity packet
+ * @id: (not nullable) a device ID
  *
- * Construct a new device for @identity.
+ * Create a new device for @id.
  *
  * Returns: (transfer full) (nullable): a new #ValentDevice
  *
  * Since: 1.0
  */
 ValentDevice *
-valent_device_new (JsonNode *identity)
+valent_device_new (const char *id)
 {
-  ValentDevice *ret;
-  const char *id;
+  g_return_val_if_fail (id != NULL && *id != '\0', NULL);
 
-  g_return_val_if_fail (VALENT_IS_PACKET (identity), NULL);
-
-  if (!valent_packet_get_string (identity, "deviceId", &id))
-    {
-      g_critical ("%s(): missing \"deviceId\" field", G_STRFUNC);
-      return NULL;
-    }
-
-  ret = g_object_new (VALENT_TYPE_DEVICE,
-                      "id", id,
-                      NULL);
-  valent_device_handle_identity (ret, identity);
-
-  return ret;
+  return g_object_new (VALENT_TYPE_DEVICE,
+                       "id", id,
+                       NULL);
 }
 
-/**
+/*< private >
  * valent_device_new_full:
  * @identity: a KDE Connect identity packet
  * @data: (nullable): the data context
  *
- * Construct a new device for @identity.
+ * Create a new device for @identity.
  *
  * Returns: (transfer full) (nullable): a new #ValentDevice
- *
- * Since: 1.0
  */
 ValentDevice *
 valent_device_new_full (JsonNode   *identity,

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1879,7 +1879,7 @@ valent_device_handle_packet (ValentDevice *device,
   type = valent_packet_get_type (packet);
 
   /* This is the only packet type an unpaired device can send or receive */
-  if G_UNLIKELY (g_strcmp0 (type, "kdeconnect.pair") == 0)
+  if G_UNLIKELY (strcmp (type, "kdeconnect.pair") == 0)
     valent_device_handle_pair (device, packet);
 
   /* If unpaired, any other packet is ignored and the remote device notified */

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -44,10 +44,7 @@ VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentDevice, valent_device, VALENT, DEVICE, ValentObject)
 
 VALENT_AVAILABLE_IN_1_0
-ValentDevice      * valent_device_new                (JsonNode             *identity);
-VALENT_AVAILABLE_IN_1_0
-ValentDevice      * valent_device_new_full           (JsonNode             *identity,
-                                                      ValentData           *data);
+ValentDevice      * valent_device_new                (const char           *id);
 VALENT_AVAILABLE_IN_1_0
 ValentChannel     * valent_device_ref_channel        (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0

--- a/src/tests/fixtures/valent-test-fixture.c
+++ b/src/tests/fixtures/valent-test-fixture.c
@@ -80,7 +80,7 @@ valent_test_fixture_init (ValentTestFixture *fixture,
 
   /* Init device */
   identity = valent_test_fixture_lookup_packet (fixture, "identity");
-  fixture->device = valent_device_new (identity);
+  fixture->device = valent_device_new_full (identity, NULL);
   valent_device_set_paired (fixture->device, TRUE);
 
   /* Init channels */

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -37,7 +37,7 @@ device_fixture_set_up (DeviceFixture *fixture,
 
   /* Init device */
   identity = get_packet (fixture, "identity");
-  fixture->device = valent_device_new (identity);
+  fixture->device = valent_device_new_full (identity, NULL);
 
   /* Init Channels */
   channels = valent_test_channels (identity, identity);
@@ -132,9 +132,7 @@ test_device_new (void)
   GMenuModel *menu;
   GPtrArray *plugins;
 
-  device = g_object_new (VALENT_TYPE_DEVICE,
-                         "id", "test-device",
-                         NULL);
+  device = valent_device_new ("test-device");
   g_assert_true (VALENT_IS_DEVICE (device));
 
   g_object_get (device,


### PR DESCRIPTION
By the time `valent_device_handle_packet()` is called we know the type
is non-NULL, so use `strcmp()` to take advantage of any optimizations
the compiler can perform.