### PR TITLE
chore: remove GParamSpec blurbs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,35 +38,6 @@ jobs:
           yamllint --config-file src/tests/extra/yamllint.yml \
                    $(git ls-files '*.yml')
 
-  codespell:
-    name: Codespell
-    needs: [lint]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Spell Check
-        uses: codespell-project/actions-codespell@master
-        with:
-          ignore_words_list: doubleclick,inout,sav
-          skip: ./src/tests/data,./subprojects,./*.po
-
-  reuse:
-    name: REUSE Compliance
-    needs: [lint]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Lint
-        uses: fsfe/reuse-action@v1
-        with:
-          args: lint
-
   abicheck:
     name: ABI Compliance
     needs: [lint]
@@ -87,6 +58,47 @@ jobs:
           COMMIT_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           ./src/tests/extra/abicheck.py ${STABLE_REF} ${COMMIT_REF}
+
+  reuse:
+    name: REUSE Compliance
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint
+        uses: fsfe/reuse-action@v1
+        with:
+          args: lint
+
+  codespell:
+    name: Codespell
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Spell Check
+        uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_list: doubleclick,inout,sav
+          skip: ./src/tests/data,./subprojects,./*.po
+
+  commitlint:
+    name: Commitlint
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
 
   test:
     name: Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,16 @@ Until the project is ready to start accepting reports, you are invited to
 discuss issues, features and get help in the [Discussions][discussions].
 
 
+## Workflow
+
+Valent uses a simple feature branch workflow, with commit messages following the
+[Conventional Commits][conventional-commits] standard.
+
+Simply create a new branch off of `main` to do your work, separate your changes
+into commits as appropriate and then open a pull request for review. Don't worry
+if any of this is unfamiliar, since this can be fixed up before merging.
+
+
 ## Submitting a Translation
 
 Valent does not yet use a translation service like Weblate or Crowdin. You
@@ -103,6 +113,7 @@ already distributed under an acceptable open source license.
 
 
 [annotations]: https://gi.readthedocs.io/en/latest/annotations/giannotations.html
+[conventional-commits]: https://www.conventionalcommits.org
 [discussions]: https://github.com/andyholmes/valent/discussions
 [linguas]: https://github.com/andyholmes/valent/blob/main/po/LINGUAS
 [po_dir]: https://github.com/andyholmes/valent/tree/main/po

--- a/src/libvalent/clipboard/valent-clipboard-adapter.c
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.c
@@ -188,9 +188,7 @@ valent_clipboard_adapter_class_init (ValentClipboardAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/contacts/valent-contact-cache.c
+++ b/src/libvalent/contacts/valent-contact-cache.c
@@ -381,9 +381,7 @@ valent_contact_cache_class_init (ValentContactCacheClass *klass)
    * Since: 1.0
    */
   properties [PROP_PATH] =
-    g_param_spec_string ("path",
-                         "Path",
-                         "The path to the database file",
+    g_param_spec_string ("path", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/contacts/valent-contact-store.c
+++ b/src/libvalent/contacts/valent-contact-store.c
@@ -284,9 +284,7 @@ valent_contact_store_class_init (ValentContactStoreClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The display name",
+    g_param_spec_string ("name", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -300,9 +298,7 @@ valent_contact_store_class_init (ValentContactStoreClass *klass)
    * Since: 1.0
    */
   properties [PROP_SOURCE] =
-    g_param_spec_object ("source",
-                         "Source",
-                         "The store source",
+    g_param_spec_object ("source", NULL, NULL,
                          E_TYPE_SOURCE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -317,9 +313,7 @@ valent_contact_store_class_init (ValentContactStoreClass *klass)
    * Since: 1.0
    */
   properties [PROP_UID] =
-    g_param_spec_string ("uid",
-                         "UID",
-                         "The unique identifier",
+    g_param_spec_string ("uid", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |

--- a/src/libvalent/contacts/valent-contacts-adapter.c
+++ b/src/libvalent/contacts/valent-contacts-adapter.c
@@ -206,9 +206,7 @@ valent_contacts_adapter_class_init (ValentContactsAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-application-plugin.c
+++ b/src/libvalent/core/valent-application-plugin.c
@@ -138,9 +138,7 @@ valent_application_plugin_class_init (ValentApplicationPluginClass *klass)
    * Since: 1.0
    */
   properties [PROP_APPLICATION] =
-    g_param_spec_object ("application",
-                         "Application",
-                         "The application this plugin is bound to",
+    g_param_spec_object ("application", NULL, NULL,
                          G_TYPE_APPLICATION,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -155,9 +153,7 @@ valent_application_plugin_class_init (ValentApplicationPluginClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this plugin",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-channel-service.c
+++ b/src/libvalent/core/valent-channel-service.c
@@ -511,9 +511,7 @@ valent_channel_service_class_init (ValentChannelServiceClass *klass)
    * Since: 1.0
    */
   properties [PROP_DATA] =
-    g_param_spec_object ("data",
-                         "Data",
-                         "The data context",
+    g_param_spec_object ("data", NULL, NULL,
                          VALENT_TYPE_DATA,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -534,9 +532,7 @@ valent_channel_service_class_init (ValentChannelServiceClass *klass)
    * Since: 1.0
    */
   properties [PROP_ID] =
-    g_param_spec_string ("id",
-                         "ID",
-                         "The local ID",
+    g_param_spec_string ("id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -557,9 +553,7 @@ valent_channel_service_class_init (ValentChannelServiceClass *klass)
    * Since: 1.0
    */
   properties [PROP_IDENTITY] =
-    g_param_spec_boxed ("identity",
-                        "Identity",
-                        "The local identity packet",
+    g_param_spec_boxed ("identity", NULL, NULL,
                         JSON_TYPE_NODE,
                         (G_PARAM_READABLE |
                          G_PARAM_EXPLICIT_NOTIFY |
@@ -579,9 +573,7 @@ valent_channel_service_class_init (ValentChannelServiceClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The display name of the local device",
+    g_param_spec_string ("name", NULL, NULL,
                          "Valent",
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |
@@ -596,9 +588,7 @@ valent_channel_service_class_init (ValentChannelServiceClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this channel service",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-channel.c
+++ b/src/libvalent/core/valent-channel.c
@@ -429,9 +429,7 @@ valent_channel_class_init (ValentChannelClass *klass)
    * Since: 1.0
    */
   properties [PROP_BASE_STREAM] =
-    g_param_spec_object ("base-stream",
-                         "Base Stream",
-                         "Base Stream",
+    g_param_spec_object ("base-stream", NULL, NULL,
                          G_TYPE_IO_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -452,9 +450,7 @@ valent_channel_class_init (ValentChannelClass *klass)
    * Since: 1.0
    */
   properties [PROP_IDENTITY] =
-    g_param_spec_boxed ("identity",
-                        "Identity",
-                        "The local device identity",
+    g_param_spec_boxed ("identity", NULL, NULL,
                         JSON_TYPE_NODE,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |
@@ -474,9 +470,7 @@ valent_channel_class_init (ValentChannelClass *klass)
    * Since: 1.0
    */
   properties [PROP_PEER_IDENTITY] =
-    g_param_spec_boxed ("peer-identity",
-                        "Peer Identity",
-                        "The peer identity packet",
+    g_param_spec_boxed ("peer-identity", NULL, NULL,
                         JSON_TYPE_NODE,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-component.c
+++ b/src/libvalent/core/valent-component.c
@@ -427,9 +427,7 @@ valent_component_class_init (ValentComponentClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_CONTEXT] =
-    g_param_spec_string ("plugin-context",
-                         "Plugin Context",
-                         "The context of the component",
+    g_param_spec_string ("plugin-context", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -447,9 +445,7 @@ valent_component_class_init (ValentComponentClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_PRIORITY] =
-    g_param_spec_string ("plugin-priority",
-                         "Plugin Priority",
-                         "The priority key for the component",
+    g_param_spec_string ("plugin-priority", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -464,9 +460,7 @@ valent_component_class_init (ValentComponentClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_TYPE] =
-    g_param_spec_gtype ("plugin-type",
-                        "Plugin Type",
-                        "The GType of the component",
+    g_param_spec_gtype ("plugin-type", NULL, NULL,
                         G_TYPE_NONE,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-data.c
+++ b/src/libvalent/core/valent-data.c
@@ -236,9 +236,7 @@ valent_data_class_init (ValentDataClass *klass)
    * Since: 1.0
    */
   properties [PROP_CACHE_PATH] =
-    g_param_spec_string ("cache-path",
-                         "Cache Path",
-                         "Path to the cache directory",
+    g_param_spec_string ("cache-path", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -252,9 +250,7 @@ valent_data_class_init (ValentDataClass *klass)
    * Since: 1.0
    */
   properties [PROP_CONFIG_PATH] =
-    g_param_spec_string ("config-path",
-                         "Config Path",
-                         "Path to the config directory",
+    g_param_spec_string ("config-path", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -272,9 +268,7 @@ valent_data_class_init (ValentDataClass *klass)
    * Since: 1.0
    */
   properties [PROP_CONTEXT] =
-    g_param_spec_string ("context",
-                         "Context",
-                         "Context to store data for",
+    g_param_spec_string ("context", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -289,9 +283,7 @@ valent_data_class_init (ValentDataClass *klass)
    * Since: 1.0
    */
   properties [PROP_DATA_PATH] =
-    g_param_spec_string ("data-path",
-                         "Data Path",
-                         "Path to the data directory",
+    g_param_spec_string ("data-path", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -308,9 +300,7 @@ valent_data_class_init (ValentDataClass *klass)
    * Since: 1.0
    */
   properties [PROP_PARENT] =
-    g_param_spec_object ("parent",
-                         "Parent",
-                         "The parent context",
+    g_param_spec_object ("parent", NULL, NULL,
                          VALENT_TYPE_DATA,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-device-impl.c
+++ b/src/libvalent/core/valent-device-impl.c
@@ -485,9 +485,7 @@ valent_device_impl_class_init (ValentDeviceImplClass *klass)
   skeleton_class->flush = valent_device_impl_flush;
 
   properties[PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The exported device",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -859,9 +859,7 @@ valent_device_manager_class_init (ValentDeviceManagerClass *klass)
    * Since: 1.0
    */
   properties [PROP_DATA] =
-    g_param_spec_object ("data",
-                         "Data Manager",
-                         "The data context",
+    g_param_spec_object ("data", NULL, NULL,
                          VALENT_TYPE_DATA,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -880,9 +878,7 @@ valent_device_manager_class_init (ValentDeviceManagerClass *klass)
    * Since: 1.0
    */
   properties [PROP_ID] =
-    g_param_spec_string ("id",
-                         "Id",
-                         "A unique Id",
+    g_param_spec_string ("id", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -896,9 +892,7 @@ valent_device_manager_class_init (ValentDeviceManagerClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The display name of the local device",
+    g_param_spec_string ("name", NULL, NULL,
                          "Valent",
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |

--- a/src/libvalent/core/valent-device-plugin.c
+++ b/src/libvalent/core/valent-device-plugin.c
@@ -456,9 +456,7 @@ valent_device_plugin_class_init (ValentDevicePluginClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this plugin is bound to",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -473,9 +471,7 @@ valent_device_plugin_class_init (ValentDevicePluginClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this plugin",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-device-transfer.c
+++ b/src/libvalent/core/valent-device-transfer.c
@@ -397,9 +397,7 @@ valent_device_transfer_class_init (ValentDeviceTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this transfer is for",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -417,9 +415,7 @@ valent_device_transfer_class_init (ValentDeviceTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_FILE] =
-    g_param_spec_object ("file",
-                         "File",
-                         "The file to transfer",
+    g_param_spec_object ("file", NULL, NULL,
                          G_TYPE_FILE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -434,9 +430,7 @@ valent_device_transfer_class_init (ValentDeviceTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_PACKET] =
-    g_param_spec_boxed ("packet",
-                        "Packet",
-                        "The KDE Connect packet describing the payload",
+    g_param_spec_boxed ("packet", NULL, NULL,
                         JSON_TYPE_NODE,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1004,9 +1004,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_CONNECTED] =
-    g_param_spec_boolean ("connected",
-                          "Connected",
-                          "Whether the device is connected",
+    g_param_spec_boolean ("connected", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -1023,9 +1021,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_DATA] =
-    g_param_spec_object ("data",
-                         "Data Manager",
-                         "The data context",
+    g_param_spec_object ("data", NULL, NULL,
                          VALENT_TYPE_DATA,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -1042,10 +1038,8 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_ICON_NAME] =
-    g_param_spec_string ("icon-name",
-                         "Icon Name",
-                         "Icon name representing the device",
-                         NULL,
+    g_param_spec_string ("icon-name", NULL, NULL,
+                         "computer-symbolic",
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));
@@ -1062,9 +1056,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_ID] =
-    g_param_spec_string ("id",
-                         "Id",
-                         "Unique id for the device",
+    g_param_spec_string ("id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -1079,9 +1071,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "Name representing the device",
+    g_param_spec_string ("name", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -1099,9 +1089,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_PAIRED] =
-    g_param_spec_boolean ("paired",
-                          "Paired",
-                          "Whether the device is paired",
+    g_param_spec_boolean ("paired", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -1118,9 +1106,7 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_STATE] =
-    g_param_spec_flags ("state",
-                        "State",
-                        "State of device",
+    g_param_spec_flags ("state", NULL, NULL,
                         VALENT_TYPE_DEVICE_STATE,
                         VALENT_DEVICE_STATE_NONE,
                         (G_PARAM_READABLE |
@@ -1140,10 +1126,8 @@ valent_device_class_init (ValentDeviceClass *klass)
    * Since: 1.0
    */
   properties [PROP_TYPE] =
-    g_param_spec_string ("type",
-                         "Type",
-                         "Type of device (eg. phone, tablet, laptop)",
-                         NULL,
+    g_param_spec_string ("type", NULL, NULL,
+                         "desktop",
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));

--- a/src/libvalent/core/valent-object.c
+++ b/src/libvalent/core/valent-object.c
@@ -215,9 +215,7 @@ valent_object_class_init (ValentObjectClass *klass)
    * Since: 1.0
    */
   properties [PROP_CANCELLABLE] =
-    g_param_spec_object ("cancellable",
-                         "Cancellable",
-                         "A cancellable for the object",
+    g_param_spec_object ("cancellable", NULL, NULL,
                          G_TYPE_CANCELLABLE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/core/valent-transfer.c
+++ b/src/libvalent/core/valent-transfer.c
@@ -175,9 +175,7 @@ valent_transfer_class_init (ValentTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_ID] =
-    g_param_spec_string ("id",
-                         "ID",
-                         "Unique identifier for the transfer",
+    g_param_spec_string ("id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -200,9 +198,7 @@ valent_transfer_class_init (ValentTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_PROGRESS] =
-    g_param_spec_double ("progress",
-                         "Progress",
-                         "The progress of the transfer",
+    g_param_spec_double ("progress", NULL, NULL,
                          0.0, 1.0,
                          0.0,
                          (G_PARAM_READWRITE |
@@ -225,9 +221,7 @@ valent_transfer_class_init (ValentTransferClass *klass)
    * Since: 1.0
    */
   properties [PROP_STATE] =
-    g_param_spec_enum ("state",
-                       "State",
-                       "The state of the transfer",
+    g_param_spec_enum ("state", NULL, NULL,
                        VALENT_TYPE_TRANSFER_STATE,
                        VALENT_TRANSFER_STATE_PENDING,
                        (G_PARAM_READABLE |

--- a/src/libvalent/input/valent-input-adapter.c
+++ b/src/libvalent/input/valent-input-adapter.c
@@ -153,9 +153,7 @@ valent_input_adapter_class_init (ValentInputAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/media/valent-media-adapter.c
+++ b/src/libvalent/media/valent-media-adapter.c
@@ -205,9 +205,7 @@ valent_media_adapter_class_init (ValentMediaAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -280,9 +280,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_FLAGS] =
-    g_param_spec_flags ("flags",
-                        "Flags",
-                        "The available actions",
+    g_param_spec_flags ("flags", NULL, NULL,
                         VALENT_TYPE_MEDIA_ACTIONS,
                         VALENT_MEDIA_ACTION_NONE,
                         (G_PARAM_READABLE |
@@ -303,9 +301,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_METADATA] =
-    g_param_spec_variant ("metadata",
-                          "Metadata",
-                          "The metadata of the active media item",
+    g_param_spec_variant ("metadata", NULL, NULL,
                           G_VARIANT_TYPE ("a{sv}"),
                           NULL,
                           (G_PARAM_READABLE |
@@ -320,9 +316,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The display name",
+    g_param_spec_string ("name", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -341,9 +335,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_POSITION] =
-    g_param_spec_int64 ("position",
-                        "Position",
-                        "Position",
+    g_param_spec_int64 ("position", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READABLE |
@@ -362,9 +354,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_STATE] =
-    g_param_spec_flags ("state",
-                        "State",
-                        "The playback state",
+    g_param_spec_flags ("state", NULL, NULL,
                         VALENT_TYPE_MEDIA_STATE,
                         VALENT_MEDIA_STATE_STOPPED,
                         (G_PARAM_READWRITE |
@@ -381,9 +371,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
    * Since: 1.0
    */
   properties [PROP_VOLUME] =
-    g_param_spec_double ("volume",
-                         "Volume",
-                         "Volume",
+    g_param_spec_double ("volume", NULL, NULL,
                          0.0, G_MAXDOUBLE,
                          0.0,
                          (G_PARAM_READWRITE |

--- a/src/libvalent/mixer/valent-mixer-adapter.c
+++ b/src/libvalent/mixer/valent-mixer-adapter.c
@@ -249,9 +249,7 @@ valent_mixer_adapter_class_init (ValentMixerAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEFAULT_INPUT] =
-    g_param_spec_object ("default-input",
-                         "Default Input",
-                         "The active input stream",
+    g_param_spec_object ("default-input", NULL, NULL,
                          VALENT_TYPE_MIXER_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -268,9 +266,7 @@ valent_mixer_adapter_class_init (ValentMixerAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEFAULT_OUTPUT] =
-    g_param_spec_object ("default-output",
-                         "Default Output",
-                         "The active output stream",
+    g_param_spec_object ("default-output", NULL, NULL,
                          VALENT_TYPE_MIXER_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -284,9 +280,7 @@ valent_mixer_adapter_class_init (ValentMixerAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/mixer/valent-mixer-stream.c
+++ b/src/libvalent/mixer/valent-mixer-stream.c
@@ -244,9 +244,7 @@ valent_mixer_stream_class_init (ValentMixerStreamClass *klass)
    * Since: 1.0
    */
   properties [PROP_DESCRIPTION] =
-    g_param_spec_string ("description",
-                         "Description",
-                         "The human-readable label of the stream",
+    g_param_spec_string ("description", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -261,9 +259,7 @@ valent_mixer_stream_class_init (ValentMixerStreamClass *klass)
    * Since: 1.0
    */
   properties [PROP_DIRECTION] =
-    g_param_spec_enum ("direction",
-                       "Direction",
-                       "The port direction of the stream",
+    g_param_spec_enum ("direction", NULL, NULL,
                        VALENT_TYPE_MIXER_DIRECTION,
                        VALENT_MIXER_INPUT,
                        (G_PARAM_CONSTRUCT_ONLY |
@@ -279,9 +275,7 @@ valent_mixer_stream_class_init (ValentMixerStreamClass *klass)
    * Since: 1.0
    */
   properties [PROP_LEVEL] =
-    g_param_spec_uint ("level",
-                       "Level",
-                       "The input or output level of the stream",
+    g_param_spec_uint ("level", NULL, NULL,
                        0, 100,
                        0,
                        (G_PARAM_READWRITE |
@@ -296,9 +290,7 @@ valent_mixer_stream_class_init (ValentMixerStreamClass *klass)
    * Since: 1.0
    */
   properties [PROP_MUTED] =
-    g_param_spec_boolean ("muted",
-                          "Muted",
-                          "Whether the stream is muted",
+    g_param_spec_boolean ("muted", NULL, NULL,
                           FALSE,
                           (G_PARAM_READWRITE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -312,9 +304,7 @@ valent_mixer_stream_class_init (ValentMixerStreamClass *klass)
    * Since: 1.0
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The unique name of the stream",
+    g_param_spec_string ("name", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/mixer/valent-mixer.c
+++ b/src/libvalent/mixer/valent-mixer.c
@@ -328,9 +328,7 @@ valent_mixer_class_init (ValentMixerClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEFAULT_INPUT] =
-    g_param_spec_object ("default-input",
-                         "Default Input",
-                         "The active input stream",
+    g_param_spec_object ("default-input", NULL, NULL,
                          VALENT_TYPE_MIXER_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -344,9 +342,7 @@ valent_mixer_class_init (ValentMixerClass *klass)
    * Since: 1.0
    */
   properties [PROP_DEFAULT_OUTPUT] =
-    g_param_spec_object ("default-output",
-                         "Default Output",
-                         "The active output stream",
+    g_param_spec_object ("default-output", NULL, NULL,
                          VALENT_TYPE_MIXER_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |

--- a/src/libvalent/notifications/valent-notification.c
+++ b/src/libvalent/notifications/valent-notification.c
@@ -259,9 +259,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_ACTION] =
-    g_param_spec_string ("action",
-                         "Action",
-                         "The default notification action",
+    g_param_spec_string ("action", NULL, NULL,
                          NULL,
                          (G_PARAM_WRITABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -281,9 +279,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_APPLICATION] =
-    g_param_spec_string ("application",
-                         "Application",
-                         "Application name",
+    g_param_spec_string ("application", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -297,9 +293,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_BODY] =
-    g_param_spec_string ("body",
-                         "Body",
-                         "The notification body",
+    g_param_spec_string ("body", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -313,9 +307,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_ICON] =
-    g_param_spec_object ("icon",
-                         "Icon",
-                         "The notification icon",
+    g_param_spec_object ("icon", NULL, NULL,
                          G_TYPE_ICON,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -329,9 +321,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_ID] =
-    g_param_spec_string ("id",
-                         "Id",
-                         "The unique ID of the notification",
+    g_param_spec_string ("id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -345,14 +335,12 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_PRIORITY] =
-    g_param_spec_enum ("priority",
-                         "Priority",
-                         "The notification priority",
-                         G_TYPE_NOTIFICATION_PRIORITY,
-                         G_NOTIFICATION_PRIORITY_NORMAL,
-                         (G_PARAM_READWRITE |
-                          G_PARAM_EXPLICIT_NOTIFY |
-                          G_PARAM_STATIC_STRINGS));
+    g_param_spec_enum ("priority", NULL, NULL,
+                       G_TYPE_NOTIFICATION_PRIORITY,
+                       G_NOTIFICATION_PRIORITY_NORMAL,
+                       (G_PARAM_READWRITE |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
 
   /**
    * ValentNotification:time: (getter get_time) (setter set_time)
@@ -362,9 +350,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_TIME] =
-    g_param_spec_int64 ("time",
-                        "Time",
-                        "Posting time of the notification",
+    g_param_spec_int64 ("time", NULL, NULL,
                         0, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |
@@ -379,9 +365,7 @@ valent_notification_class_init (ValentNotificationClass *klass)
    * Since: 1.0
    */
   properties [PROP_TITLE] =
-    g_param_spec_string ("title",
-                         "Title",
-                         "Title for the notification",
+    g_param_spec_string ("title", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |

--- a/src/libvalent/notifications/valent-notifications-adapter.c
+++ b/src/libvalent/notifications/valent-notifications-adapter.c
@@ -172,9 +172,7 @@ valent_notifications_adapter_class_init (ValentNotificationsAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/session/valent-session-adapter.c
+++ b/src/libvalent/session/valent-session-adapter.c
@@ -163,9 +163,7 @@ valent_session_adapter_class_init (ValentSessionAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_ACTIVE] =
-    g_param_spec_boolean ("active",
-                          "Active",
-                          "Whether the session is active",
+    g_param_spec_boolean ("active", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -179,9 +177,7 @@ valent_session_adapter_class_init (ValentSessionAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_LOCKED] =
-    g_param_spec_boolean ("locked",
-                          "Locked",
-                          "Whether the session is locked",
+    g_param_spec_boolean ("locked", NULL, NULL,
                           FALSE,
                           (G_PARAM_READWRITE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -195,9 +191,7 @@ valent_session_adapter_class_init (ValentSessionAdapterClass *klass)
    * Since: 1.0
    */
   properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info",
-                        "Plugin Info",
-                        "The plugin info describing this adapter",
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
                         PEAS_TYPE_PLUGIN_INFO,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-device-activity.c
+++ b/src/libvalent/ui/valent-device-activity.c
@@ -43,9 +43,7 @@ valent_device_activity_default_init (ValentDeviceActivityInterface *iface)
    * Since: 1.0
    */
   g_object_interface_install_property (iface,
-                                       g_param_spec_object ("device",
-                                                            "Device",
-                                                            "The device this activity is for",
+                                       g_param_spec_object ("device", NULL, NULL,
                                                             G_TYPE_OBJECT,
                                                             (G_PARAM_READWRITE |
                                                              G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-device-gadget.c
+++ b/src/libvalent/ui/valent-device-gadget.c
@@ -43,9 +43,7 @@ valent_device_gadget_default_init (ValentDeviceGadgetInterface *iface)
    * Since: 1.0
    */
   g_object_interface_install_property (iface,
-                                       g_param_spec_object ("device",
-                                                            "Device",
-                                                            "The device this gadget is for",
+                                       g_param_spec_object ("device", NULL, NULL,
                                                             G_TYPE_OBJECT,
                                                             (G_PARAM_READWRITE |
                                                              G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-device-panel.c
+++ b/src/libvalent/ui/valent-device-panel.c
@@ -330,9 +330,7 @@ valent_device_panel_class_init (ValentDevicePanelClass *klass)
    * The device this panel controls and represents.
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "device",
-                         "The device for this settings widget",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-device-preferences-page.c
+++ b/src/libvalent/ui/valent-device-preferences-page.c
@@ -42,9 +42,7 @@ valent_device_preferences_page_default_init (ValentDevicePreferencesPageInterfac
    * Since: 1.0
    */
   g_object_interface_install_property (iface,
-                                       g_param_spec_string ("device-id",
-                                                            "Device ID",
-                                                            "The ID of the device the plugin is bound to",
+                                       g_param_spec_string ("device-id", NULL, NULL,
                                                             NULL,
                                                             (G_PARAM_READWRITE |
                                                              G_PARAM_CONSTRUCT_ONLY |
@@ -59,9 +57,7 @@ valent_device_preferences_page_default_init (ValentDevicePreferencesPageInterfac
    * Since: 1.0
    */
   g_object_interface_install_property (iface,
-                                       g_param_spec_boxed ("plugin-info",
-                                                           "Plugin Info",
-                                                           "The plugin info describing the plugin this page configures",
+                                       g_param_spec_boxed ("plugin-info", NULL, NULL,
                                                            PEAS_TYPE_PLUGIN_INFO,
                                                            (G_PARAM_READWRITE |
                                                             G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-device-preferences-window.c
+++ b/src/libvalent/ui/valent-device-preferences-window.c
@@ -333,9 +333,7 @@ valent_device_preferences_window_class_init (ValentDevicePreferencesWindowClass 
    * The device this panel controls and represents.
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "device",
-                         "The device for this settings widget",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-menu-list.c
+++ b/src/libvalent/ui/valent-menu-list.c
@@ -345,9 +345,7 @@ valent_menu_list_class_init (ValentMenuListClass *klass)
    * The "model" property holds the #GMenuModel used to build this list.
    */
   properties [PROP_MENU_MODEL] =
-    g_param_spec_object ("menu-model",
-                         "Menu Model",
-                         "The menu model used to build the list",
+    g_param_spec_object ("menu-model", NULL, NULL,
                          G_TYPE_MENU_MODEL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -359,9 +357,7 @@ valent_menu_list_class_init (ValentMenuListClass *klass)
    * The parent #ValentMenuList this is a submenu for.
    */
   properties [PROP_SUBMENU_OF] =
-    g_param_spec_object ("submenu-of",
-                         "Submenu Of",
-                         "The parent menu list",
+    g_param_spec_object ("submenu-of", NULL, NULL,
                          VALENT_TYPE_MENU_LIST,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-menu-stack.c
+++ b/src/libvalent/ui/valent-menu-stack.c
@@ -100,9 +100,7 @@ valent_menu_stack_class_init (ValentMenuStackClass *klass)
    * The #GMenuModel for this #ValentMenuStack.
    */
   properties [PROP_MENU_MODEL] =
-    g_param_spec_object ("menu-model",
-                         "menu-model",
-                         "The menu model for this stack",
+    g_param_spec_object ("menu-model", NULL, NULL,
                          G_TYPE_MENU_MODEL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |

--- a/src/libvalent/ui/valent-preferences-page.c
+++ b/src/libvalent/ui/valent-preferences-page.c
@@ -49,9 +49,7 @@ valent_preferences_page_default_init (ValentPreferencesPageInterface *iface)
    * Since: 1.0
    */
   g_object_interface_install_property (iface,
-                                       g_param_spec_boxed ("plugin-info",
-                                                           "Plugin Info",
-                                                           "The plugin info describing the plugin this page configures",
+                                       g_param_spec_boxed ("plugin-info", NULL, NULL,
                                                            PEAS_TYPE_PLUGIN_INFO,
                                                            (G_PARAM_READWRITE |
                                                             G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/ui/valent-window.c
+++ b/src/libvalent/ui/valent-window.c
@@ -461,9 +461,7 @@ valent_window_class_init (ValentWindowClass *klass)
    * The [class@Valent.DeviceManager] that the window represents.
    */
   properties [PROP_DEVICE_MANAGER] =
-    g_param_spec_object ("device-manager",
-                         "Device Manager",
-                         "The device manager for this window",
+    g_param_spec_object ("device-manager", NULL, NULL,
                          VALENT_TYPE_DEVICE_MANAGER,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/bluez/valent-bluez-channel.c
+++ b/src/plugins/bluez/valent-bluez-channel.c
@@ -186,9 +186,7 @@ valent_bluez_channel_class_init (ValentBluezChannelClass *klass)
    * The #ValentMuxConnection responsible for muxing and demuxing data.
    */
   properties [PROP_MUXER] =
-    g_param_spec_object ("muxer",
-                         "Muxer",
-                         "The multiplexer responsible for muxing and demuxing data",
+    g_param_spec_object ("muxer", NULL, NULL,
                          VALENT_TYPE_MUX_CONNECTION,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -201,9 +199,7 @@ valent_bluez_channel_class_init (ValentBluezChannelClass *klass)
    * A unique identifier for the channel.
    */
   properties [PROP_UUID] =
-    g_param_spec_string ("uuid",
-                         "UUID",
-                         "Unique identifier for the channel",
+    g_param_spec_string ("uuid", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/bluez/valent-bluez-device.c
+++ b/src/plugins/bluez/valent-bluez-device.c
@@ -235,9 +235,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * The DBus object path of the adapter for this device.
    */
   properties [PROP_ADAPTER] =
-    g_param_spec_string ("adapter",
-                         "Adapter",
-                         "The DBus object path of the adapter for this device",
+    g_param_spec_string ("adapter", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -249,9 +247,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * The address of the device.
    */
   properties [PROP_ADDRESS] =
-    g_param_spec_string ("address",
-                         "Address",
-                         "The address of the device",
+    g_param_spec_string ("address", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -263,9 +259,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * Whether the device is connected.
    */
   properties [PROP_CONNECTED] =
-    g_param_spec_boolean ("connected",
-                          "Connected",
-                          "Whether the device is connected",
+    g_param_spec_boolean ("connected", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -277,9 +271,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * The icon of the device.
    */
   properties [PROP_ICON_NAME] =
-    g_param_spec_string ("icon-name",
-                         "Icon Name",
-                         "The icon of the device",
+    g_param_spec_string ("icon-name", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -291,9 +283,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * The name of the device.
    */
   properties [PROP_NAME] =
-    g_param_spec_string ("name",
-                         "Name",
-                         "The alias or name of the device",
+    g_param_spec_string ("name", NULL, NULL,
                          NULL,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -305,9 +295,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * Whether the device is paired.
    */
   properties [PROP_PAIRED] =
-    g_param_spec_boolean ("paired",
-                          "Paired",
-                          "Whether the device is paired",
+    g_param_spec_boolean ("paired", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -319,9 +307,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * Whether service discovery has been resolved.
    */
   properties [PROP_SERVICES_RESOLVED] =
-    g_param_spec_boolean ("services-resolved",
-                          "Services Resolved",
-                          "Whether service discovery has been resolved",
+    g_param_spec_boolean ("services-resolved", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -333,9 +319,7 @@ valent_bluez_device_class_init (ValentBluezDeviceClass *klass)
    * Whether the device is trusted.
    */
   properties [PROP_TRUSTED] =
-    g_param_spec_boolean ("trusted",
-                          "Trusted",
-                          "Whether the device is trusted",
+    g_param_spec_boolean ("trusted", NULL, NULL,
                           FALSE,
                           (G_PARAM_READABLE |
                            G_PARAM_EXPLICIT_NOTIFY |

--- a/src/plugins/bluez/valent-mux-connection.c
+++ b/src/plugins/bluez/valent-mux-connection.c
@@ -885,9 +885,7 @@ valent_mux_connection_class_init (ValentMuxConnectionClass *klass)
    * The "base-stream" property is the #GIOStream being wrapped.
    */
   properties [PROP_BASE_STREAM] =
-    g_param_spec_object ("base-stream",
-                         "Base Stream",
-                         "The base stream for this connection",
+    g_param_spec_object ("base-stream", NULL, NULL,
                          G_TYPE_IO_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -900,9 +898,7 @@ valent_mux_connection_class_init (ValentMuxConnectionClass *klass)
    * Size of the input buffer allocated to each multiplex channel.
    */
   properties [PROP_BUFFER_SIZE] =
-    g_param_spec_uint ("buffer-size",
-                       "Buffer Size",
-                       "The base stream for this connection",
+    g_param_spec_uint ("buffer-size", NULL, NULL,
                        1024, G_MAXUINT16,
                        BUFFER_SIZE,
                        (G_PARAM_READWRITE |

--- a/src/plugins/bluez/valent-mux-input-stream.c
+++ b/src/plugins/bluez/valent-mux-input-stream.c
@@ -144,9 +144,7 @@ valent_mux_input_stream_class_init (ValentMuxInputStreamClass *klass)
    * The multiplexer supplying data for this stream.
    */
   properties [PROP_MUXER] =
-    g_param_spec_object ("muxer",
-                         "Muxer",
-                         "Multiplexer that muxes and demuxes this stream",
+    g_param_spec_object ("muxer", NULL, NULL,
                          VALENT_TYPE_MUX_CONNECTION,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -159,9 +157,7 @@ valent_mux_input_stream_class_init (ValentMuxInputStreamClass *klass)
    * UUID of the channel that owns this stream.
    */
   properties [PROP_UUID] =
-    g_param_spec_string ("uuid",
-                         "UUID",
-                         "UUID of the channel owning the stream",
+    g_param_spec_string ("uuid", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/bluez/valent-mux-output-stream.c
+++ b/src/plugins/bluez/valent-mux-output-stream.c
@@ -156,9 +156,7 @@ valent_mux_output_stream_class_init (ValentMuxOutputStreamClass *klass)
    * The multiplexer supplying data for this stream.
    */
   properties [PROP_MUXER] =
-    g_param_spec_object ("muxer",
-                         "Muxer",
-                         "Multiplexer that muxes and demuxes this stream",
+    g_param_spec_object ("muxer", NULL, NULL,
                          VALENT_TYPE_MUX_CONNECTION,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -171,9 +169,7 @@ valent_mux_output_stream_class_init (ValentMuxOutputStreamClass *klass)
    * UUID of the channel that owns this stream.
    */
   properties [PROP_UUID] =
-    g_param_spec_string ("uuid",
-                         "UUID",
-                         "UUID of the channel owning the stream",
+    g_param_spec_string ("uuid", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/eds/valent-ebook-store.c
+++ b/src/plugins/eds/valent-ebook-store.c
@@ -390,9 +390,7 @@ valent_ebook_store_class_init (ValentEBookStoreClass *klass)
    * The #EBookClient for the store.
    */
   properties [PROP_CLIENT] =
-    g_param_spec_object ("client",
-                         "Client",
-                         "The client for the store",
+    g_param_spec_object ("client", NULL, NULL,
                          E_TYPE_BOOK_CLIENT,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -892,9 +892,7 @@ valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
    * This available as a construct property primarily for use in unit tests.
    */
   properties [PROP_BROADCAST_ADDRESS] =
-    g_param_spec_string ("broadcast-address",
-                         "Broadcast Address",
-                         "The UDP broadcast address for outgoing identity packets",
+    g_param_spec_string ("broadcast-address", NULL, NULL,
                          PROTOCOL_ADDR,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -907,9 +905,7 @@ valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
    * The TLS certificate the service uses to authenticate with other devices.
    */
   properties [PROP_CERTIFICATE] =
-    g_param_spec_object ("certificate",
-                         "Certificate",
-                         "TLS Certificate",
+    g_param_spec_object ("certificate", NULL, NULL,
                          G_TYPE_TLS_CERTIFICATE,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -924,9 +920,7 @@ valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
    * This available as a construct property primarily for use in unit tests.
    */
   properties [PROP_PORT] =
-    g_param_spec_uint ("port",
-                       "Port",
-                       "TCP/IP port",
+    g_param_spec_uint ("port", NULL, NULL,
                        1024, G_MAXUINT16,
                        PROTOCOL_PORT,
                        (G_PARAM_READWRITE |

--- a/src/plugins/lan/valent-lan-channel.c
+++ b/src/plugins/lan/valent-lan-channel.c
@@ -359,9 +359,7 @@ valent_lan_channel_class_init (ValentLanChannelClass *klass)
    * The local #GTlsCertificate used by the service.
    */
   properties [PROP_CERTIFICATE] =
-    g_param_spec_object ("certificate",
-                         "Certificate",
-                         "TLS Certificate",
+    g_param_spec_object ("certificate", NULL, NULL,
                          G_TYPE_TLS_CERTIFICATE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -374,9 +372,7 @@ valent_lan_channel_class_init (ValentLanChannelClass *klass)
    * The remote TCP/IP address for the channel.
    */
   properties [PROP_HOST] =
-    g_param_spec_string ("host",
-                         "Host",
-                         "TCP/IP address",
+    g_param_spec_string ("host", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -390,9 +386,7 @@ valent_lan_channel_class_init (ValentLanChannelClass *klass)
    * the certificate has been accepted.
    */
   properties [PROP_PEER_CERTIFICATE] =
-    g_param_spec_object ("peer-certificate",
-                         "Peer Certificate",
-                         "Peer TLS Certificate",
+    g_param_spec_object ("peer-certificate", NULL, NULL,
                          G_TYPE_TLS_CERTIFICATE,
                          (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -404,9 +398,7 @@ valent_lan_channel_class_init (ValentLanChannelClass *klass)
    * The remote TCP/IP port for the channel.
    */
   properties [PROP_PORT] =
-    g_param_spec_uint ("port",
-                       "Port",
-                       "TCP/IP port",
+    g_param_spec_uint ("port", NULL, NULL,
                        0, G_MAXUINT16,
                        VALENT_LAN_TCP_PORT,
                        (G_PARAM_READWRITE |

--- a/src/plugins/mousepad/valent-mousepad-remote.c
+++ b/src/plugins/mousepad/valent-mousepad-remote.c
@@ -599,9 +599,7 @@ valent_mousepad_remote_class_init (ValentMousepadRemoteClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, on_triple_end);
 
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The target device",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -778,9 +778,7 @@ valent_mpris_player_class_init (ValentMPRISPlayerClass *klass)
    * The well-known or unique name that the player is on.
    */
   properties [PROP_BUS_NAME] =
-    g_param_spec_string ("bus-name",
-                         "Bus Name",
-                         "The well-known or unique name that the player is on.",
+    g_param_spec_string ("bus-name", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/notification/valent-notification-dialog.c
+++ b/src/plugins/notification/valent-notification-dialog.c
@@ -175,9 +175,7 @@ valent_notification_dialog_class_init (ValentNotificationDialogClass *klass)
    * The notification the dialog represents.
    */
   properties[PROP_NOTIFICATION] =
-    g_param_spec_object ("notification",
-                         "Notification",
-                         "The notification the dialog represents",
+    g_param_spec_object ("notification", NULL, NULL,
                          VALENT_TYPE_NOTIFICATION,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -190,9 +188,7 @@ valent_notification_dialog_class_init (ValentNotificationDialogClass *klass)
    * The notification reply ID.
    */
   properties[PROP_REPLY_ID] =
-    g_param_spec_string ("reply-id",
-                         "Reply ID",
-                         "The notification reply ID",
+    g_param_spec_string ("reply-id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |

--- a/src/plugins/notification/valent-notification-upload.c
+++ b/src/plugins/notification/valent-notification-upload.c
@@ -446,9 +446,7 @@ valent_notification_upload_class_init (ValentNotificationUploadClass *klass)
    * The [class@Valent.Device] this transfer is for.
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this transfer is for",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -461,9 +459,7 @@ valent_notification_upload_class_init (ValentNotificationUploadClass *klass)
    * The [iface@Gio.Icon] for the notification.
    */
   properties [PROP_ICON] =
-    g_param_spec_object ("icon",
-                         "Icon",
-                         "The icon for the notification",
+    g_param_spec_object ("icon", NULL, NULL,
                          G_TYPE_ICON,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -476,9 +472,7 @@ valent_notification_upload_class_init (ValentNotificationUploadClass *klass)
    * The packet to send the payload with.
    */
   properties [PROP_PACKET] =
-    g_param_spec_boxed ("packet",
-                        "Packet",
-                        "The packet to send the payload with",
+    g_param_spec_boxed ("packet", NULL, NULL,
                         JSON_TYPE_NODE,
                         (G_PARAM_READWRITE |
                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/presenter/valent-presenter-remote.c
+++ b/src/plugins/presenter/valent-presenter-remote.c
@@ -185,9 +185,7 @@ valent_presenter_remote_class_init (ValentPresenterRemoteClass *klass)
   gtk_widget_class_install_action (widget_class, "remote.open", NULL, presenter_open_action);
 
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this remote controls",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/pulseaudio/valent-pa-stream.c
+++ b/src/plugins/pulseaudio/valent-pa-stream.c
@@ -244,9 +244,7 @@ valent_pa_stream_class_init (ValentPaStreamClass *klass)
    * The #GvcMixerStream this stream wraps.
    */
   properties [PROP_BASE_STREAM] =
-    g_param_spec_object ("base-stream",
-                         "Base Stream",
-                         "The underlying GvcMixerStream",
+    g_param_spec_object ("base-stream", NULL, NULL,
                          GVC_TYPE_MIXER_STREAM,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -259,9 +257,7 @@ valent_pa_stream_class_init (ValentPaStreamClass *klass)
    * The maximum volume.
    */
   properties [PROP_VOL_MAX] =
-    g_param_spec_uint ("vol-max",
-                       "Maximum Volume",
-                       "The maximum volume of the underlying GvcMixerStream",
+    g_param_spec_uint ("vol-max", NULL, NULL,
                        0, G_MAXUINT32,
                        G_MAXUINT32,
                        (G_PARAM_READWRITE |

--- a/src/plugins/share/valent-share-download.c
+++ b/src/plugins/share/valent-share-download.c
@@ -278,9 +278,7 @@ valent_share_download_class_init (ValentShareDownloadClass *klass)
    * The [class@Valent.Device] this transfer is for.
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this transfer is for",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/share/valent-share-upload.c
+++ b/src/plugins/share/valent-share-upload.c
@@ -287,9 +287,7 @@ valent_share_upload_class_init (ValentShareUploadClass *klass)
    * The [class@Valent.Device] this transfer is for.
    */
   properties [PROP_DEVICE] =
-    g_param_spec_object ("device",
-                         "Device",
-                         "The device this transfer is for",
+    g_param_spec_object ("device", NULL, NULL,
                          VALENT_TYPE_DEVICE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/sms/valent-contact-row.c
+++ b/src/plugins/sms/valent-contact-row.c
@@ -124,9 +124,7 @@ valent_contact_row_class_init (ValentContactRowClass *klass)
    * The #EContact for this row.
    */
   properties [PROP_CONTACT] =
-    g_param_spec_object ("contact",
-                         "Contact",
-                         "The contact this row displays",
+    g_param_spec_object ("contact", NULL, NULL,
                          E_TYPE_CONTACT,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -142,9 +140,7 @@ valent_contact_row_class_init (ValentContactRowClass *klass)
    * format.
    */
   properties [PROP_CONTACT_ADDRESS] =
-    g_param_spec_string ("contact-address",
-                         "Contact Address",
-                         "The contact phone number or address",
+    g_param_spec_string ("contact-address", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -157,9 +153,7 @@ valent_contact_row_class_init (ValentContactRowClass *klass)
    * #ValentContactRow:contact.
    */
   properties [PROP_CONTACT_NAME] =
-    g_param_spec_string ("contact-name",
-                         "Contact Name",
-                         "The contact name",
+    g_param_spec_string ("contact-name", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |

--- a/src/plugins/sms/valent-date-label.c
+++ b/src/plugins/sms/valent-date-label.c
@@ -252,9 +252,7 @@ valent_date_label_class_init (ValentDateLabelClass *klass)
    * The timestamp this label represents.
    */
   properties [PROP_DATE] =
-    g_param_spec_int64 ("date",
-                        "Date",
-                        "The timestamp this label represents",
+    g_param_spec_int64 ("date", NULL, NULL,
                         0, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |
@@ -267,9 +265,7 @@ valent_date_label_class_init (ValentDateLabelClass *klass)
    * The brevity of the label.
    */
   properties [PROP_MODE] =
-    g_param_spec_uint ("mode",
-                       "Mode",
-                       "The display mode of the label",
+    g_param_spec_uint ("mode", NULL, NULL,
                        0, G_MAXUINT32,
                        0,
                        (G_PARAM_READWRITE |

--- a/src/plugins/sms/valent-message-row.c
+++ b/src/plugins/sms/valent-message-row.c
@@ -129,9 +129,7 @@ valent_message_row_class_init (ValentMessageRowClass *klass)
    * The #EContact that sent this message.
    */
   properties [PROP_CONTACT] =
-    g_param_spec_object ("contact",
-                         "Contact",
-                         "The contact that sent this message.",
+    g_param_spec_object ("contact", NULL, NULL,
                          E_TYPE_CONTACT,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |
@@ -144,9 +142,7 @@ valent_message_row_class_init (ValentMessageRowClass *klass)
    * The timestamp of the message.
    */
   properties [PROP_DATE] =
-    g_param_spec_int64 ("date",
-                        "Date",
-                        "The timestamp of the message.",
+    g_param_spec_int64 ("date", NULL, NULL,
                         0, G_MAXINT64,
                         0,
                         (G_PARAM_READABLE |
@@ -159,9 +155,7 @@ valent_message_row_class_init (ValentMessageRowClass *klass)
    * The message this row displays.
    */
   properties [PROP_MESSAGE] =
-    g_param_spec_object ("message",
-                         "Message",
-                         "The message this row displays.",
+    g_param_spec_object ("message", NULL, NULL,
                           VALENT_TYPE_MESSAGE,
                           (G_PARAM_READWRITE |
                            G_PARAM_CONSTRUCT |
@@ -174,9 +168,7 @@ valent_message_row_class_init (ValentMessageRowClass *klass)
    * The thread id this message belongs to.
    */
   properties [PROP_THREAD_ID] =
-    g_param_spec_int64 ("thread-id",
-                        "Thread ID",
-                        "The thread id this message belongs to.",
+    g_param_spec_int64 ("thread-id", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READABLE |

--- a/src/plugins/sms/valent-message-thread.c
+++ b/src/plugins/sms/valent-message-thread.c
@@ -332,9 +332,7 @@ valent_message_thread_class_init (ValentMessageThreadClass *klass)
    * The ID of the thread.
    */
   properties [PROP_ID] =
-    g_param_spec_int64 ("id",
-                        "ID",
-                        "The ID of the thread",
+    g_param_spec_int64 ("id", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |
@@ -348,9 +346,7 @@ valent_message_thread_class_init (ValentMessageThreadClass *klass)
    * The #ValentSmsStore providing #ValentMessage objects for the thread.
    */
   properties [PROP_STORE] =
-    g_param_spec_object ("store",
-                         "Store",
-                         "The message store backing this thread.",
+    g_param_spec_object ("store", NULL, NULL,
                          VALENT_TYPE_SMS_STORE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/plugins/sms/valent-message.c
+++ b/src/plugins/sms/valent-message.c
@@ -166,15 +166,13 @@ valent_message_class_init (ValentMessageClass *klass)
    * The #ValentMessageBox of the message.
    */
   properties [PROP_BOX] =
-    g_param_spec_uint ("box",
-                       "Category",
-                        "The ValentMessageBox of the message",
-                        VALENT_MESSAGE_BOX_ALL, VALENT_MESSAGE_BOX_FAILED,
-                        VALENT_MESSAGE_BOX_ALL,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
+    g_param_spec_uint ("box", NULL, NULL,
+                       VALENT_MESSAGE_BOX_ALL, VALENT_MESSAGE_BOX_FAILED,
+                       VALENT_MESSAGE_BOX_ALL,
+                       (G_PARAM_READWRITE |
+                        G_PARAM_CONSTRUCT_ONLY |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
 
   /**
    * ValentMessage:date:
@@ -182,9 +180,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * A UNIX epoch timestamp for the message.
    */
   properties [PROP_DATE] =
-    g_param_spec_int64 ("date",
-                        "Date",
-                        "Integer indicating the date",
+    g_param_spec_int64 ("date", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |
@@ -198,9 +194,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * The unique ID for this message.
    */
   properties [PROP_ID] =
-    g_param_spec_int64 ("id",
-                        "ID",
-                        "Unique ID for this message",
+    g_param_spec_int64 ("id", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |
@@ -214,9 +208,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * Ancillary data for the message, such as media.
    */
   properties [PROP_METADATA] =
-    g_param_spec_variant ("metadata",
-                          "Metadata",
-                          "Ancillary data for the message",
+    g_param_spec_variant ("metadata", NULL, NULL,
                           G_VARIANT_TYPE_VARDICT,
                           NULL,
                           (G_PARAM_READWRITE |
@@ -230,9 +222,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * Whether the message has been read.
    */
   properties [PROP_READ] =
-    g_param_spec_boolean ("read",
-                          "Read",
-                          "Whether the message has been read",
+    g_param_spec_boolean ("read", NULL, NULL,
                           FALSE,
                           (G_PARAM_READWRITE |
                            G_PARAM_EXPLICIT_NOTIFY |
@@ -245,9 +235,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * address form.
    */
   properties [PROP_SENDER] =
-    g_param_spec_string ("sender",
-                         "Sender",
-                         "The sender of the message",
+    g_param_spec_string ("sender", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -260,9 +248,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * The text content of the message.
    */
   properties [PROP_TEXT] =
-    g_param_spec_string ("text",
-                         "Text",
-                         "The text content of the message",
+    g_param_spec_string ("text", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -275,9 +261,7 @@ valent_message_class_init (ValentMessageClass *klass)
    * The thread this message belongs to.
    */
   properties [PROP_THREAD_ID] =
-    g_param_spec_int64 ("thread-id",
-                        "Thread ID",
-                        "The thread this message belongs to",
+    g_param_spec_int64 ("thread-id", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |

--- a/src/plugins/sms/valent-sms-conversation-row.c
+++ b/src/plugins/sms/valent-sms-conversation-row.c
@@ -170,9 +170,7 @@ valent_sms_conversation_row_class_init (ValentSmsConversationRowClass *klass)
    * The #EContact that sent this message.
    */
   properties [PROP_CONTACT] =
-    g_param_spec_object ("contact",
-                         "Contact",
-                         "The contact that sent this message.",
+    g_param_spec_object ("contact", NULL, NULL,
                          E_TYPE_CONTACT,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |
@@ -185,9 +183,7 @@ valent_sms_conversation_row_class_init (ValentSmsConversationRowClass *klass)
    * The timestamp of the message.
    */
   properties [PROP_DATE] =
-    g_param_spec_int64 ("date",
-                        "Date",
-                        "The timestamp of the message.",
+    g_param_spec_int64 ("date", NULL, NULL,
                         0, G_MAXINT64,
                         0,
                         (G_PARAM_READABLE |
@@ -200,9 +196,7 @@ valent_sms_conversation_row_class_init (ValentSmsConversationRowClass *klass)
    * The message this row displays.
    */
   properties [PROP_MESSAGE] =
-    g_param_spec_object ("message",
-                         "Message",
-                         "The message this row displays.",
+    g_param_spec_object ("message", NULL, NULL,
                           VALENT_TYPE_MESSAGE,
                           (G_PARAM_READWRITE |
                            G_PARAM_CONSTRUCT |

--- a/src/plugins/sms/valent-sms-conversation.c
+++ b/src/plugins/sms/valent-sms-conversation.c
@@ -745,9 +745,7 @@ valent_sms_conversation_class_init (ValentSmsConversationClass *klass)
    * The #ValentContactStore providing #EContact objects for the conversation.
    */
   properties [PROP_CONTACT_STORE] =
-    g_param_spec_object ("contact-store",
-                         "Contact Store",
-                         "Contact store providing contact information",
+    g_param_spec_object ("contact-store", NULL, NULL,
                          VALENT_TYPE_CONTACT_STORE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT |
@@ -761,9 +759,7 @@ valent_sms_conversation_class_init (ValentSmsConversationClass *klass)
    * conversation.
    */
   properties [PROP_MESSAGE_STORE] =
-    g_param_spec_object ("message-store",
-                         "Message Store",
-                         "The SMS message store for this conversation.",
+    g_param_spec_object ("message-store", NULL, NULL,
                          VALENT_TYPE_SMS_STORE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -776,9 +772,7 @@ valent_sms_conversation_class_init (ValentSmsConversationClass *klass)
    * The thread ID of the conversation.
    */
   properties [PROP_THREAD_ID] =
-    g_param_spec_int64 ("thread-id",
-                        "Thread ID",
-                        "The thread ID of the conversation",
+    g_param_spec_int64 ("thread-id", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
                         (G_PARAM_READWRITE |

--- a/src/plugins/sms/valent-sms-window.c
+++ b/src/plugins/sms/valent-sms-window.c
@@ -760,9 +760,7 @@ valent_sms_window_class_init (ValentSmsWindowClass *klass)
    * The #ValentContactStore providing contacts for the window.
    */
   properties [PROP_CONTACT_STORE] =
-    g_param_spec_object ("contact-store",
-                         "Contact Store",
-                         "The contact model for this window.",
+    g_param_spec_object ("contact-store", NULL, NULL,
                          VALENT_TYPE_CONTACT_STORE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -775,9 +773,7 @@ valent_sms_window_class_init (ValentSmsWindowClass *klass)
    * The #ValentSmsStore providing messages for the window.
    */
   properties [PROP_MESSAGE_STORE] =
-    g_param_spec_object ("message-store",
-                         "Message Store",
-                         "The message store for this window.",
+    g_param_spec_object ("message-store", NULL, NULL,
                          VALENT_TYPE_SMS_STORE,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/tests/fixtures/valent-mock-channel.c
+++ b/src/tests/fixtures/valent-mock-channel.c
@@ -226,9 +226,7 @@ valent_mock_channel_class_init (ValentMockChannelClass *klass)
    * property. The underlying connection is actually a #GUnixConnection.
    */
   properties [PROP_HOST] =
-    g_param_spec_string ("host",
-                         "Host",
-                         "TCP/IP address",
+    g_param_spec_string ("host", NULL, NULL,
                          "127.0.0.1",
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
@@ -244,9 +242,7 @@ valent_mock_channel_class_init (ValentMockChannelClass *klass)
    * property. The underlying connection is actually a #GUnixConnection.
    */
   properties [PROP_PORT] =
-    g_param_spec_uint ("port",
-                       "Port",
-                       "TCP/IP port",
+    g_param_spec_uint ("port", NULL, NULL,
                        1024, G_MAXUINT16,
                        VALENT_TEST_TCP_PORT,
                        (G_PARAM_READWRITE |


### PR DESCRIPTION
These are an artifact of the past and require needless extra work to
keep up to date with the actual class documentation.