### PR TITLE
refactor(device): remove the "connected" property

### DIFF
--- a/data/ca.andyholmes.Valent.xml
+++ b/data/ca.andyholmes.Valent.xml
@@ -5,7 +5,6 @@
 
 <node>
   <interface name="ca.andyholmes.Valent.Device">
-    <property type="b" name="Connected" access="read"/>
     <property type="s" name="Id" access="read"/>
     <property type="s" name="Name" access="read"/>
     <property type="s" name="IconName" access="read"/>

--- a/src/libvalent/core/valent-device-impl.c
+++ b/src/libvalent/core/valent-device-impl.c
@@ -33,14 +33,6 @@ static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 /*
  * ca.andyholmes.Valent.Device Interface
  */
-static const GDBusPropertyInfo iface_property_connected = {
-  -1,
-  "Connected",
-  "b",
-  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
-  NULL
-};
-
 static const GDBusPropertyInfo iface_property_icon_name = {
   -1,
   "IconName",
@@ -82,7 +74,6 @@ static const GDBusPropertyInfo iface_property_type = {
 };
 
 static const GDBusPropertyInfo * const iface_properties[] = {
-  &iface_property_connected,
   &iface_property_icon_name,
   &iface_property_id,
   &iface_property_name,
@@ -113,7 +104,6 @@ typedef struct
 
 static PropertyMapping property_map[] = {
     { "state",     G_TYPE_UINT,    &iface_property_state },
-    { "connected", G_TYPE_BOOLEAN, &iface_property_connected },
     { "name",      G_TYPE_STRING,  &iface_property_name },
     { "icon-name", G_TYPE_STRING,  &iface_property_icon_name },
     { "type",      G_TYPE_STRING,  &iface_property_type },

--- a/src/libvalent/core/valent-device.h
+++ b/src/libvalent/core/valent-device.h
@@ -50,8 +50,6 @@ ValentChannel     * valent_device_ref_channel        (ValentDevice         *devi
 VALENT_AVAILABLE_IN_1_0
 ValentData        * valent_device_ref_data           (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-gboolean            valent_device_get_connected      (ValentDevice         *device);
-VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_icon_name      (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_id             (ValentDevice         *device);

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -86,7 +86,7 @@ on_notification_added (ValentNotifications      *listener,
 
   device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
 
-  if (!valent_device_get_connected (device))
+  if ((valent_device_get_state (device) & VALENT_DEVICE_STATE_CONNECTED) == 0)
     {
       VALENT_TODO ("Cache notifications for later sending?");
       return;
@@ -112,7 +112,7 @@ on_notification_removed (ValentNotifications      *listener,
 
   device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
 
-  if (!valent_device_get_connected (device))
+  if ((valent_device_get_state (device) & VALENT_DEVICE_STATE_CONNECTED) == 0)
     {
       VALENT_TODO ("Cache notifications for later removal?");
       return;

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -26,6 +26,12 @@ get_packet (DeviceFixture *fixture,
 }
 
 static inline gboolean
+valent_device_get_connected (ValentDevice *device)
+{
+  return (valent_device_get_state (device) & VALENT_DEVICE_STATE_CONNECTED) != 0;
+}
+
+static inline gboolean
 valent_device_get_paired (ValentDevice *device)
 {
   return (valent_device_get_state (device) & VALENT_DEVICE_STATE_PAIRED) != 0;
@@ -132,7 +138,7 @@ test_device_new (void)
   g_autofree char *id = NULL;
   g_autofree char *name = NULL;
   g_autofree char *type = NULL;
-  gboolean connected;
+  ValentDeviceState state = VALENT_DEVICE_STATE_NONE;
 
   GMenuModel *menu;
   GPtrArray *plugins;
@@ -144,16 +150,16 @@ test_device_new (void)
                 "id",        &id,
                 "icon-name", &icon_name,
                 "name",      &name,
+                "state",     &state,
                 "type",      &type,
-                "connected", &connected,
                 NULL);
 
   /* id should be set, but everything else should be %FALSE or %NULL */
   g_assert_cmpstr (id, ==, "test-device");
   g_assert_null (icon_name);
-  g_assert_null (type);
   g_assert_null (name);
-  g_assert_false (connected);
+  g_assert_cmpuint (state, ==, VALENT_DEVICE_STATE_NONE);
+  g_assert_null (type);
 
   menu = valent_device_get_menu (device);
   g_assert_true (G_IS_MENU (menu));
@@ -178,7 +184,6 @@ test_device_basic (DeviceFixture *fixture,
   g_autofree char *name = NULL;
   g_autofree char *icon_name = NULL;
   g_autofree char *type = NULL;
-  gboolean connected;
   ValentDeviceState state = VALENT_DEVICE_STATE_NONE;
   GPtrArray *plugins;
 
@@ -189,7 +194,6 @@ test_device_basic (DeviceFixture *fixture,
                 "name",             &name,
                 "icon-name",        &icon_name,
                 "type",             &type,
-                "connected",        &connected,
                 "state",            &state,
                 NULL);
 
@@ -201,8 +205,6 @@ test_device_basic (DeviceFixture *fixture,
   g_assert_cmpstr (icon_name, ==, "phone-symbolic");
   g_assert_cmpstr (valent_device_get_icon_name (fixture->device), ==, "phone-symbolic");
   g_assert_cmpstr (type, ==, "phone");
-  g_assert_false (connected);
-  g_assert_false (valent_device_get_connected (fixture->device));
   g_assert_cmpuint (state, ==, VALENT_DEVICE_STATE_NONE);
   g_assert_cmpuint (valent_device_get_state (fixture->device), ==, VALENT_DEVICE_STATE_NONE);
 


### PR DESCRIPTION
As with `Valent.Device:property`, this connected state is better
expressed by the `Valent.Device:state` property. Remove this property
from the public API and D-Bus interface.