### PR TITLE
test: propagate output from python wrapper for timeouts

### DIFF
--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -307,7 +307,7 @@ valent_telephony_plugin_handle_telephony (ValentTelephonyPlugin *self,
       valent_notification_add_device_button (notification,
                                              device,
                                              _("Mute"),
-                                             "mute-call",
+                                             "telephony.mute-call",
                                              NULL);
       g_notification_set_priority (notification,
                                    G_NOTIFICATION_PRIORITY_URGENT);

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -340,9 +340,9 @@ valent_telephony_plugin_mute_call (ValentTelephonyPlugin *self)
  * GActions
  */
 static void
-mute_action (GSimpleAction *action,
-             GVariant      *parameter,
-             gpointer       user_data)
+mute_call_action (GSimpleAction *action,
+                  GVariant      *parameter,
+                  gpointer       user_data)
 {
   ValentTelephonyPlugin *self = VALENT_TELEPHONY_PLUGIN (user_data);
 
@@ -352,7 +352,7 @@ mute_action (GSimpleAction *action,
 }
 
 static const GActionEntry actions[] = {
-    {"mute-call", mute_action, NULL, NULL, NULL}
+    {"mute-call", mute_call_action, NULL, NULL, NULL}
 };
 
 /*

--- a/src/tests/fixtures/glibtest.py
+++ b/src/tests/fixtures/glibtest.py
@@ -123,6 +123,15 @@ class GLibTestCase(metaclass = _GLibTestCaseMeta):
                                   check=True,
                                   encoding='utf-8')
 
+        # NOTE: If the meson timeout is reached, *this* process will be killed
+        #       and output from the test executable will not be propagated.
+        except subprocess.TimeoutExpired as error:
+            stdout = '' if not error.stdout else error.stdout.decode('utf-8')
+            stderr = '' if not error.stderr else error.stderr.decode('utf-8')
+
+            # pylint: disable-next=no-member
+            self.fail(f'\nstdout:\n{stdout}\nstderr:\n{stderr}') # type: ignore
+
         # On failure, preserve the output and pipe
         except subprocess.CalledProcessError as error:
             # pylint: disable-next=no-member


### PR DESCRIPTION
If a test run with the `glibtest.py` wrapper, or a dbusmock derivation,
times out, be sure to propagate the output to aid in debugging.

Unfortunately, if the meson timeout is reached before the script's then
the process is killed and the output never propagated. Make a note of
this if someone goes looking for a reason.