### PR TITLE
wip/andyholmes/connectivity_report

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2022-07-13 14:59-0700\n"
+"POT-Creation-Date: 2022-07-14 20:56-0700\n"
 "PO-Revision-Date: 2022-03-28 11:21-0700\n"
 "Last-Translator: Andy Holmes <andrew.g.r.holmes@gmail.com>\n"
 "Language-Team: English <andrew.g.r.holmes@gmail.com>\n"
@@ -451,15 +451,37 @@ msgstr ""
 msgid "Sync network connectivity status"
 msgstr ""
 
-#. TRANSLATORS: This is <device name>: No Service
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:287
-#, c-format
-msgid "%s: No Service"
+#. TRANSLATORS: When the mobile network signal is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
+msgid "Mobile Network"
 msgstr ""
 
-#. TRANSLATORS: This indicates the remote device has lost service
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:289
-msgid "No mobile network service."
+#. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:174
+#, c-format
+msgid "Signal Strength %f%%"
+msgstr ""
+
+#. TRANSLATORS: When no mobile service is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:180
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:187
+msgid "No Service"
+msgstr ""
+
+#. TRANSLATORS: When no mobile network signal is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:182
+msgid "No mobile network service"
+msgstr ""
+
+#. TRANSLATORS: When the device is missing a SIM card
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:189
+msgid "No SIM"
+msgstr ""
+
+#. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:317
+#, c-format
+msgid "%s: %s"
 msgstr ""
 
 #: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12

--- a/po/valent.pot
+++ b/po/valent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2022-07-13 14:59-0700\n"
+"POT-Creation-Date: 2022-07-14 20:56-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -451,15 +451,37 @@ msgstr ""
 msgid "Sync network connectivity status"
 msgstr ""
 
-#. TRANSLATORS: This is <device name>: No Service
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:287
-#, c-format
-msgid "%s: No Service"
+#. TRANSLATORS: When the mobile network signal is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
+msgid "Mobile Network"
 msgstr ""
 
-#. TRANSLATORS: This indicates the remote device has lost service
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:289
-msgid "No mobile network service."
+#. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:174
+#, c-format
+msgid "Signal Strength %f%%"
+msgstr ""
+
+#. TRANSLATORS: When no mobile service is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:180
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:187
+msgid "No Service"
+msgstr ""
+
+#. TRANSLATORS: When no mobile network signal is available
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:182
+msgid "No mobile network service"
+msgstr ""
+
+#. TRANSLATORS: When the device is missing a SIM card
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:189
+msgid "No SIM"
+msgstr ""
+
+#. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:317
+#, c-format
+msgid "%s: %s"
 msgstr ""
 
 #: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12

--- a/src/plugins/battery/valent-battery-gadget.c
+++ b/src/plugins/battery/valent-battery-gadget.c
@@ -119,7 +119,9 @@ on_action_state_changed (GActionGroup        *action_group,
 
   gtk_level_bar_set_value (GTK_LEVEL_BAR (self->level_bar), percentage);
   gtk_label_set_text (GTK_LABEL (self->label), label);
-  gtk_widget_set_visible (self->button, TRUE);
+
+  if (g_action_group_get_action_enabled (action_group, action_name))
+    gtk_widget_set_visible (self->button, TRUE);
 }
 
 static void

--- a/src/plugins/connectivity_report/valent-connectivity_report-gadget.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-gadget.c
@@ -6,7 +6,6 @@
 #include "config.h"
 
 #include <gtk/gtk.h>
-#include <glib/gi18n.h>
 #include <libvalent-core.h>
 #include <libvalent-ui.h>
 

--- a/src/plugins/connectivity_report/valent-connectivity_report-gadget.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-gadget.c
@@ -119,7 +119,8 @@ on_action_state_changed (GActionGroup        *action_group,
   if (g_variant_lookup (value, "title", "&s", &title))
     gtk_widget_set_tooltip_text (GTK_WIDGET (self->button), title);
 
-  gtk_widget_set_visible (self->button, TRUE);
+  if (g_action_group_get_action_enabled (action_group, action_name))
+    gtk_widget_set_visible (self->button, TRUE);
 }
 
 static void

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -261,7 +261,7 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
   /* Update the GAction */
   action = g_action_map_lookup_action (G_ACTION_MAP (self), "state");
   g_simple_action_set_enabled (G_SIMPLE_ACTION (action),
-                               g_variant_n_children (state) > 0);
+                               json_object_get_size (signal_strengths) > 0);
   g_simple_action_set_state (G_SIMPLE_ACTION (action), state);
 
   /* Notify if necessary */
@@ -269,7 +269,6 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
     {
       valent_device_plugin_hide_notification (VALENT_DEVICE_PLUGIN (self),
                                               "offline");
-
     }
   else if (g_settings_get_boolean (self->settings, "offline-notification"))
     {

--- a/src/tests/extra/cppcheck.supp
+++ b/src/tests/extra/cppcheck.supp
@@ -26,13 +26,14 @@ leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:117
 leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:173
 
 # src/tests/plugins/connectivity_report/
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:227
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:229
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:231
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:247
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:253
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:255
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:257
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:265
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:267
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:269
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:271
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:275
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:284
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:286
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:288
 
 # src/tests/plugins/bluez/
 memleak:src/tests/plugins/bluez/test-bluez-plugin.c:183

--- a/src/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
+++ b/src/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
@@ -103,7 +103,7 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
   packet = valent_test_fixture_lookup_packet (fixture, "modemless-report");
   valent_test_fixture_handle_packet (fixture, packet);
 
-  g_assert_true (g_action_group_get_action_enabled (actions, "connectivity_report.state"));
+  g_assert_false (g_action_group_get_action_enabled (actions, "connectivity_report.state"));
   state = g_action_group_get_action_state (actions, "connectivity_report.state");
 
   g_variant_lookup (state, "signal-strengths", "@a{sv}", &signal_strengths);


### PR DESCRIPTION
* respect the plugin's opinion about the action state of gadgets
* show the "offline" icon when appropriate, instead of "no signal"
* improve the status labels in the state action
* remove unused instance fields of ValentConnectivityReportPlugin
* remove unused import in ValentConnectivityReportGadget