### PR TITLE
test(ci): use `dir` type for sources in flatpak test manifest

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Tests.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Tests.json
@@ -227,9 +227,8 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/andyholmes/valent.git",
-                    "branch" : "main"
+                    "type" : "dir",
+                    "path" : "../../"
                 }
             ]
         }


### PR DESCRIPTION
When running flatpak tests, use `type: dir` for sources so tests are run
on the current `HEAD` commit instead of `type: git` which resulted in
tests being run on the current revision in the `main` branch.