### PR TITLE
ci: cleanup cppcheck config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,12 @@ jobs:
       - name: Build
         env:
           BUILDTOOL: ${{ matrix.label }}
-          SCANBUILD: ${{ github.workspace }}/src/tests/extra/scanbuild.sh
+          CC: ${{ matrix.label == 'LLVM' && 'clang' || 'gcc' }}
+          CC_LD: ${{ matrix.label == 'LLVM' && 'lld' || 'bfd' }}
+          CXX: ${{ matrix.label == 'LLVM' && 'clang++' || 'g++' }}
+          CXX_LD: ${{ matrix.label == 'LLVM' && 'lld' || 'bfd' }}
           CFLAGS: ${{ matrix.label == 'GCC' && '-fanalyzer' || '' }}
+          SCANBUILD: ${{ github.workspace }}/src/tests/extra/scanbuild.sh
         run: |
           meson setup --buildtype=debug \
                       -Dintrospection=false \
@@ -141,8 +145,9 @@ jobs:
 
           if [ "${BUILDTOOL}" == "cppcheck" ]; then
               cppcheck --quiet \
-                       --library=gtk \
                        -Isrc/tests/fixtures \
+                       --library=gtk \
+                       --library=src/tests/extra/cppcheck.cfg \
                        --suppressions-list=src/tests/extra/cppcheck.supp \
                        --xml \
                        src 2> _build/meson-logs/cppcheck.xml
@@ -152,8 +157,9 @@ jobs:
 
               cppcheck --quiet \
                        --error-exitcode=1 \
-                       --library=gtk \
                        -Isrc/tests/fixtures \
+                       --library=gtk \
+                       --library=src/tests/extra/cppcheck.cfg \
                        --suppressions-list=src/tests/extra/cppcheck.supp \
                        src
           elif [ "${BUILDTOOL}" == "GCC" ]; then
@@ -162,7 +168,7 @@ jobs:
               ninja -C _build scan-build
           fi
 
-      - name: Report (${{ matrix.label }})
+      - name: Report
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:

--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -500,7 +500,6 @@ static ValentDevice *
 valent_device_manager_ensure_device (ValentDeviceManager *manager,
                                      JsonNode            *identity)
 {
-  ValentDevice *device = NULL;
   const char *device_id;
 
   g_assert (VALENT_IS_DEVICE_MANAGER (manager));
@@ -513,18 +512,18 @@ valent_device_manager_ensure_device (ValentDeviceManager *manager,
       return NULL;
     }
 
-  if ((device = g_hash_table_lookup (manager->devices, device_id)) == NULL)
+  if (!g_hash_table_contains (manager->devices, device_id))
     {
+      g_autoptr (ValentDevice) device = NULL;
       g_autoptr (ValentData) data = NULL;
 
       data = valent_data_new (device_id, manager->data);
       device = valent_device_new_full (identity, data);
 
       valent_device_manager_add_device (manager, device);
-      g_object_unref (device);
     }
 
-  return device;
+  return g_hash_table_lookup (manager->devices, device_id);
 }
 
 static void

--- a/src/tests/extra/cppcheck.cfg
+++ b/src/tests/extra/cppcheck.cfg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: No rights reserved -->
+
+<!-- See: https://github.com/danmar/cppcheck/pull/4247 -->
+<def format="2">
+  <define name="G_DEFINE_TYPE(TN, t_n, T_P)" value=""/>
+  <define name="G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(TypeName, func)" value=""/>
+  <define name="G_DEFINE_AUTO_CLEANUP_FREE_FUNC(TypeName, func, none)" value=""/>
+  <define name="G_DEFINE_AUTOPTR_CLEANUP_FUNC(TypeName, func)" value=""/>
+</def>

--- a/src/tests/extra/cppcheck.supp
+++ b/src/tests/extra/cppcheck.supp
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: No rights reserved
 
-# src/libvalent/core/valent-device-manager.c
-deallocret:src/libvalent/core/valent-device-manager.c:527
-
 # src/libvalent/notifications/valent-notification.c
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:88
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:89

--- a/src/tests/extra/cppcheck.supp
+++ b/src/tests/extra/cppcheck.supp
@@ -4,9 +4,6 @@
 # src/libvalent/core/valent-device-manager.c
 deallocret:src/libvalent/core/valent-device-manager.c:527
 
-# src/libvalent/contacts/
-unknownMacro:src/libvalent/contacts/valent-eds.h:30
-
 # src/libvalent/notifications/valent-notification.c
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:88
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:89
@@ -19,25 +16,11 @@ leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:866
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:885
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:888
 
-# src/libvalent/ui/
-unknownMacro:src/libvalent/ui/valent-application.c:36
-unknownMacro:src/libvalent/ui/valent-preferences-window.c:49
-
-
-# src/plugins/bluez/
-unknownMacro:src/plugins/bluez/valent-bluez-channel-service.c:29
-
 # src/plugins/sms/
 memleak:src/plugins/sms/valent-sms-store.c:809
 memleak:src/plugins/sms/valent-sms-store.c:859
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:583
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:588
-
-# src/plugins/systemvolume/
-unknownMacro:src/plugins/systemvolume/valent-systemvolume-plugin.c:32
-
-# src/plugins/telephony/
-unknownMacro:src/plugins/telephony/valent-telephony-plugin.c:29
 
 
 # src/tests/fixtures/


### PR DESCRIPTION
Remove the `unknownMacro` suppressions and add `cppcheck.cfg` with
proper macro definitions, until the macros are included upstream.