### PR TITLE
test: temporarily enable the bluez plugin and its tests

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -262,6 +262,7 @@
             "config-opts" : [
                 "--prefix=/app",
                 "--buildtype=debugoptimized",
+                "-Dplugin_bluez=true",
                 "-Dprofile=devel",
                 "-Dtests=true",
                 "-Dtracing=true"

--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -22,6 +22,7 @@
         "--socket=session-bus",
         "--socket=ssh-auth",
         "--socket=wayland",
+        "--system-talk-name=org.bluez",
         "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.ModemManager1",

--- a/build-aux/flatpak/ca.andyholmes.Valent.Tests.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Tests.json
@@ -17,6 +17,7 @@
         "--socket=session-bus",
         "--socket=ssh-auth",
         "--socket=wayland",
+        "--system-talk-name=org.bluez",
         "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.ModemManager1",

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -17,6 +17,7 @@
         "--socket=session-bus",
         "--socket=ssh-auth",
         "--socket=wayland",
+        "--system-talk-name=org.bluez",
         "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.ModemManager1",

--- a/src/tests/extra/tsan.supp
+++ b/src/tests/extra/tsan.supp
@@ -8,6 +8,10 @@
 #
 mutex:valent_device_get_type_once
 
+# src/plugins/bluez/valent-mux-io-stream.c
+race:valent_mux_io_stream_constructed
+race:valent_mux_io_stream_finalize
+
 # src/plugins/sms/valent-sms-store.c
 race:valent_sms_store_thread
 


### PR DESCRIPTION
Until the bluez plugin is enabled by default, enable it manually in the
development flatpak and CI for testing purposes.

Also add two temporary ThreadSanitizer suppressions until they can be
fixed.