### PR TITLE
test(fixtures): cleanup some helpers

### DIFF
--- a/src/tests/fixtures/valent-test-fixture.c
+++ b/src/tests/fixtures/valent-test-fixture.c
@@ -38,16 +38,6 @@ expect_packet_cb (ValentChannel  *channel,
     g_critical ("%s(): %s", G_STRFUNC, error->message);
 }
 
-static gboolean
-valent_test_fixture_wait_cb (gpointer data)
-{
-  ValentTestFixture *fixture = data;
-
-  valent_test_fixture_quit (fixture);
-
-  return G_SOURCE_REMOVE;
-}
-
 static void
 valent_test_fixture_free (gpointer data)
 {
@@ -84,7 +74,7 @@ valent_test_fixture_init (ValentTestFixture *fixture,
   valent_device_set_paired (fixture->device, TRUE);
 
   /* Init channels */
-  channels = valent_test_channels (identity, identity);
+  channels = valent_test_channel_pair (identity, identity);
   fixture->channel = g_steal_pointer (&channels[0]);
   fixture->endpoint = g_steal_pointer(&channels[1]);
 }
@@ -275,23 +265,6 @@ valent_test_fixture_quit (ValentTestFixture *fixture)
   g_assert (fixture != NULL);
 
   g_main_loop_quit (fixture->loop);
-}
-
-/**
- * valent_test_fixture_wait:
- * @fixture: a #ValentTestFixture
- * @interval: time to wait in milliseconds
- *
- * Iterate the #GMainLoop of @fixture for @interval milliseconds.
- */
-void
-valent_test_fixture_wait (ValentTestFixture *fixture,
-                          unsigned int       interval)
-{
-  g_assert (fixture != NULL);
-
-  g_timeout_add (interval, valent_test_fixture_wait_cb, fixture);
-  g_main_loop_run (fixture->loop);
 }
 
 /**

--- a/src/tests/fixtures/valent-test-fixture.h
+++ b/src/tests/fixtures/valent-test-fixture.h
@@ -42,8 +42,6 @@ void                valent_test_fixture_connect       (ValentTestFixture  *fixtu
                                                        gboolean            connected);
 void                valent_test_fixture_run           (ValentTestFixture  *fixture);
 void                valent_test_fixture_quit          (ValentTestFixture  *fixture);
-void                valent_test_fixture_wait          (ValentTestFixture  *fixture,
-                                                       unsigned int        interval);
 gpointer            valent_test_fixture_get_data      (ValentTestFixture  *fixture);
 void                valent_test_fixture_set_data      (ValentTestFixture  *fixture,
                                                        gpointer            data,

--- a/src/tests/fixtures/valent-test-utils.c
+++ b/src/tests/fixtures/valent-test-utils.c
@@ -307,11 +307,38 @@ valent_test_load_json (const char *path)
   return json_parser_steal_root (parser);
 }
 
+static gboolean
+valent_test_wait_cb (gpointer data)
+{
+  gboolean *done = data;
+
+  if (done != NULL)
+    *done = TRUE;
+
+  return G_SOURCE_REMOVE;
+}
+
 /**
- * valent_test_channels:
+ * valent_test_wait:
+ * @duration: the time to wait, in milliseconds
+ *
+ * Iterate the default main context for @duration.
+ */
+void
+valent_test_wait (unsigned int duration)
+{
+  gboolean done = FALSE;
+
+  g_timeout_add (duration, valent_test_wait_cb, &done);
+
+  while (!done)
+    g_main_context_iteration (NULL, FALSE);
+}
+
+/**
+ * valent_test_channel_pair:
  * @identity: a #JsonNode
  * @peer_identity: (nullable): a #JsonNode
- * @port: the local port
  *
  * Create a pair of connected channels with @identity representing the local
  * device and @peer_identity representing the endpoint device.
@@ -319,8 +346,8 @@ valent_test_load_json (const char *path)
  * Returns: (array length=2) (element-type Valent.Channel): a pair of #ValentChannel
  */
 ValentChannel **
-valent_test_channels (JsonNode *identity,
-                      JsonNode *peer_identity)
+valent_test_channel_pair (JsonNode *identity,
+                          JsonNode *peer_identity)
 {
   ValentChannel **channels = NULL;
   int sv[2] = { 0, };

--- a/src/tests/libvalent/core/test-device-transfer.c
+++ b/src/tests/libvalent/core/test-device-transfer.c
@@ -56,7 +56,7 @@ test_device_transfer (ValentTestFixture *fixture,
   g_assert_no_error (error);
 
   /* Ensure the download task has time to set the file mtime */
-  valent_test_fixture_wait (fixture, 1);
+  valent_test_wait (1);
 
   dest_dir = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
   dest = valent_data_get_file (dest_dir, "image.png", FALSE);

--- a/src/tests/libvalent/core/test-device.c
+++ b/src/tests/libvalent/core/test-device.c
@@ -52,7 +52,7 @@ device_fixture_set_up (DeviceFixture *fixture,
   fixture->device = valent_device_new_full (identity, NULL);
 
   /* Init Channels */
-  channels = valent_test_channels (identity, identity);
+  channels = valent_test_channel_pair (identity, identity);
   fixture->channel = g_steal_pointer (&channels[0]);
   fixture->endpoint = g_steal_pointer (&channels[1]);
 }

--- a/src/tests/plugins/notification/test-notification-plugin.c
+++ b/src/tests/plugins/notification/test-notification-plugin.c
@@ -62,7 +62,7 @@ test_notification_plugin_handle_notification (ValentTestFixture *fixture,
 
   // FIXME: Without this the notification plugin will reliably segfault, which
   //        ostensibly implies ValentDevicePlugin is not thread-safe
-  valent_test_fixture_wait (fixture, 1000);
+  valent_test_wait (1000);
 
   /* Receive a notification with actions */
   packet = valent_test_fixture_lookup_packet (fixture, "notification-actions");

--- a/src/tests/plugins/share/test-share-download.c
+++ b/src/tests/plugins/share/test-share-download.c
@@ -33,7 +33,7 @@ test_share_download_single (ValentTestFixture *fixture,
   g_assert_no_error (error);
 
   /* Ensure the download task has an opportunity to finish completely */
-  valent_test_fixture_wait (fixture, 1);
+  valent_test_wait (1);
 
   dest_dir = valent_data_get_directory (G_USER_DIRECTORY_DOWNLOAD);
   dest = valent_data_get_file (dest_dir, "image.png", FALSE);


### PR DESCRIPTION
* rename `valent_test_channels()` to `valent_test_channel_pair()`
* move `valent_test_fixture_wait()` to `valent_test_wait()` and iterate
  the default main context instead of a `GMainLoop`
* cleanup assertion macros, using more useful log messages and variable
  names that won't conflict with surrounding code