### PR TITLE
fix(lan): never trust the device ID from the identity packet

### DIFF
--- a/src/libvalent/core/valent-certificate.c
+++ b/src/libvalent/core/valent-certificate.c
@@ -21,10 +21,6 @@
 #define SHA256_HEX_LEN 64
 #define SHA256_STR_LEN 96
 
-G_DEFINE_QUARK (VALENT_CERTIFICATE_CN, valent_certificate_cn);
-G_DEFINE_QUARK (VALENT_CERTIFICATE_FP, valent_certificate_fp);
-G_DEFINE_QUARK (VALENT_CERTIFICATE_PK, valent_certificate_pk);
-
 
 /**
  * valent_certificate_generate:
@@ -312,8 +308,8 @@ valent_certificate_get_common_name (GTlsCertificate *certificate)
   g_return_val_if_fail (G_IS_TLS_CERTIFICATE (certificate), NULL);
 
   /* Check */
-  device_id = g_object_get_qdata (G_OBJECT (certificate),
-                                  valent_certificate_cn_quark());
+  device_id = g_object_get_data (G_OBJECT (certificate),
+                                 "valent-certificate-cn");
 
   if G_LIKELY (device_id != NULL)
     return device_id;
@@ -341,13 +337,12 @@ valent_certificate_get_common_name (GTlsCertificate *certificate)
   gnutls_x509_crt_deinit (crt);
 
   /* Intern the id as private data */
-  g_object_set_qdata_full (G_OBJECT (certificate),
-                           valent_certificate_cn_quark(),
-                           g_strndup (buf, buf_size),
-                           g_free);
+  g_object_set_data_full (G_OBJECT (certificate),
+                          "valent-certificate-cn",
+                          g_strndup (buf, buf_size),
+                          g_free);
 
-  return g_object_get_qdata (G_OBJECT (certificate),
-                             valent_certificate_cn_quark());
+  return g_object_get_data (G_OBJECT (certificate), "valent-certificate-cn");
 }
 
 /**
@@ -373,8 +368,8 @@ valent_certificate_get_fingerprint (GTlsCertificate *certificate)
 
   g_return_val_if_fail (G_IS_TLS_CERTIFICATE (certificate), NULL);
 
-  fingerprint = g_object_get_qdata (G_OBJECT (certificate),
-                                    valent_certificate_fp_quark());
+  fingerprint = g_object_get_data (G_OBJECT (certificate),
+                                   "valent-certificate-fp");
 
   if G_LIKELY (fingerprint != NULL)
     return fingerprint;
@@ -394,13 +389,12 @@ valent_certificate_get_fingerprint (GTlsCertificate *certificate)
   buf[SHA256_STR_LEN - 1] = '\0';
 
   /* Intern the hash as private data */
-  g_object_set_qdata_full (G_OBJECT (certificate),
-                           valent_certificate_fp_quark(),
-                           g_strdup (buf),
-                           g_free);
+  g_object_set_data_full (G_OBJECT (certificate),
+                          "valent-certificate-fp",
+                          g_strdup (buf),
+                          g_free);
 
-  return g_object_get_qdata (G_OBJECT (certificate),
-                             valent_certificate_fp_quark());
+  return g_object_get_data (G_OBJECT (certificate), "valent-certificate-fp");
 }
 
 /**
@@ -426,8 +420,8 @@ valent_certificate_get_public_key (GTlsCertificate *certificate)
 
   g_return_val_if_fail (G_IS_TLS_CERTIFICATE (certificate), NULL);
 
-  pubkey = g_object_get_qdata (G_OBJECT (certificate),
-                               valent_certificate_pk_quark());
+  pubkey = g_object_get_data (G_OBJECT (certificate),
+                              "valent-certificate-pk");
 
   if (pubkey != NULL)
     return g_steal_pointer (&pubkey);
@@ -463,13 +457,13 @@ valent_certificate_get_public_key (GTlsCertificate *certificate)
                                  GNUTLS_X509_FMT_DER,
                                  pubkey->data, &size);
 
-      /* Intern the PEM as private data */
+      /* Intern the DER as private data */
       if (rc == GNUTLS_E_SUCCESS)
         {
-          g_object_set_qdata_full (G_OBJECT (certificate),
-                                   valent_certificate_pk_quark(),
-                                   g_steal_pointer (&pubkey),
-                                   (GDestroyNotify)g_byte_array_unref);
+          g_object_set_data_full (G_OBJECT (certificate),
+                                  "valent-certificate-pk",
+                                  g_steal_pointer (&pubkey),
+                                  (GDestroyNotify)g_byte_array_unref);
         }
       else
         g_warning ("%s(): %s", G_STRFUNC, gnutls_strerror (rc));
@@ -481,7 +475,6 @@ valent_certificate_get_public_key (GTlsCertificate *certificate)
     gnutls_x509_crt_deinit (crt);
     gnutls_pubkey_deinit (crt_pk);
 
-  return g_object_get_qdata (G_OBJECT (certificate),
-                             valent_certificate_pk_quark());
+  return g_object_get_data (G_OBJECT (certificate), "valent-certificate-pk");
 }
 

--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -103,21 +103,18 @@ on_incoming_connection (ValentChannelService   *service,
   if (peer_identity == NULL)
     return TRUE;
 
-  /* Now that we have the device ID we can authorize or reject certificates.
-   * NOTE: We're the client when accepting incoming connections */
-  valent_object_lock (VALENT_OBJECT (self));
-
+  /* Ignore identity packets without a deviceId */
   if (!valent_packet_get_string (peer_identity, "deviceId", &device_id))
     {
       g_warning ("%s(): expected \"deviceId\" field holding a string",
                  G_STRFUNC);
-      valent_object_unlock (VALENT_OBJECT (self));
       return TRUE;
     }
 
+  /* NOTE: We're the client when accepting incoming connections */
+  valent_object_lock (VALENT_OBJECT (self));
   tls_stream = valent_lan_encrypt_new_client (connection,
                                               self->certificate,
-                                              device_id,
                                               cancellable,
                                               NULL);
   valent_object_unlock (VALENT_OBJECT (self));
@@ -281,7 +278,6 @@ on_incoming_broadcast (ValentLanChannelService  *self,
   valent_object_lock (VALENT_OBJECT (self));
   tls_stream = valent_lan_encrypt_new_server (connection,
                                               self->certificate,
-                                              device_id,
                                               cancellable,
                                               &warn);
   valent_object_unlock (VALENT_OBJECT (self));

--- a/src/plugins/lan/valent-lan-utils.h
+++ b/src/plugins/lan/valent-lan-utils.h
@@ -9,7 +9,6 @@ G_BEGIN_DECLS
 
 GIOStream * valent_lan_encrypt_new_client (GSocketConnection  *connection,
                                            GTlsCertificate    *certificate,
-                                           const char         *device_id,
                                            GCancellable       *cancellable,
                                            GError            **error);
 GIOStream * valent_lan_encrypt_client     (GSocketConnection  *connection,
@@ -19,7 +18,6 @@ GIOStream * valent_lan_encrypt_client     (GSocketConnection  *connection,
                                            GError            **error);
 GIOStream * valent_lan_encrypt_new_server (GSocketConnection  *connection,
                                            GTlsCertificate    *certificate,
-                                           const char         *device_id,
                                            GCancellable       *cancellable,
                                            GError            **error);
 GIOStream * valent_lan_encrypt_server     (GSocketConnection  *connection,

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -142,7 +142,6 @@ g_socket_listener_accept_cb (GSocketListener   *listener,
 
   tls_stream = valent_lan_encrypt_new_client (connection,
                                               fixture->certificate,
-                                              device_id,
                                               NULL,
                                               &error);
   g_assert_no_error (error);
@@ -419,7 +418,6 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
    */
   tls_stream = valent_lan_encrypt_new_server (connection,
                                               fixture->certificate,
-                                              "test-device",
                                               NULL,
                                               &error);
   g_assert_no_error (error);


### PR DESCRIPTION
The TLS certificate is the single source of truth for a device's ID, so
never trust the ID from the identity packet.