### PR TITLE
fix(build): use a valid version in `pkgconfig` file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,12 +20,12 @@ pkgconfig = import('pkgconfig')
 #
 # Versioning
 #
-valent_version = meson.project_version()
-version_split = valent_version.split('.')
+version_split = meson.project_version().split('.')
 MAJOR_VERSION = version_split[0].to_int()
 MINOR_VERSION = version_split[1].to_int()
 MICRO_VERSION = version_split[2].to_int()
 
+valent_version = '@0@.@1@.@2@'.format(MAJOR_VERSION, MINOR_VERSION, MICRO_VERSION)
 valent_api_version = '@0@.@1@'.format(MAJOR_VERSION, MINOR_VERSION)
 valent_api_name = 'valent-@0@'.format(valent_api_version)
 

--- a/src/libvalent/meson.build
+++ b/src/libvalent/meson.build
@@ -53,7 +53,7 @@ libvalent_dep = declare_dependency(
 pkgconfig.generate(
          name: valent_api_name,
   description: 'Core implementation and plugin API for Valent.',
-      version: meson.project_version(),
+      version: valent_version,
      requires: [
        'gio-2.0',
        'gio-unix-2.0',


### PR DESCRIPTION
Even though libvalent is not stable we need to exclude the pre-release
suffix, because it results in an invalid version being generated in the
`.pc` file.