### PR TITLE
refactor(device): remove the "paired" property

### DIFF
--- a/data/ca.andyholmes.Valent.xml
+++ b/data/ca.andyholmes.Valent.xml
@@ -8,7 +8,6 @@
     <property type="b" name="Connected" access="read"/>
     <property type="s" name="Id" access="read"/>
     <property type="s" name="Name" access="read"/>
-    <property type="b" name="Paired" access="read"/>
     <property type="s" name="IconName" access="read"/>
     <property type="u" name="State" access="read"/>
     <property type="s" name="Type" access="read"/>

--- a/src/libvalent/core/valent-device-impl.c
+++ b/src/libvalent/core/valent-device-impl.c
@@ -65,14 +65,6 @@ static const GDBusPropertyInfo iface_property_name = {
   NULL
 };
 
-static const GDBusPropertyInfo iface_property_paired = {
-  -1,
-  "Paired",
-  "b",
-  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
-  NULL
-};
-
 static const GDBusPropertyInfo iface_property_state = {
   -1,
   "State",
@@ -94,7 +86,6 @@ static const GDBusPropertyInfo * const iface_properties[] = {
   &iface_property_icon_name,
   &iface_property_id,
   &iface_property_name,
-  &iface_property_paired,
   &iface_property_state,
   &iface_property_type,
   NULL,
@@ -123,7 +114,6 @@ typedef struct
 static PropertyMapping property_map[] = {
     { "state",     G_TYPE_UINT,    &iface_property_state },
     { "connected", G_TYPE_BOOLEAN, &iface_property_connected },
-    { "paired",    G_TYPE_BOOLEAN, &iface_property_paired },
     { "name",      G_TYPE_STRING,  &iface_property_name },
     { "icon-name", G_TYPE_STRING,  &iface_property_icon_name },
     { "type",      G_TYPE_STRING,  &iface_property_type },

--- a/src/libvalent/core/valent-device-manager.c
+++ b/src/libvalent/core/valent-device-manager.c
@@ -242,14 +242,14 @@ valent_device_manager_check_device (ValentDeviceManager *self,
   gpointer value;
   unsigned int n_unpaired = 0;
 
-  if (valent_device_get_paired (device))
+  if ((valent_device_get_state (device) & VALENT_DEVICE_STATE_PAIRED) != 0)
     return TRUE;
 
   g_hash_table_iter_init (&iter, self->devices);
 
   while (g_hash_table_iter_next (&iter, NULL, &value))
     {
-      if (!valent_device_get_paired (VALENT_DEVICE (value)))
+      if ((valent_device_get_state (value) & VALENT_DEVICE_STATE_PAIRED) == 0)
         n_unpaired++;
     }
 

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -88,7 +88,6 @@ enum {
   PROP_ICON_NAME,
   PROP_ID,
   PROP_NAME,
-  PROP_PAIRED,
   PROP_STATE,
   PROP_TYPE,
   N_PROPERTIES
@@ -932,10 +931,6 @@ valent_device_get_property (GObject    *object,
       g_value_set_string (value, self->name);
       break;
 
-    case PROP_PAIRED:
-      g_value_set_boolean (value, self->paired);
-      break;
-
     case PROP_STATE:
       g_value_set_flags (value, valent_device_get_state (self));
       break;
@@ -1097,30 +1092,9 @@ valent_device_class_init (ValentDeviceClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   /**
-   * ValentDevice:paired: (getter get_paired)
-   *
-   * Whether the device is paired.
-   *
-   * This property indicates whether the device is paired with respect to the
-   * KDE Connect protocol and may be unrelated to the underlying transport
-   * protocol (eg. Bluetooth).
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PAIRED] =
-    g_param_spec_boolean ("paired", NULL, NULL,
-                          FALSE,
-                          (G_PARAM_READABLE |
-                           G_PARAM_EXPLICIT_NOTIFY |
-                           G_PARAM_STATIC_STRINGS));
-
-  /**
    * ValentDevice:state: (getter get_state)
    *
    * The state of the device.
-   *
-   * This is intended to provide more granular information about the state than
-   * [property@Valent.Device:connected] or [property@Valent.Device:paired].
    *
    * Since: 1.0
    */
@@ -1706,31 +1680,7 @@ valent_device_get_name (ValentDevice *device)
 }
 
 /**
- * valent_device_get_paired: (get-property paired)
- * @device: a #ValentDevice
- *
- * Get whether the device is paired.
- *
- * Returns: %TRUE if the device is paired, or %FALSE if unpaired
- *
- * Since: 1.0
- */
-gboolean
-valent_device_get_paired (ValentDevice *device)
-{
-  gboolean ret;
-
-  g_return_val_if_fail (VALENT_IS_DEVICE (device), FALSE);
-
-  valent_object_lock (VALENT_OBJECT (device));
-  ret = device->paired;
-  valent_object_unlock (VALENT_OBJECT (device));
-
-  return ret;
-}
-
-/**
- * valent_device_set_paired: (set-property paired)
+ * valent_device_set_paired:
  * @device: a #ValentDevice
  * @paired: %TRUE if paired, %FALSE if unpaired
  *
@@ -1738,8 +1688,6 @@ valent_device_get_paired (ValentDevice *device)
  *
  * NOTE: since valent_device_update_plugins() will be called as a side effect,
  * this must be called after valent_device_send_pair().
- *
- * Since: 1.0
  */
 void
 valent_device_set_paired (ValentDevice *device,
@@ -1771,7 +1719,6 @@ valent_device_set_paired (ValentDevice *device,
 
   /* Update plugins and notify */
   valent_device_update_plugins (device);
-  valent_object_notify_by_pspec (G_OBJECT (device), properties [PROP_PAIRED]);
   valent_object_notify_by_pspec (G_OBJECT (device), properties [PROP_STATE]);
 }
 

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -60,8 +60,6 @@ GMenuModel        * valent_device_get_menu           (ValentDevice         *devi
 VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_name           (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-gboolean            valent_device_get_paired         (ValentDevice         *device);
-VALENT_AVAILABLE_IN_1_0
 GPtrArray         * valent_device_get_plugins        (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
 ValentDeviceState   valent_device_get_state          (ValentDevice         *device);

--- a/src/libvalent/ui/valent-device-preferences-window.c
+++ b/src/libvalent/ui/valent-device-preferences-window.c
@@ -171,6 +171,19 @@ on_plugin_removed (ValentDevice                  *device,
     gtk_list_box_remove (self->plugin_list, row);
 }
 
+static gboolean
+device_state_transform_to (GBinding     *binding,
+                           const GValue *from_value,
+                           GValue       *to_value,
+                           gpointer      user_data)
+{
+  ValentDeviceState state = g_value_get_flags (from_value);
+
+  g_value_set_boolean (to_value, (state & VALENT_DEVICE_STATE_PAIRED) != 0);
+
+  return TRUE;
+}
+
 /*
  * GActions
  */
@@ -219,9 +232,11 @@ valent_device_preferences_window_constructed (GObject *object)
   g_object_bind_property (self->device, "name",
                           self,         "title",
                           G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE);
-  g_object_bind_property (self->device,       "paired",
-                          self->unpair_group, "visible",
-                          G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE);
+  g_object_bind_property_full (self->device,       "state",
+                               self->unpair_group, "visible",
+                               G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE,
+                               device_state_transform_to, NULL,
+                               NULL, NULL);
 
   gtk_widget_insert_action_group (GTK_WIDGET (self),
                                   "device",

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -25,6 +25,12 @@ get_packet (DeviceFixture *fixture,
   return json_object_get_member (json_node_get_object (fixture->packets), name);
 }
 
+static inline gboolean
+valent_device_get_paired (ValentDevice *device)
+{
+  return (valent_device_get_state (device) & VALENT_DEVICE_STATE_PAIRED) != 0;
+}
+
 static void
 device_fixture_set_up (DeviceFixture *fixture,
                        gconstpointer  user_data)
@@ -127,7 +133,6 @@ test_device_new (void)
   g_autofree char *name = NULL;
   g_autofree char *type = NULL;
   gboolean connected;
-  gboolean paired;
 
   GMenuModel *menu;
   GPtrArray *plugins;
@@ -141,7 +146,6 @@ test_device_new (void)
                 "name",      &name,
                 "type",      &type,
                 "connected", &connected,
-                "paired",    &paired,
                 NULL);
 
   /* id should be set, but everything else should be %FALSE or %NULL */
@@ -150,7 +154,6 @@ test_device_new (void)
   g_assert_null (type);
   g_assert_null (name);
   g_assert_false (connected);
-  g_assert_false (paired);
 
   menu = valent_device_get_menu (device);
   g_assert_true (G_IS_MENU (menu));
@@ -176,7 +179,6 @@ test_device_basic (DeviceFixture *fixture,
   g_autofree char *icon_name = NULL;
   g_autofree char *type = NULL;
   gboolean connected;
-  gboolean paired;
   ValentDeviceState state = VALENT_DEVICE_STATE_NONE;
   GPtrArray *plugins;
 
@@ -188,7 +190,6 @@ test_device_basic (DeviceFixture *fixture,
                 "icon-name",        &icon_name,
                 "type",             &type,
                 "connected",        &connected,
-                "paired",           &paired,
                 "state",            &state,
                 NULL);
 
@@ -202,8 +203,6 @@ test_device_basic (DeviceFixture *fixture,
   g_assert_cmpstr (type, ==, "phone");
   g_assert_false (connected);
   g_assert_false (valent_device_get_connected (fixture->device));
-  g_assert_false (paired);
-  g_assert_false (valent_device_get_paired (fixture->device));
   g_assert_cmpuint (state, ==, VALENT_DEVICE_STATE_NONE);
   g_assert_cmpuint (valent_device_get_state (fixture->device), ==, VALENT_DEVICE_STATE_NONE);
 


### PR DESCRIPTION
The `Valent.Device:paired` property is rarely needed in isolation, so
migrate the few remaining uses and remove it from the public API, in
favour of `Valent.Device:state`.