### PR TITLE
refactor(lan): make channel "certificate" property read-only

### DIFF
--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -255,11 +255,10 @@ on_incoming_connection (ValentChannelService   *service,
   identity = valent_channel_service_ref_identity (service);
   channel = g_object_new (VALENT_TYPE_LAN_CHANNEL,
                           "base-stream",   tls_stream,
-                          "certificate",   certificate,
                           "host",          host,
+                          "port",          self->port,
                           "identity",      identity,
                           "peer-identity", peer_identity,
-                          "port",          self->port,
                           NULL);
 
   valent_channel_service_emit_channel (service, channel);
@@ -424,7 +423,6 @@ on_incoming_broadcast (ValentLanChannelService  *self,
   /* Create new channel */
   channel = g_object_new (VALENT_TYPE_LAN_CHANNEL,
                           "base-stream",   tls_stream,
-                          "certificate",   certificate,
                           "host",          host,
                           "port",          port,
                           "identity",      identity,

--- a/src/plugins/lan/valent-lan-channel.c
+++ b/src/plugins/lan/valent-lan-channel.c
@@ -225,7 +225,7 @@ valent_lan_channel_store_data (ValentChannel *channel,
   g_autofree char *certificate_path = NULL;
   g_autoptr (GError) error = NULL;
 
-  g_assert (VALENT_IS_CHANNEL (channel));
+  g_assert (VALENT_IS_LAN_CHANNEL (channel));
   g_assert (VALENT_IS_DATA (data));
 
   /* Chain-up first */
@@ -355,8 +355,7 @@ valent_lan_channel_class_init (ValentLanChannelClass *klass)
   properties [PROP_CERTIFICATE] =
     g_param_spec_object ("certificate", NULL, NULL,
                          G_TYPE_TLS_CERTIFICATE,
-                         (G_PARAM_READWRITE |
-                          G_PARAM_CONSTRUCT_ONLY |
+                         (G_PARAM_READABLE |
                           G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));
 
@@ -418,14 +417,15 @@ valent_lan_channel_init (ValentLanChannel *self)
 GTlsCertificate *
 valent_lan_channel_ref_certificate (ValentLanChannel *self)
 {
+  g_autoptr (GIOStream) base_stream = NULL;
   GTlsCertificate *ret = NULL;
 
   g_return_val_if_fail (VALENT_IS_LAN_CHANNEL (self), NULL);
 
-  valent_object_lock (VALENT_OBJECT (self));
-  if (self->certificate != NULL)
-    ret = g_object_ref (self->certificate);
-  valent_object_unlock (VALENT_OBJECT (self));
+  base_stream = valent_channel_ref_base_stream (VALENT_CHANNEL (self));
+
+  if (base_stream != NULL)
+    g_object_get (base_stream, "certificate", &ret, NULL);
 
   return g_steal_pointer (&ret);
 }

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -170,11 +170,10 @@ g_socket_listener_accept_cb (GSocketListener   *listener,
                                      "identity");
   fixture->endpoint = g_object_new (VALENT_TYPE_LAN_CHANNEL,
                                     "base-stream",   tls_stream,
-                                    "certificate",   fixture->certificate,
                                     "host",          SERVICE_HOST,
+                                    "port",          SERVICE_PORT,
                                     "identity",      identity,
                                     "peer-identity", peer_identity,
-                                    "port",          SERVICE_PORT,
                                     NULL);
 }
 
@@ -482,7 +481,6 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
    */
   fixture->endpoint = g_object_new (VALENT_TYPE_LAN_CHANNEL,
                                     "base-stream",   tls_stream,
-                                    "certificate",   fixture->certificate,
                                     "host",          SERVICE_HOST,
                                     "port",          SERVICE_PORT,
                                     "identity",      identity,

--- a/src/tests/plugins/lan/test-lan-plugin.c
+++ b/src/tests/plugins/lan/test-lan-plugin.c
@@ -760,38 +760,38 @@ main (int   argc,
   g_type_ensure (VALENT_TYPE_LAN_CHANNEL);
   g_type_ensure (VALENT_TYPE_LAN_CHANNEL_SERVICE);
 
-  /* g_test_add ("/backends/lan-backend/incoming-broadcast", */
-  /*             LanBackendFixture, NULL, */
-  /*             lan_service_fixture_set_up, */
-  /*             test_lan_service_incoming_broadcast, */
-  /*             lan_service_fixture_tear_down); */
+  g_test_add ("/backends/lan-backend/incoming-broadcast",
+              LanBackendFixture, NULL,
+              lan_service_fixture_set_up,
+              test_lan_service_incoming_broadcast,
+              lan_service_fixture_tear_down);
 
-  /* g_test_add_func ("/backends/lan-backend/incoming-broadcast-oversize", */
-  /*                  test_lan_service_incoming_broadcast_oversize); */
+  g_test_add_func ("/backends/lan-backend/incoming-broadcast-oversize",
+                   test_lan_service_incoming_broadcast_oversize);
 
-  /* g_test_add ("/backends/lan-backend/outgoing-broadcast", */
-  /*             LanBackendFixture, NULL, */
-  /*             lan_service_fixture_set_up, */
-  /*             test_lan_service_outgoing_broadcast, */
-  /*             lan_service_fixture_tear_down); */
+  g_test_add ("/backends/lan-backend/outgoing-broadcast",
+              LanBackendFixture, NULL,
+              lan_service_fixture_set_up,
+              test_lan_service_outgoing_broadcast,
+              lan_service_fixture_tear_down);
 
-  /* g_test_add_func ("/backends/lan-backend/outgoing-broadcast-oversize", */
-  /*                  test_lan_service_outgoing_broadcast_oversize); */
+  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-oversize",
+                   test_lan_service_outgoing_broadcast_oversize);
 
-  /* g_test_add_func ("/backends/lan-backend/outgoing-broadcast-timeout", */
-  /*                  test_lan_service_outgoing_broadcast_timeout); */
+  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-timeout",
+                   test_lan_service_outgoing_broadcast_timeout);
 
-  /* g_test_add_func ("/backends/lan-backend/outgoing-broadcast-tls-auth", */
-  /*                  test_lan_service_outgoing_broadcast_tls_timeout); */
+  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-tls-auth",
+                   test_lan_service_outgoing_broadcast_tls_timeout);
 
   g_test_add_func ("/backends/lan-backend/outgoing-broadcast-tls-cert",
                    test_lan_service_outgoing_broadcast_tls_spoofer);
 
-  /* g_test_add ("/backends/lan-backend/channel", */
-  /*             LanBackendFixture, NULL, */
-  /*             lan_service_fixture_set_up, */
-  /*             test_lan_service_channel, */
-  /*             lan_service_fixture_tear_down); */
+  g_test_add ("/backends/lan-backend/channel",
+              LanBackendFixture, NULL,
+              lan_service_fixture_set_up,
+              test_lan_service_channel,
+              lan_service_fixture_tear_down);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Refactor the `certificate` property  of `ValentLanChannel` to match
`peer-certificate`, proxying the `GTlsConnection` properties.