### PR TITLE
fix: address potential exploits from CVE-2020-26164

### DIFF
--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -13,13 +13,6 @@
 #include "valent-lan-channel-service.h"
 #include "valent-lan-utils.h"
 
-#define PROTOCOL_ADDR        "255.255.255.255"
-#define PROTOCOL_PORT        (1716)
-#define TRANSFER_PORT_MIN    (1739)
-#define TRANSFER_PORT_MAX    (1764)
-
-#define IDENTITY_BUFFER_MAX  (8192)
-
 #define IDENTITY_BUFFER_MAX  (8192)
 #define IDENTITY_TIMEOUT_MAX (1000)
 
@@ -284,10 +277,12 @@ on_incoming_broadcast (ValentLanChannelService  *self,
   host = g_inet_address_to_string (iaddr);
 
   if (valent_packet_get_int (peer_identity, "tcpPort", &port) &&
-      (port < 0 || port > G_MAXUINT16))
+      (port < VALENT_LAN_PROTOCOL_PORT_MIN || port > VALENT_LAN_PROTOCOL_PORT_MAX))
     {
-      g_warning ("%s(): expected \"tcpPort\" field holding a uint16",
-                 G_STRFUNC);
+      g_warning ("%s(): expected \"tcpPort\" field holding a uint16 between %u-%u",
+                 G_STRFUNC,
+                 VALENT_LAN_PROTOCOL_PORT_MIN,
+                 VALENT_LAN_PROTOCOL_PORT_MAX);
       return TRUE;
     }
 
@@ -621,7 +616,7 @@ valent_lan_channel_service_identify (ValentChannelService *service,
       g_autoptr (GError) error = NULL;
 
       naddr = G_NETWORK_ADDRESS (g_network_address_parse (target,
-                                                          PROTOCOL_PORT,
+                                                          VALENT_LAN_PROTOCOL_PORT,
                                                           &error));
 
       if (naddr == NULL)
@@ -892,7 +887,7 @@ valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
    */
   properties [PROP_BROADCAST_ADDRESS] =
     g_param_spec_string ("broadcast-address", NULL, NULL,
-                         PROTOCOL_ADDR,
+                         VALENT_LAN_PROTOCOL_ADDR,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |
                           G_PARAM_EXPLICIT_NOTIFY |
@@ -913,15 +908,16 @@ valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
   /**
    * ValentLanChannelService:port:
    *
-   * The TCP/IP port for the service. The current KDE Connect protocol (v7)
-   * defines port 1716 as the default.
+   * The TCP/IP port for the service.
+   *
+   * The current KDE Connect protocol (v7) defines port 1716 as the default.
    *
    * This available as a construct property primarily for use in unit tests.
    */
   properties [PROP_PORT] =
     g_param_spec_uint ("port", NULL, NULL,
-                       1024, G_MAXUINT16,
-                       PROTOCOL_PORT,
+                       VALENT_LAN_PROTOCOL_PORT_MIN, VALENT_LAN_PROTOCOL_PORT_MAX,
+                       VALENT_LAN_PROTOCOL_PORT,
                        (G_PARAM_READWRITE |
                         G_PARAM_CONSTRUCT_ONLY |
                         G_PARAM_EXPLICIT_NOTIFY |

--- a/src/plugins/lan/valent-lan-channel.h
+++ b/src/plugins/lan/valent-lan-channel.h
@@ -7,6 +7,52 @@
 
 G_BEGIN_DECLS
 
+/**
+ * VALENT_LAN_PROTOCOL_ADDR: (value "255.255.255.255")
+ *
+ * The default broadcast address used by the KDE Connect protocol.
+ */
+#define VALENT_LAN_PROTOCOL_ADDR     "255.255.255.255"
+
+/**
+ * VALENT_LAN_PROTOCOL_PORT: (value 1716)
+ *
+ * The default port used by the KDE Connect protocol for UDP discovery and
+ * JSON packet exchange.
+ */
+#define VALENT_LAN_PROTOCOL_PORT     (1716)
+
+/**
+ * VALENT_LAN_PROTOCOL_PORT_MIN: (value 1716)
+ *
+ * The minimum port used by the KDE Connect protocol.
+ */
+#define VALENT_LAN_PROTOCOL_PORT_MIN (1716)
+
+/**
+ * VALENT_LAN_PROTOCOL_PORT_MAX: (value 1764)
+ *
+ * The maximum port used by the KDE Connect protocol.
+ */
+#define VALENT_LAN_PROTOCOL_PORT_MAX (1764)
+
+/**
+ * VALENT_LAN_TRANSFER_PORT_MIN: (value 1739)
+ *
+ * The minimum port used by the KDE Connect protocol for auxiliary streams,
+ * such as file transfers.
+ */
+#define VALENT_LAN_TRANSFER_PORT_MIN (1739)
+
+/**
+ * VALENT_LAN_PROTOCOL_PORT_MIN: (value 1764)
+ *
+ * The maximum port used by the KDE Connect protocol for auxiliary streams,
+ * such as file transfers.
+ */
+#define VALENT_LAN_TRANSFER_PORT_MAX (1764)
+
+
 #define VALENT_TYPE_LAN_CHANNEL (valent_lan_channel_get_type())
 
 G_DECLARE_FINAL_TYPE (ValentLanChannel, valent_lan_channel, VALENT, LAN_CHANNEL, ValentChannel)

--- a/src/tests/data/plugin-lan.json
+++ b/src/tests/data/plugin-lan.json
@@ -15,7 +15,7 @@
         "kdeconnect.mock.echo",
         "kdeconnect.mock.transfer"
       ],
-      "tcpPort": 3716
+      "tcpPort": 1717
     }
   },
   "transfer": {

--- a/src/tests/fixtures/valent-mock-channel.c
+++ b/src/tests/fixtures/valent-mock-channel.c
@@ -11,7 +11,9 @@
 
 #include "valent-mock-channel.h"
 
-#define VALENT_TEST_TCP_PORT 2716
+#define VALENT_MOCK_PROTOCOL_PORT_DEFAULT (1717)
+#define VALENT_MOCK_PROTOCOL_PORT_MIN     (1717)
+#define VALENT_MOCK_PROTOCOL_PORT_MAX     (1764)
 
 
 struct _ValentMockChannel
@@ -243,8 +245,8 @@ valent_mock_channel_class_init (ValentMockChannelClass *klass)
    */
   properties [PROP_PORT] =
     g_param_spec_uint ("port", NULL, NULL,
-                       1024, G_MAXUINT16,
-                       VALENT_TEST_TCP_PORT,
+                       VALENT_MOCK_PROTOCOL_PORT_MIN, VALENT_MOCK_PROTOCOL_PORT_MAX,
+                       VALENT_MOCK_PROTOCOL_PORT_DEFAULT,
                        (G_PARAM_READWRITE |
                         G_PARAM_CONSTRUCT_ONLY |
                         G_PARAM_EXPLICIT_NOTIFY |

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -10,12 +10,16 @@
 #include "valent-lan-channel.h"
 #include "valent-lan-channel-service.h"
 
-#define ENDPOINT_ADDR "127.0.0.1:3716"
-#define ENDPOINT_HOST "127.0.0.1"
-#define ENDPOINT_PORT 3716
-#define SERVICE_ADDR  "127.0.0.1:2716"
-#define SERVICE_HOST  "127.0.0.1"
-#define SERVICE_PORT  2716
+/* NOTE: These ports must be between 1716-1764 or they will trigger an error.
+ *       Port 1716 is still avoided, since it would conflict with a running
+ *       service when testing on a real system.
+ */
+#define ENDPOINT_ADDR          "127.0.0.1:1717"
+#define ENDPOINT_HOST          "127.0.0.1"
+#define ENDPOINT_PORT          (1717)
+#define SERVICE_ADDR           "127.0.0.1:1718"
+#define SERVICE_HOST           "127.0.0.1"
+#define SERVICE_PORT           (1718)
 
 #define IDENTITY_BUFFER_MAX    (8192)
 


### PR DESCRIPTION
A number of potential vulnerabilities in `kdeconnect-kde` identified in
CVE-2020-26164[1] also affect Valent. The summary here references the
security review report[2] published by Matthias Gerstner.

Of the 8 security issues (3.a-h), 4 are applicable (3.d, 3.e, 3.f, 3.h), 2 are
not applicable (3.b, 3.c), and 2 were previously addressed (3.a, 3.g).

* [X] set a maximum size for incoming identity packets `3.d(i)`

     When reading the identity from an incoming connection, set a limit of
     8KiB for the peer identity packet.

* [X] set a limit on concurrent unpaired connections `3.d(ii)`

    When handling a new `ValentChannel`, limit the maximum number of
    concurrent unpaired connections to 10.

* [X] set a maximum time to wait for a peer to authenticate `3.d(ii)`

    When accepting an incoming connection, set a timeout of 1000ms for the
    peer to write its identity packet and negotiate a TLS connection.

* [X] restrict outgoing connection ports to the protocol range `3.e`

    When receiving an incoming broadcast, limit outgoing connections to the
    protocol port range (`1716-1764`).

* [x] reject incoming connections with incongruent certificates `3.f, 3.h`

    When accepting incoming connections, reject any with certificates that
    don't match existing connections.

References:
[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26164
[2]: https://www.openwall.com/lists/oss-security/2020/10/13/4