### PR TITLE
refactor(plugins): expand ValentApplicationPlugin class

### DIFF
--- a/src/libvalent/core/valent-application-plugin.c
+++ b/src/libvalent/core/valent-application-plugin.c
@@ -10,6 +10,7 @@
 
 #include "valent-application-plugin.h"
 #include "valent-debug.h"
+#include "valent-device-manager.h"
 #include "valent-object.h"
 
 
@@ -22,6 +23,15 @@
  * scope of the application. This usually means integrating the application with
  * the host environment (eg. XDG Autostart).
  *
+ * ## Implementation Notes
+ *
+ * Implementations may handle application events by overriding the appropriate
+ * virtual function, including [vfunc@Valent.ApplicationPlugin.activate] to
+ * handle activation, [vfunc@Valent.ApplicationPlugin.command-line] to handle
+ * CLI options, or [vfunc@Valent.ApplicationPlugin.open] to handle files.
+ *
+ * For plugin preferences see [iface@Valent.PreferencesPage].
+ *
  * ## `.plugin` File
  *
  * Application plugins have no special fields in the `.plugin` file.
@@ -31,8 +41,9 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
-  GApplication   *application;
+  PeasPluginInfo      *plugin_info;
+  GApplication        *application;
+  ValentDeviceManager *manager;
 } ValentApplicationPluginPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentApplicationPlugin, valent_application_plugin, VALENT_TYPE_OBJECT)
@@ -41,6 +52,9 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentApplicationPlugin, valent_application
  * ValentApplicationPluginClass:
  * @enable: the virtual function pointer for valent_application_plugin_enable()
  * @disable: the virtual function pointer for valent_application_plugin_disable()
+ * @activate: the virtual function pointer for valent_application_plugin_activate()
+ * @command_line: the virtual function pointer for valent_application_plugin_command_line()
+ * @open: the virtual function pointer for valent_application_plugin_open()
  *
  * The virtual function table for #ValentApplicationPlugin.
  */
@@ -48,6 +62,7 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentApplicationPlugin, valent_application
 enum {
   PROP_0,
   PROP_APPLICATION,
+  PROP_DEVICE_MANAGER,
   PROP_PLUGIN_INFO,
   N_PROPERTIES
 };
@@ -59,11 +74,45 @@ static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 static void
 valent_application_plugin_real_disable (ValentApplicationPlugin *plugin)
 {
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
 }
 
 static void
 valent_application_plugin_real_enable (ValentApplicationPlugin *plugin)
 {
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
+}
+
+static gboolean
+valent_application_plugin_real_activate (ValentApplicationPlugin *plugin)
+{
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
+
+  return FALSE;
+}
+
+static int
+valent_application_plugin_real_command_line (ValentApplicationPlugin *plugin,
+                                             GApplicationCommandLine *command_line)
+{
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
+  g_assert (G_IS_APPLICATION_COMMAND_LINE (command_line));
+
+  return 0;
+}
+
+static gboolean
+valent_application_plugin_real_open (ValentApplicationPlugin  *plugin,
+                                     GFile                   **files,
+                                     int                       n_files,
+                                     const char               *hint)
+{
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
+  g_assert (files != NULL);
+  g_assert (n_files > 0);
+  g_assert (hint != NULL);
+
+  return FALSE;
 }
 /* LCOV_EXCL_STOP */
 
@@ -84,6 +133,10 @@ valent_application_plugin_get_property (GObject    *object,
     {
     case PROP_APPLICATION:
       g_value_set_object (value, priv->application);
+      break;
+
+    case PROP_DEVICE_MANAGER:
+      g_value_set_object (value, priv->manager);
       break;
 
     case PROP_PLUGIN_INFO:
@@ -110,6 +163,10 @@ valent_application_plugin_set_property (GObject      *object,
       priv->application = g_value_get_object (value);
       break;
 
+    case PROP_DEVICE_MANAGER:
+      priv->manager = g_value_get_object (value);
+      break;
+
     case PROP_PLUGIN_INFO:
       priv->plugin_info = g_value_get_boxed (value);
       break;
@@ -129,6 +186,9 @@ valent_application_plugin_class_init (ValentApplicationPluginClass *klass)
 
   klass->disable = valent_application_plugin_real_disable;
   klass->enable = valent_application_plugin_real_enable;
+  klass->activate = valent_application_plugin_real_activate;
+  klass->command_line = valent_application_plugin_real_command_line;
+  klass->open = valent_application_plugin_real_open;
 
   /**
    * ValentApplicationPlugin:application:
@@ -140,6 +200,21 @@ valent_application_plugin_class_init (ValentApplicationPluginClass *klass)
   properties [PROP_APPLICATION] =
     g_param_spec_object ("application", NULL, NULL,
                          G_TYPE_APPLICATION,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentApplicationPlugin:device-maanger:
+   *
+   * The [class@Valent.DeviceManager] this plugin is bound to.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_DEVICE_MANAGER] =
+    g_param_spec_object ("device-manager", NULL, NULL,
+                         VALENT_TYPE_DEVICE_MANAGER,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -166,6 +241,46 @@ valent_application_plugin_class_init (ValentApplicationPluginClass *klass)
 static void
 valent_application_plugin_init (ValentApplicationPlugin *adapter)
 {
+}
+
+/**
+ * valent_application_plugin_get_application: (get-property application)
+ * @plugin: a #ValentApplicationPlugin
+ *
+ * Get the application this plugin is bound to.
+ *
+ * Returns: (transfer none): a #GApplication
+ *
+ * Since: 1.0
+ */
+GApplication *
+valent_application_plugin_get_application (ValentApplicationPlugin *plugin)
+{
+  ValentApplicationPluginPrivate *priv = valent_application_plugin_get_instance_private (plugin);
+
+  g_return_val_if_fail (VALENT_IS_APPLICATION_PLUGIN (plugin), NULL);
+
+  return priv->application;
+}
+
+/**
+ * valent_application_plugin_get_device_manager: (get-property device-manager)
+ * @plugin: a #ValentApplicationPlugin
+ *
+ * Get the [class@Valent.DeviceManager] of the application.
+ *
+ * Returns: (transfer none): a #ValentDeviceManager
+ *
+ * Since: 1.0
+ */
+ValentDeviceManager *
+valent_application_plugin_get_device_manager (ValentApplicationPlugin *plugin)
+{
+  ValentApplicationPluginPrivate *priv = valent_application_plugin_get_instance_private (plugin);
+
+  g_return_val_if_fail (VALENT_IS_APPLICATION_PLUGIN (plugin), NULL);
+
+  return priv->manager;
 }
 
 /**
@@ -212,5 +327,105 @@ valent_application_plugin_disable (ValentApplicationPlugin *plugin)
   VALENT_APPLICATION_PLUGIN_GET_CLASS (plugin)->disable (plugin);
 
   VALENT_EXIT;
+}
+
+/**
+ * valent_application_plugin_activate: (virtual activate)
+ * @plugin: a #ValentApplicationPlugin
+ *
+ * Handle activation of the application.
+ *
+ * Implementations should override this method to handle activation, as
+ * a result of [signal@Gio.Application::activate] being emitted on the primary
+ * instance of the application.
+ *
+ * Returns: %TRUE if handled, or %FALSE if not
+ *
+ * Since: 1.0
+ */
+gboolean
+valent_application_plugin_activate (ValentApplicationPlugin *plugin)
+{
+  gboolean ret;
+
+  VALENT_ENTRY;
+
+  g_return_val_if_fail (VALENT_IS_APPLICATION_PLUGIN (plugin), FALSE);
+
+  ret = VALENT_APPLICATION_PLUGIN_GET_CLASS (plugin)->activate (plugin);
+
+  VALENT_RETURN (ret);
+}
+
+/**
+ * valent_application_plugin_command_line: (virtual command_line)
+ * @plugin: a #ValentApplicationPlugin
+ * @command_line: a #GApplicationCommandLine
+ *
+ * Handle the given command-line options.
+ *
+ * Implementations should override this method to handle command-line options,
+ * as a result of [signal@Gio.Application::command-line] being emitted on the
+ * primary instance of the application.
+ *
+ * Returns: an integer that is set as the exit status for the calling process
+ *
+ * Since: 1.0
+ */
+int
+valent_application_plugin_command_line (ValentApplicationPlugin *plugin,
+                                        GApplicationCommandLine *command_line)
+{
+  int ret;
+
+  VALENT_ENTRY;
+
+  g_return_val_if_fail (VALENT_IS_APPLICATION_PLUGIN (plugin), 1);
+  g_return_val_if_fail (G_IS_APPLICATION_COMMAND_LINE (command_line), 1);
+
+  ret = VALENT_APPLICATION_PLUGIN_GET_CLASS (plugin)->command_line (plugin,
+                                                                    command_line);
+
+  VALENT_RETURN (ret);
+}
+
+/**
+ * valent_application_plugin_open: (virtual open)
+ * @plugin: a #ValentApplicationPlugin
+ * @files: (array length=n_files): an array of #GFiles to open
+ * @n_files: the length of the @files array
+ * @hint: (not nullable): a hint (or "")
+ *
+ * Open the given files.
+ *
+ * Implementations should override this method to handle files and URIs, as
+ * a result of [signal@Gio.Application::open] being emitted on the primary
+ * instance of the application.
+ *
+ * Returns: %TRUE if handled, or %FALSE if not
+ *
+ * Since: 1.0
+ */
+gboolean
+valent_application_plugin_open (ValentApplicationPlugin  *plugin,
+                                GFile                   **files,
+                                int                       n_files,
+                                const char               *hint)
+{
+  gboolean ret;
+
+  VALENT_ENTRY;
+
+  g_return_val_if_fail (VALENT_IS_APPLICATION_PLUGIN (plugin), FALSE);
+  g_return_val_if_fail (files != NULL, FALSE);
+  g_return_val_if_fail (n_files > 0, FALSE);
+  g_return_val_if_fail (hint != NULL, FALSE);
+
+  ret = VALENT_APPLICATION_PLUGIN_GET_CLASS (plugin)->open (plugin,
+                                                            files,
+                                                            n_files,
+                                                            hint);
+
+  VALENT_RETURN (ret);
 }
 

--- a/src/libvalent/core/valent-application-plugin.h
+++ b/src/libvalent/core/valent-application-plugin.h
@@ -9,6 +9,7 @@
 
 #include <glib-object.h>
 
+#include "valent-device-manager.h"
 #include "valent-object.h"
 
 G_BEGIN_DECLS
@@ -23,14 +24,35 @@ struct _ValentApplicationPluginClass
   ValentObjectClass   parent_class;
 
   /* virtual functions */
-  void                (*disable) (ValentApplicationPlugin *plugin);
-  void                (*enable)  (ValentApplicationPlugin *plugin);
+  void                (*disable)      (ValentApplicationPlugin  *plugin);
+  void                (*enable)       (ValentApplicationPlugin  *plugin);
+  gboolean            (*activate)     (ValentApplicationPlugin  *plugin);
+  int                 (*command_line) (ValentApplicationPlugin  *plugin,
+                                       GApplicationCommandLine  *command_line);
+  gboolean            (*open)         (ValentApplicationPlugin  *plugin,
+                                       GFile                   **files,
+                                       int                       n_files,
+                                       const char               *hint);
 };
 
 VALENT_AVAILABLE_IN_1_0
-void   valent_application_plugin_disable (ValentApplicationPlugin *plugin);
+GApplication        * valent_application_plugin_get_application    (ValentApplicationPlugin  *plugin);
 VALENT_AVAILABLE_IN_1_0
-void   valent_application_plugin_enable  (ValentApplicationPlugin *plugin);
+ValentDeviceManager * valent_application_plugin_get_device_manager (ValentApplicationPlugin  *plugin);
+VALENT_AVAILABLE_IN_1_0
+void                  valent_application_plugin_disable            (ValentApplicationPlugin  *plugin);
+VALENT_AVAILABLE_IN_1_0
+void                  valent_application_plugin_enable             (ValentApplicationPlugin  *plugin);
+VALENT_AVAILABLE_IN_1_0
+gboolean              valent_application_plugin_activate           (ValentApplicationPlugin  *plugin);
+VALENT_AVAILABLE_IN_1_0
+int                   valent_application_plugin_command_line       (ValentApplicationPlugin  *plugin,
+                                                                    GApplicationCommandLine  *command_line);
+VALENT_AVAILABLE_IN_1_0
+gboolean              valent_application_plugin_open               (ValentApplicationPlugin  *plugin,
+                                                                    GFile                   **files,
+                                                                    int                       n_files,
+                                                                    const char               *hint);
 
 G_END_DECLS
 

--- a/src/tests/fixtures/valent-mock-application-plugin.c
+++ b/src/tests/fixtures/valent-mock-application-plugin.c
@@ -29,6 +29,35 @@ valent_mock_application_plugin_disable (ValentApplicationPlugin *plugin)
   g_assert (VALENT_IS_MOCK_APPLICATION_PLUGIN (plugin));
 }
 
+static gboolean
+valent_mock_application_plugin_activate (ValentApplicationPlugin *plugin)
+{
+  g_assert (VALENT_IS_MOCK_APPLICATION_PLUGIN (plugin));
+
+  return TRUE;
+}
+
+static int
+valent_mock_application_plugin_command_line (ValentApplicationPlugin *plugin,
+                                             GApplicationCommandLine *command_line)
+{
+  g_assert (VALENT_IS_APPLICATION_PLUGIN (plugin));
+  g_assert (G_IS_APPLICATION_COMMAND_LINE (command_line));
+
+  return 0;
+}
+
+static gboolean
+valent_mock_application_plugin_open (ValentApplicationPlugin  *plugin,
+                                     GFile                   **files,
+                                     int                       n_files,
+                                     const char               *hint)
+{
+  g_assert (VALENT_IS_MOCK_APPLICATION_PLUGIN (plugin));
+
+  return TRUE;
+}
+
 /*
  * GObject
  */
@@ -39,6 +68,9 @@ valent_mock_application_plugin_class_init (ValentMockApplicationPluginClass *kla
 
   plugin_class->enable = valent_mock_application_plugin_enable;
   plugin_class->disable = valent_mock_application_plugin_disable;
+  plugin_class->activate = valent_mock_application_plugin_activate;
+  plugin_class->command_line = valent_mock_application_plugin_command_line;
+  plugin_class->open = valent_mock_application_plugin_open;
 }
 
 static void

--- a/src/tests/libvalent/core/meson.build
+++ b/src/tests/libvalent/core/meson.build
@@ -8,6 +8,7 @@ libvalent_core_test_deps = [
 ]
 
 libvalent_core_tests = [
+  'test-application-plugin',
   'test-certificate',
   'test-channel-service',
   'test-data',

--- a/src/tests/libvalent/core/test-application-plugin.c
+++ b/src/tests/libvalent/core/test-application-plugin.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include <gio/gio.h>
+#include <libvalent-core.h>
+#include <libvalent-test.h>
+
+
+typedef struct
+{
+  GApplication        *application;
+  ValentDeviceManager *manager;
+  PeasExtension       *extension;
+} ApplicationPluginFixture;
+
+static void
+application_fixture_set_up (ApplicationPluginFixture *fixture,
+                            gconstpointer             user_data)
+{
+  PeasEngine *engine;
+  PeasPluginInfo *plugin_info;
+
+  engine = valent_get_engine ();
+  plugin_info = peas_engine_get_plugin_info (engine, "mock");
+
+  fixture->application = g_application_new ("ca.andyholmes.Valent.Tests",
+                                            G_APPLICATION_FLAGS_NONE);
+  fixture->manager = valent_device_manager_new_sync (NULL, NULL, NULL);
+  fixture->extension = peas_engine_create_extension (engine,
+                                                     plugin_info,
+                                                     VALENT_TYPE_APPLICATION_PLUGIN,
+                                                     "application",    fixture->application,
+                                                     "device-manager", fixture->manager,
+                                                     NULL);
+}
+
+static void
+application_fixture_tear_down (ApplicationPluginFixture *fixture,
+                               gconstpointer             user_data)
+{
+  v_await_finalize_object (fixture->extension);
+  v_await_finalize_object (fixture->manager);
+  v_await_finalize_object (fixture->application);
+}
+
+static void
+test_application_plugin_basic (ApplicationPluginFixture *fixture,
+                               gconstpointer             user_data)
+{
+  ValentApplicationPlugin *plugin = VALENT_APPLICATION_PLUGIN (fixture->extension);
+  g_autoptr (GApplication) application = NULL;
+  g_autoptr (ValentDeviceManager) manager = NULL;
+  PeasPluginInfo *plugin_info = NULL;
+
+  /* Test properties */
+  g_object_get (fixture->extension,
+                "application",    &application,
+                "device-manager", &manager,
+                "plugin-info",    &plugin_info,
+                NULL);
+
+  g_assert_true (G_IS_APPLICATION (application));
+  g_assert_true (VALENT_IS_DEVICE_MANAGER (manager));
+  g_assert_nonnull (plugin_info);
+  g_boxed_free (PEAS_TYPE_PLUGIN_INFO, plugin_info);
+
+  application = valent_application_plugin_get_application (plugin);
+  g_assert_true (G_IS_APPLICATION (application));
+
+  manager = valent_application_plugin_get_device_manager (plugin);
+  g_assert_true (VALENT_IS_DEVICE_MANAGER (manager));
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  valent_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/core/application-plugin/basic",
+              ApplicationPluginFixture, NULL,
+              application_fixture_set_up,
+              test_application_plugin_basic,
+              application_fixture_tear_down);
+
+  return g_test_run ();
+}
+


### PR DESCRIPTION
Refactor ValentApplicationPlugin to handle more GApplication virtual
functions including `activate()`, `command_line()` and `open()`. This
allows delegating these operations to plugins, such as the `share`
which can then serve as the defacto URI handler.

* add `activate()`, `command_line()` and `open()` virtual functions
* add `device-manager` property to `ValentApplicationPlugin`
* add property accessors for `application` and `device-manager`