### PR TITLE
Clipboard Refactor

### DIFF
--- a/src/libvalent/clipboard/valent-clipboard-adapter.h
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.h
@@ -21,37 +21,65 @@ struct _ValentClipboardAdapterClass
   GObjectClass   parent_class;
 
   /* virtual functions */
-  void           (*get_text_async)  (ValentClipboardAdapter  *adapter,
-                                     GCancellable            *cancellable,
-                                     GAsyncReadyCallback      callback,
-                                     gpointer                 user_data);
-  char         * (*get_text_finish) (ValentClipboardAdapter  *adapter,
-                                     GAsyncResult            *result,
-                                     GError                 **error);
-  void           (*set_text)        (ValentClipboardAdapter  *adapter,
-                                     const char              *text);
-  gint64         (*get_timestamp)   (ValentClipboardAdapter  *adapter);
+  void           (*get_bytes)        (ValentClipboardAdapter  *adapter,
+                                      const char              *mimetype,
+                                      GCancellable            *cancellable,
+                                      GAsyncReadyCallback      callback,
+                                      gpointer                 user_data);
+  GBytes       * (*get_bytes_finish) (ValentClipboardAdapter  *adapter,
+                                      GAsyncResult            *result,
+                                      GError                 **error);
+  void           (*set_bytes)        (ValentClipboardAdapter  *adapter,
+                                      const char              *mimetype,
+                                      GBytes                  *bytes);
+  GStrv          (*get_mimetypes)    (ValentClipboardAdapter  *adapter);
+  void           (*get_text_async)   (ValentClipboardAdapter  *adapter,
+                                      GCancellable            *cancellable,
+                                      GAsyncReadyCallback      callback,
+                                      gpointer                 user_data);
+  char         * (*get_text_finish)  (ValentClipboardAdapter  *adapter,
+                                      GAsyncResult            *result,
+                                      GError                 **error);
+  void           (*set_text)         (ValentClipboardAdapter  *adapter,
+                                      const char              *text);
+  gint64         (*get_timestamp)    (ValentClipboardAdapter  *adapter);
 
   /* signals */
-  void           (*changed)         (ValentClipboardAdapter  *adapter);
+  void           (*changed)          (ValentClipboardAdapter  *adapter);
 };
 
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_emit_changed    (ValentClipboardAdapter  *adapter);
+void     valent_clipboard_adapter_emit_changed     (ValentClipboardAdapter  *adapter);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_get_text_async  (ValentClipboardAdapter  *adapter,
-                                                   GCancellable            *cancellable,
-                                                   GAsyncReadyCallback      callback,
-                                                   gpointer                 user_data);
+void     valent_clipboard_adapter_get_bytes        (ValentClipboardAdapter  *adapter,
+                                                    const char              *mimetype,
+                                                    GCancellable            *cancellable,
+                                                    GAsyncReadyCallback      callback,
+                                                    gpointer                 user_data);
 VALENT_AVAILABLE_IN_1_0
-char   * valent_clipboard_adapter_get_text_finish (ValentClipboardAdapter  *adapter,
-                                                   GAsyncResult            *result,
-                                                   GError                 **error);
+GBytes * valent_clipboard_adapter_get_bytes_finish (ValentClipboardAdapter  *adapter,
+                                                    GAsyncResult            *result,
+                                                    GError                 **error);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_set_text        (ValentClipboardAdapter  *adapter,
-                                                   const char              *text);
+void     valent_clipboard_adapter_set_bytes        (ValentClipboardAdapter  *adapter,
+                                                    const char              *mimetype,
+                                                    GBytes                  *bytes);
 VALENT_AVAILABLE_IN_1_0
-gint64   valent_clipboard_adapter_get_timestamp   (ValentClipboardAdapter  *adapter);
+GStrv    valent_clipboard_adapter_get_mimetypes    (ValentClipboardAdapter  *adapter);
+VALENT_AVAILABLE_IN_1_0
+void     valent_clipboard_adapter_get_text_async   (ValentClipboardAdapter  *adapter,
+                                                    GCancellable            *cancellable,
+                                                    GAsyncReadyCallback      callback,
+                                                    gpointer                 user_data);
+VALENT_AVAILABLE_IN_1_0
+char   * valent_clipboard_adapter_get_text_finish  (ValentClipboardAdapter  *adapter,
+                                                    GAsyncResult            *result,
+                                                    GError                 **error);
+VALENT_AVAILABLE_IN_1_0
+void     valent_clipboard_adapter_set_text         (ValentClipboardAdapter  *adapter,
+                                                    const char              *text);
+VALENT_AVAILABLE_IN_1_0
+gint64   valent_clipboard_adapter_get_timestamp    (ValentClipboardAdapter  *adapter);
 
 G_END_DECLS
 

--- a/src/libvalent/clipboard/valent-clipboard-adapter.h
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.h
@@ -21,65 +21,91 @@ struct _ValentClipboardAdapterClass
   GObjectClass   parent_class;
 
   /* virtual functions */
-  void           (*get_bytes)        (ValentClipboardAdapter  *adapter,
-                                      const char              *mimetype,
-                                      GCancellable            *cancellable,
-                                      GAsyncReadyCallback      callback,
-                                      gpointer                 user_data);
-  GBytes       * (*get_bytes_finish) (ValentClipboardAdapter  *adapter,
-                                      GAsyncResult            *result,
-                                      GError                 **error);
-  void           (*set_bytes)        (ValentClipboardAdapter  *adapter,
-                                      const char              *mimetype,
-                                      GBytes                  *bytes);
-  GStrv          (*get_mimetypes)    (ValentClipboardAdapter  *adapter);
-  void           (*get_text_async)   (ValentClipboardAdapter  *adapter,
-                                      GCancellable            *cancellable,
-                                      GAsyncReadyCallback      callback,
-                                      gpointer                 user_data);
-  char         * (*get_text_finish)  (ValentClipboardAdapter  *adapter,
-                                      GAsyncResult            *result,
-                                      GError                 **error);
-  void           (*set_text)         (ValentClipboardAdapter  *adapter,
-                                      const char              *text);
-  gint64         (*get_timestamp)    (ValentClipboardAdapter  *adapter);
+  GStrv          (*get_mimetypes)      (ValentClipboardAdapter  *adapter);
+  gint64         (*get_timestamp)      (ValentClipboardAdapter  *adapter);
+  void           (*read_bytes)         (ValentClipboardAdapter  *adapter,
+                                        const char              *mimetype,
+                                        GCancellable            *cancellable,
+                                        GAsyncReadyCallback      callback,
+                                        gpointer                 user_data);
+  GBytes       * (*read_bytes_finish)  (ValentClipboardAdapter  *adapter,
+                                        GAsyncResult            *result,
+                                        GError                 **error);
+  void           (*write_bytes)        (ValentClipboardAdapter  *adapter,
+                                        const char              *mimetype,
+                                        GBytes                  *bytes,
+                                        GCancellable            *cancellable,
+                                        GAsyncReadyCallback      callback,
+                                        gpointer                 user_data);
+  gboolean       (*write_bytes_finish) (ValentClipboardAdapter  *adapter,
+                                        GAsyncResult            *result,
+                                        GError                 **error);
+  void           (*read_text)          (ValentClipboardAdapter  *adapter,
+                                        GCancellable            *cancellable,
+                                        GAsyncReadyCallback      callback,
+                                        gpointer                 user_data);
+  char         * (*read_text_finish)   (ValentClipboardAdapter  *adapter,
+                                        GAsyncResult            *result,
+                                        GError                 **error);
+  void           (*write_text)         (ValentClipboardAdapter  *adapter,
+                                        const char              *text,
+                                        GCancellable            *cancellable,
+                                        GAsyncReadyCallback      callback,
+                                        gpointer                 user_data);
+  gboolean       (*write_text_finish)  (ValentClipboardAdapter  *adapter,
+                                        GAsyncResult            *result,
+                                        GError                 **error);
 
   /* signals */
-  void           (*changed)          (ValentClipboardAdapter  *adapter);
+  void           (*changed)            (ValentClipboardAdapter  *adapter);
 };
 
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_emit_changed     (ValentClipboardAdapter  *adapter);
+void       valent_clipboard_adapter_emit_changed       (ValentClipboardAdapter  *adapter);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_get_bytes        (ValentClipboardAdapter  *adapter,
-                                                    const char              *mimetype,
-                                                    GCancellable            *cancellable,
-                                                    GAsyncReadyCallback      callback,
-                                                    gpointer                 user_data);
+GStrv      valent_clipboard_adapter_get_mimetypes      (ValentClipboardAdapter  *adapter);
 VALENT_AVAILABLE_IN_1_0
-GBytes * valent_clipboard_adapter_get_bytes_finish (ValentClipboardAdapter  *adapter,
-                                                    GAsyncResult            *result,
-                                                    GError                 **error);
+gint64     valent_clipboard_adapter_get_timestamp      (ValentClipboardAdapter  *adapter);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_set_bytes        (ValentClipboardAdapter  *adapter,
-                                                    const char              *mimetype,
-                                                    GBytes                  *bytes);
+void       valent_clipboard_adapter_read_bytes         (ValentClipboardAdapter  *adapter,
+                                                        const char              *mimetype,
+                                                        GCancellable            *cancellable,
+                                                        GAsyncReadyCallback      callback,
+                                                        gpointer                 user_data);
 VALENT_AVAILABLE_IN_1_0
-GStrv    valent_clipboard_adapter_get_mimetypes    (ValentClipboardAdapter  *adapter);
+GBytes   * valent_clipboard_adapter_read_bytes_finish  (ValentClipboardAdapter  *adapter,
+                                                        GAsyncResult            *result,
+                                                        GError                 **error);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_get_text_async   (ValentClipboardAdapter  *adapter,
-                                                    GCancellable            *cancellable,
-                                                    GAsyncReadyCallback      callback,
-                                                    gpointer                 user_data);
+void       valent_clipboard_adapter_write_bytes        (ValentClipboardAdapter  *adapter,
+                                                        const char              *mimetype,
+                                                        GBytes                  *bytes,
+                                                        GCancellable            *cancellable,
+                                                        GAsyncReadyCallback      callback,
+                                                        gpointer                 user_data);
 VALENT_AVAILABLE_IN_1_0
-char   * valent_clipboard_adapter_get_text_finish  (ValentClipboardAdapter  *adapter,
-                                                    GAsyncResult            *result,
-                                                    GError                 **error);
+gboolean   valent_clipboard_adapter_write_bytes_finish (ValentClipboardAdapter  *adapter,
+                                                        GAsyncResult            *result,
+                                                        GError                 **error);
 VALENT_AVAILABLE_IN_1_0
-void     valent_clipboard_adapter_set_text         (ValentClipboardAdapter  *adapter,
-                                                    const char              *text);
+void       valent_clipboard_adapter_read_text          (ValentClipboardAdapter  *adapter,
+                                                        GCancellable            *cancellable,
+                                                        GAsyncReadyCallback      callback,
+                                                        gpointer                 user_data);
 VALENT_AVAILABLE_IN_1_0
-gint64   valent_clipboard_adapter_get_timestamp    (ValentClipboardAdapter  *adapter);
+char     * valent_clipboard_adapter_read_text_finish   (ValentClipboardAdapter  *adapter,
+                                                        GAsyncResult            *result,
+                                                        GError                 **error);
+VALENT_AVAILABLE_IN_1_0
+void      valent_clipboard_adapter_write_text          (ValentClipboardAdapter  *adapter,
+                                                        const char              *text,
+                                                        GCancellable            *cancellable,
+                                                        GAsyncReadyCallback      callback,
+                                                        gpointer                 user_data);
+VALENT_AVAILABLE_IN_1_0
+gboolean   valent_clipboard_adapter_write_text_finish  (ValentClipboardAdapter  *adapter,
+                                                        GAsyncResult            *result,
+                                                        GError                 **error);
 
 G_END_DECLS
 

--- a/src/libvalent/clipboard/valent-clipboard.h
+++ b/src/libvalent/clipboard/valent-clipboard.h
@@ -17,22 +17,37 @@ VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentClipboard, valent_clipboard, VALENT, CLIPBOARD, ValentComponent)
 
 VALENT_AVAILABLE_IN_1_0
-ValentClipboard * valent_clipboard_get_default     (void);
-
+ValentClipboard * valent_clipboard_get_default      (void);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_get_text_async  (ValentClipboard      *clipboard,
-                                                    GCancellable         *cancellable,
-                                                    GAsyncReadyCallback   callback,
-                                                    gpointer              user_data);
+void              valent_clipboard_get_bytes        (ValentClipboard      *clipboard,
+                                                     const char           *mimetype,
+                                                     GCancellable         *cancellable,
+                                                     GAsyncReadyCallback   callback,
+                                                     gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-char            * valent_clipboard_get_text_finish (ValentClipboard      *clipboard,
-                                                    GAsyncResult         *result,
-                                                    GError              **error);
+GBytes          * valent_clipboard_get_bytes_finish (ValentClipboard      *clipboard,
+                                                     GAsyncResult         *result,
+                                                     GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_set_text        (ValentClipboard      *clipboard,
-                                                    const char           *text);
+void              valent_clipboard_set_bytes        (ValentClipboard      *clipboard,
+                                                     const char           *mimetype,
+                                                     GBytes               *bytes);
 VALENT_AVAILABLE_IN_1_0
-gint64            valent_clipboard_get_timestamp   (ValentClipboard      *clipboard);
+GStrv             valent_clipboard_get_mimetypes    (ValentClipboard      *clipboard);
+VALENT_AVAILABLE_IN_1_0
+void              valent_clipboard_get_text_async   (ValentClipboard      *clipboard,
+                                                     GCancellable         *cancellable,
+                                                     GAsyncReadyCallback   callback,
+                                                     gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
+char            * valent_clipboard_get_text_finish  (ValentClipboard      *clipboard,
+                                                     GAsyncResult         *result,
+                                                     GError              **error);
+VALENT_AVAILABLE_IN_1_0
+void              valent_clipboard_set_text         (ValentClipboard      *clipboard,
+                                                     const char           *text);
+VALENT_AVAILABLE_IN_1_0
+gint64            valent_clipboard_get_timestamp    (ValentClipboard      *clipboard);
 
 G_END_DECLS
 

--- a/src/libvalent/clipboard/valent-clipboard.h
+++ b/src/libvalent/clipboard/valent-clipboard.h
@@ -17,37 +17,51 @@ VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentClipboard, valent_clipboard, VALENT, CLIPBOARD, ValentComponent)
 
 VALENT_AVAILABLE_IN_1_0
-ValentClipboard * valent_clipboard_get_default      (void);
+ValentClipboard * valent_clipboard_get_default        (void);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_get_bytes        (ValentClipboard      *clipboard,
-                                                     const char           *mimetype,
-                                                     GCancellable         *cancellable,
-                                                     GAsyncReadyCallback   callback,
-                                                     gpointer              user_data);
+GStrv             valent_clipboard_get_mimetypes      (ValentClipboard      *clipboard);
 VALENT_AVAILABLE_IN_1_0
-GBytes          * valent_clipboard_get_bytes_finish (ValentClipboard      *clipboard,
-                                                     GAsyncResult         *result,
-                                                     GError              **error);
+gint64            valent_clipboard_get_timestamp      (ValentClipboard      *clipboard);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_set_bytes        (ValentClipboard      *clipboard,
-                                                     const char           *mimetype,
-                                                     GBytes               *bytes);
+void              valent_clipboard_read_bytes         (ValentClipboard      *clipboard,
+                                                       const char           *mimetype,
+                                                       GCancellable         *cancellable,
+                                                       GAsyncReadyCallback   callback,
+                                                       gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-GStrv             valent_clipboard_get_mimetypes    (ValentClipboard      *clipboard);
+GBytes          * valent_clipboard_read_bytes_finish  (ValentClipboard      *clipboard,
+                                                       GAsyncResult         *result,
+                                                       GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_get_text_async   (ValentClipboard      *clipboard,
-                                                     GCancellable         *cancellable,
-                                                     GAsyncReadyCallback   callback,
-                                                     gpointer              user_data);
+void              valent_clipboard_write_bytes        (ValentClipboard      *clipboard,
+                                                       const char           *mimetype,
+                                                       GBytes               *bytes,
+                                                       GCancellable         *cancellable,
+                                                       GAsyncReadyCallback   callback,
+                                                       gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-char            * valent_clipboard_get_text_finish  (ValentClipboard      *clipboard,
-                                                     GAsyncResult         *result,
-                                                     GError              **error);
+gboolean          valent_clipboard_write_bytes_finish (ValentClipboard      *clipboard,
+                                                       GAsyncResult         *result,
+                                                       GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void              valent_clipboard_set_text         (ValentClipboard      *clipboard,
-                                                     const char           *text);
+void              valent_clipboard_read_text          (ValentClipboard      *clipboard,
+                                                       GCancellable         *cancellable,
+                                                       GAsyncReadyCallback   callback,
+                                                       gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-gint64            valent_clipboard_get_timestamp    (ValentClipboard      *clipboard);
+char            * valent_clipboard_read_text_finish   (ValentClipboard      *clipboard,
+                                                       GAsyncResult         *result,
+                                                       GError              **error);
+VALENT_AVAILABLE_IN_1_0
+void              valent_clipboard_write_text         (ValentClipboard      *clipboard,
+                                                       const char           *text,
+                                                       GCancellable         *cancellable,
+                                                       GAsyncReadyCallback   callback,
+                                                       gpointer              user_data);
+VALENT_AVAILABLE_IN_1_0
+gboolean          valent_clipboard_write_text_finish  (ValentClipboard      *clipboard,
+                                                       GAsyncResult         *result,
+                                                       GError              **error);
 
 G_END_DECLS
 

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -81,9 +81,9 @@ valent_clipboard_plugin_clipboard_connect (ValentClipboardPlugin *self,
 }
 
 static void
-get_text_cb (ValentClipboard       *clipboard,
-             GAsyncResult          *result,
-             ValentClipboardPlugin *self)
+valent_clipboard_read_text_cb (ValentClipboard       *clipboard,
+                               GAsyncResult          *result,
+                               ValentClipboardPlugin *self)
 {
   g_autoptr (GError) error = NULL;
   g_autofree char *text = NULL;
@@ -91,7 +91,7 @@ get_text_cb (ValentClipboard       *clipboard,
   g_assert (VALENT_IS_CLIPBOARD (clipboard));
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
 
-  text = valent_clipboard_get_text_finish (clipboard, result, &error);
+  text = valent_clipboard_read_text_finish (clipboard, result, &error);
 
   if (error != NULL)
     {
@@ -115,9 +115,9 @@ get_text_cb (ValentClipboard       *clipboard,
 }
 
 static void
-get_text_connect_cb (ValentClipboard       *clipboard,
-                     GAsyncResult          *result,
-                     ValentClipboardPlugin *self)
+valent_clipboard_read_text_connect_cb (ValentClipboard       *clipboard,
+                                       GAsyncResult          *result,
+                                       ValentClipboardPlugin *self)
 {
   g_autoptr (GError) error = NULL;
   g_autofree char *text = NULL;
@@ -125,7 +125,7 @@ get_text_connect_cb (ValentClipboard       *clipboard,
   g_assert (VALENT_IS_CLIPBOARD (clipboard));
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
 
-  text = valent_clipboard_get_text_finish (clipboard, result, &error);
+  text = valent_clipboard_read_text_finish (clipboard, result, &error);
 
   if (error != NULL)
     {
@@ -153,10 +153,10 @@ static void
 on_clipboard_changed (ValentClipboard       *clipboard,
                       ValentClipboardPlugin *self)
 {
-  valent_clipboard_get_text_async (clipboard,
-                                   NULL,
-                                   (GAsyncReadyCallback)get_text_cb,
-                                   self);
+  valent_clipboard_read_text (clipboard,
+                              NULL,
+                              (GAsyncReadyCallback)valent_clipboard_read_text_cb,
+                              self);
 }
 
 /*
@@ -185,7 +185,7 @@ valent_clipboard_plugin_handle_clipboard (ValentClipboardPlugin *self,
 
   /* Set clipboard */
   if (g_settings_get_boolean (self->settings, "auto-pull"))
-    valent_clipboard_set_text (self->clipboard, content);
+    valent_clipboard_write_text (self->clipboard, content, NULL, NULL, NULL);
 }
 
 static void
@@ -223,7 +223,7 @@ valent_clipboard_plugin_handle_clipboard_connect (ValentClipboardPlugin *self,
 
   /* Set clipboard */
   if (g_settings_get_boolean (self->settings, "auto-pull"))
-    valent_clipboard_set_text (self->clipboard, content);
+    valent_clipboard_write_text (self->clipboard, content, NULL, NULL, NULL);
 }
 
 /*
@@ -239,7 +239,11 @@ clipboard_pull_action (GSimpleAction *action,
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
 
   /* Set the local clipboard text from the remote buffer */
-  valent_clipboard_set_text (self->clipboard, self->remote_text);
+  valent_clipboard_write_text (self->clipboard,
+                               self->remote_text,
+                               NULL,
+                               NULL,
+                               NULL);
 }
 
 static void
@@ -320,10 +324,10 @@ valent_clipboard_plugin_update_state (ValentDevicePlugin *plugin,
                                              self);
 
       if (g_settings_get_boolean (self->settings, "auto-push"))
-        valent_clipboard_get_text_async (self->clipboard,
-                                         NULL,
-                                         (GAsyncReadyCallback)get_text_connect_cb,
-                                         self);
+        valent_clipboard_read_text (self->clipboard,
+                                    NULL,
+                                    (GAsyncReadyCallback)valent_clipboard_read_text_connect_cb,
+                                    self);
     }
   else
     {

--- a/src/tests/extra/lsan.supp
+++ b/src/tests/extra/lsan.supp
@@ -7,6 +7,9 @@ leak:libfontconfig.so
 # https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/merge_requests/1078
 leak:gst_gio_src_query
 
+# https://gitlab.gnome.org/GNOME/gtk/-/issues/5110
+leak:gdk_clipboard_read_text_async
+
 # https://gitlab.gnome.org/GNOME/gvfs/-/issues/577
 leak:g_daemon_vfs_init
 

--- a/src/tests/fixtures/valent-mock-clipboard-adapter.c
+++ b/src/tests/fixtures/valent-mock-clipboard-adapter.c
@@ -17,6 +17,7 @@ struct _ValentMockClipboardAdapter
   ValentClipboardAdapter  parent_instance;
 
   char                   *text;
+  GStrv                   mimetypes;
   gint64                  timestamp;
 };
 
@@ -29,6 +30,63 @@ static ValentClipboardAdapter *test_instance = NULL;
  * ValentClipboardAdapter
  */
 static void
+valent_mock_clipboard_adapter_get_bytes (ValentClipboardAdapter *adapter,
+                                         const char             *mimetype,
+                                         GCancellable           *cancellable,
+                                         GAsyncReadyCallback     callback,
+                                         gpointer                user_data)
+{
+  ValentMockClipboardAdapter *self = VALENT_MOCK_CLIPBOARD_ADAPTER (adapter);
+  g_autoptr (GTask) task = NULL;
+
+  g_assert (VALENT_IS_MOCK_CLIPBOARD_ADAPTER (self));
+  g_assert (mimetype != NULL && *mimetype != '\0');
+  g_assert (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+
+  if (self->text == NULL)
+    {
+      g_task_return_new_error (task,
+                               G_IO_ERROR,
+                               G_IO_ERROR_NOT_FOUND,
+                               "Clipboard empty");
+      return;
+    }
+
+  task = g_task_new (self, cancellable, callback, user_data);
+  g_task_set_source_tag (task, valent_mock_clipboard_adapter_get_bytes);
+  g_task_return_pointer (task,
+                         g_bytes_new (self->text, strlen (self->text) + 1),
+                         (GDestroyNotify)g_bytes_unref);
+}
+
+static void
+valent_mock_clipboard_adapter_set_bytes (ValentClipboardAdapter *adapter,
+                                         const char             *mimetype,
+                                         GBytes                 *bytes)
+{
+  ValentMockClipboardAdapter *self = VALENT_MOCK_CLIPBOARD_ADAPTER (adapter);
+  const char *text = NULL;
+
+  g_assert (VALENT_IS_MOCK_CLIPBOARD_ADAPTER (self));
+  g_assert (bytes == NULL || (mimetype != NULL && *mimetype != '\0'));
+
+  if (bytes != NULL && g_str_has_prefix (mimetype, "text/plain"))
+    text = g_bytes_get_data (bytes, NULL);
+
+  if (g_strcmp0 (self->text, text) == 0)
+    return;
+
+  g_clear_pointer (&self->mimetypes, g_strfreev);
+  g_clear_pointer (&self->text, g_free);
+
+  self->mimetypes = g_strdupv ((char *[]){"text/plain;charset=utf-8", NULL});
+  self->text = g_strdup (text);
+  self->timestamp = valent_timestamp_ms ();
+
+  valent_clipboard_adapter_emit_changed (adapter);
+}
+
+static void
 valent_mock_clipboard_adapter_get_text_async (ValentClipboardAdapter *adapter,
                                               GCancellable           *cancellable,
                                               GAsyncReadyCallback     callback,
@@ -38,6 +96,7 @@ valent_mock_clipboard_adapter_get_text_async (ValentClipboardAdapter *adapter,
   g_autoptr (GTask) task = NULL;
 
   g_assert (VALENT_IS_MOCK_CLIPBOARD_ADAPTER (self));
+  g_assert (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
 
   task = g_task_new (self, cancellable, callback, user_data);
   g_task_return_pointer (task, g_strdup (self->text), g_free);
@@ -54,10 +113,24 @@ valent_mock_clipboard_adapter_set_text (ValentClipboardAdapter *adapter,
   if (g_strcmp0 (self->text, text) == 0)
     return;
 
+  g_clear_pointer (&self->mimetypes, g_strfreev);
   g_clear_pointer (&self->text, g_free);
+
+  self->mimetypes = g_strdupv ((char *[]){"text/plain;charset=utf-8", NULL});
   self->text = g_strdup (text);
   self->timestamp = valent_timestamp_ms ();
+
   valent_clipboard_adapter_emit_changed (adapter);
+}
+
+static char **
+valent_mock_clipboard_adapter_get_mimetypes (ValentClipboardAdapter *adapter)
+{
+  ValentMockClipboardAdapter *self = VALENT_MOCK_CLIPBOARD_ADAPTER (adapter);
+
+  g_assert (VALENT_IS_MOCK_CLIPBOARD_ADAPTER (self));
+
+  return g_strdupv (self->mimetypes);
 }
 
 static gint64
@@ -70,7 +143,6 @@ valent_mock_clipboard_adapter_get_timestamp (ValentClipboardAdapter *adapter)
   return self->timestamp;
 }
 
-
 /*
  * GObject
  */
@@ -79,6 +151,7 @@ valent_mock_clipboard_adapter_finalize (GObject *object)
 {
   ValentMockClipboardAdapter *self = VALENT_MOCK_CLIPBOARD_ADAPTER (object);
 
+  g_clear_pointer (&self->mimetypes, g_strfreev);
   g_clear_pointer (&self->text, g_free);
 
   G_OBJECT_CLASS (valent_mock_clipboard_adapter_parent_class)->finalize (object);
@@ -92,6 +165,9 @@ valent_mock_clipboard_adapter_class_init (ValentMockClipboardAdapterClass *klass
 
   object_class->finalize = valent_mock_clipboard_adapter_finalize;
 
+  clipboard_class->get_bytes = valent_mock_clipboard_adapter_get_bytes;
+  clipboard_class->set_bytes = valent_mock_clipboard_adapter_set_bytes;
+  clipboard_class->get_mimetypes = valent_mock_clipboard_adapter_get_mimetypes;
   clipboard_class->get_text_async = valent_mock_clipboard_adapter_get_text_async;
   clipboard_class->set_text = valent_mock_clipboard_adapter_set_text;
   clipboard_class->get_timestamp = valent_mock_clipboard_adapter_get_timestamp;
@@ -100,6 +176,7 @@ valent_mock_clipboard_adapter_class_init (ValentMockClipboardAdapterClass *klass
 static void
 valent_mock_clipboard_adapter_init (ValentMockClipboardAdapter *self)
 {
+  self->mimetypes = g_strdupv ((char *[]){"text/plain;charset=utf-8", NULL});
   self->text = g_strdup ("connect");
 
   if (test_instance == NULL)

--- a/src/tests/libvalent/clipboard/test-clipboard-component.c
+++ b/src/tests/libvalent/clipboard/test-clipboard-component.c
@@ -45,13 +45,41 @@ on_changed (ValentClipboardAdapter    *adapter,
 }
 
 static void
+adapter_get_bytes_cb (ValentClipboardAdapter    *adapter,
+                      GAsyncResult              *result,
+                      ClipboardComponentFixture *fixture)
+{
+  GError *error = NULL;
+
+  fixture->data = valent_clipboard_adapter_get_bytes_finish (adapter,
+                                                             result,
+                                                             &error);
+  g_assert_no_error (error);
+  g_main_loop_quit (fixture->loop);
+}
+
+static void
 adapter_get_text_cb (ValentClipboardAdapter    *adapter,
                      GAsyncResult              *result,
                      ClipboardComponentFixture *fixture)
 {
   GError *error = NULL;
 
-  fixture->data = valent_clipboard_adapter_get_text_finish (adapter, result, &error);
+  fixture->data = valent_clipboard_adapter_get_text_finish (adapter,
+                                                            result,
+                                                            &error);
+  g_assert_no_error (error);
+  g_main_loop_quit (fixture->loop);
+}
+
+static void
+get_bytes_cb (ValentClipboard           *clipboard,
+              GAsyncResult              *result,
+              ClipboardComponentFixture *fixture)
+{
+  GError *error = NULL;
+
+  fixture->data = valent_clipboard_get_bytes_finish (clipboard, result, &error);
   g_assert_no_error (error);
   g_main_loop_quit (fixture->loop);
 }
@@ -72,17 +100,79 @@ static void
 test_clipboard_component_adapter (ClipboardComponentFixture *fixture,
                                   gconstpointer              user_data)
 {
-  g_autofree char *text = NULL;
   PeasPluginInfo *info;
+  g_autoptr (GBytes) bytes = NULL;
+  g_autofree char *text = NULL;
+  g_auto (GStrv) mimetypes = NULL;
+  gint64 timestamp = 0;
 
-  /* Properties */
+  /* Adapter Properties */
   g_object_get (fixture->adapter,
                 "plugin-info", &info,
                 NULL);
   g_assert_nonnull (info);
   g_boxed_free (PEAS_TYPE_PLUGIN_INFO, info);
 
-  /* Signals */
+  /* Data can be written */
+  text = g_uuid_string_random ();
+  bytes = g_bytes_new_take (text, strlen (text) + 1);
+  text = NULL;
+  valent_clipboard_adapter_set_bytes (fixture->adapter,
+                                      "text/plain;charset=utf-8",
+                                      bytes);
+
+  /* Data can be read */
+  valent_clipboard_adapter_get_bytes (fixture->adapter,
+                                      "text/plain;charset=utf-8",
+                                      NULL,
+                                      (GAsyncReadyCallback)adapter_get_bytes_cb,
+                                      fixture);
+  g_main_loop_run (fixture->loop);
+
+  g_assert_cmpmem (g_bytes_get_data (bytes, NULL),
+                   g_bytes_get_size (bytes),
+                   g_bytes_get_data (fixture->data, NULL),
+                   g_bytes_get_size (fixture->data));
+  g_clear_pointer (&fixture->data, g_bytes_unref);
+
+  /* Timestamp is updated */
+  timestamp = valent_clipboard_adapter_get_timestamp (fixture->adapter);
+  g_assert_cmpint (timestamp, !=, 0);
+
+  /* Mimetypes are updated */
+  mimetypes = valent_clipboard_adapter_get_mimetypes (fixture->adapter);
+  g_assert_nonnull (mimetypes);
+  g_assert_true (g_strv_contains ((const char * const *)mimetypes,
+                                  "text/plain;charset=utf-8"));
+  g_clear_pointer (&mimetypes, g_strfreev);
+
+  /* Text can be written */
+  text = g_uuid_string_random ();
+  valent_clipboard_set_text (fixture->clipboard, text);
+
+  /* Text can be read */
+  valent_clipboard_adapter_get_text_async (fixture->adapter,
+                                           NULL,
+                                           (GAsyncReadyCallback)adapter_get_text_cb,
+                                           fixture);
+  g_main_loop_run (fixture->loop);
+
+  g_assert_cmpstr (fixture->data, ==, text);
+  g_clear_pointer (&fixture->data, g_free);
+  g_clear_pointer (&text, g_free);
+
+  /* Timestamp is updated */
+  timestamp = valent_clipboard_adapter_get_timestamp (fixture->adapter);
+  g_assert_cmpint (timestamp, !=, 0);
+
+  /* Mimetypes are updated */
+  mimetypes = valent_clipboard_adapter_get_mimetypes (fixture->adapter);
+  g_assert_nonnull (mimetypes);
+  g_assert_true (g_strv_contains ((const char * const *)mimetypes,
+                                  "text/plain;charset=utf-8"));
+  g_clear_pointer (&mimetypes, g_strfreev);
+
+  /* Signals are emitted from adapter */
   g_signal_connect (fixture->adapter,
                     "changed",
                     G_CALLBACK (on_changed),
@@ -92,29 +182,56 @@ test_clipboard_component_adapter (ClipboardComponentFixture *fixture,
   g_assert_true (fixture->data == fixture->adapter);
   fixture->data = NULL;
 
-  /* Methods */
-  text = g_uuid_string_random ();
-  valent_clipboard_set_text (fixture->clipboard, text);
-
-  valent_clipboard_adapter_get_text_async (fixture->adapter,
-                                           NULL,
-                                           (GAsyncReadyCallback)adapter_get_text_cb,
-                                           fixture);
-  g_main_loop_run (fixture->loop);
-
-  g_assert_cmpstr (fixture->data, ==, text);
-  g_clear_pointer (&fixture->data, g_free);
+  g_signal_handlers_disconnect_by_data (fixture->adapter, fixture);
 }
 
 static void
 test_clipboard_component_self (ClipboardComponentFixture *fixture,
                                gconstpointer              user_data)
 {
+  g_autoptr (GBytes) bytes = NULL;
   g_autofree char *text = NULL;
+  g_auto (GStrv) mimetypes = NULL;
+  gint64 timestamp = 0;
 
+  /* Data can be written */
+  text = g_uuid_string_random ();
+  bytes = g_bytes_new_take (text, strlen (text) + 1);
+  text = NULL;
+  valent_clipboard_set_bytes (fixture->clipboard,
+                              "text/plain;charset=utf-8",
+                              bytes);
+
+  /* Data can be read */
+  valent_clipboard_get_bytes (fixture->clipboard,
+                              "text/plain;charset=utf-8",
+                              NULL,
+                              (GAsyncReadyCallback)get_bytes_cb,
+                              fixture);
+  g_main_loop_run (fixture->loop);
+
+  g_assert_cmpmem (g_bytes_get_data (bytes, NULL),
+                   g_bytes_get_size (bytes),
+                   g_bytes_get_data (fixture->data, NULL),
+                   g_bytes_get_size (fixture->data));
+  g_clear_pointer (&fixture->data, g_bytes_unref);
+
+  /* Timestamp is updated */
+  timestamp = valent_clipboard_get_timestamp (fixture->clipboard);
+  g_assert_cmpint (timestamp, !=, 0);
+
+  /* Mimetypes are updated */
+  mimetypes = valent_clipboard_get_mimetypes (fixture->clipboard);
+  g_assert_nonnull (mimetypes);
+  g_assert_true (g_strv_contains ((const char * const *)mimetypes,
+                                  "text/plain;charset=utf-8"));
+  g_clear_pointer (&mimetypes, g_strfreev);
+
+  /* Text can be written */
   text = g_uuid_string_random ();
   valent_clipboard_set_text (fixture->clipboard, text);
 
+  /* Text can be read */
   valent_clipboard_get_text_async (fixture->clipboard,
                                    NULL,
                                    (GAsyncReadyCallback)get_text_cb,
@@ -123,6 +240,30 @@ test_clipboard_component_self (ClipboardComponentFixture *fixture,
 
   g_assert_cmpstr (fixture->data, ==, text);
   g_clear_pointer (&fixture->data, g_free);
+  g_clear_pointer (&text, g_free);
+
+  /* Timestamp is updated */
+  timestamp = valent_clipboard_get_timestamp (fixture->clipboard);
+  g_assert_cmpint (timestamp, !=, 0);
+
+  /* Mimetypes are updated */
+  mimetypes = valent_clipboard_get_mimetypes (fixture->clipboard);
+  g_assert_nonnull (mimetypes);
+  g_assert_true (g_strv_contains ((const char * const *)mimetypes,
+                                  "text/plain;charset=utf-8"));
+  g_clear_pointer (&mimetypes, g_strfreev);
+
+  /* Signals are propagated from adapter */
+  g_signal_connect (fixture->clipboard,
+                    "changed",
+                    G_CALLBACK (on_changed),
+                    fixture);
+
+  valent_clipboard_adapter_emit_changed (fixture->adapter);
+  g_assert_true (fixture->data == fixture->clipboard);
+  fixture->data = NULL;
+
+  g_signal_handlers_disconnect_by_data (fixture->clipboard, fixture);
 }
 
 int

--- a/src/tests/plugins/clipboard/test-clipboard-plugin.c
+++ b/src/tests/plugins/clipboard/test-clipboard-plugin.c
@@ -29,7 +29,7 @@ get_text_cb (ValentClipboard   *clipboard,
 {
   GError *error = NULL;
 
-  fixture->data = valent_clipboard_get_text_finish (clipboard, result, &error);
+  fixture->data = valent_clipboard_read_text_finish (clipboard, result, &error);
   g_assert_no_error (error);
 
   valent_test_fixture_quit (fixture);
@@ -61,10 +61,10 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   packet = valent_test_fixture_lookup_packet (fixture, "clipboard-content");
   valent_test_fixture_handle_packet (fixture, packet);
 
-  valent_clipboard_get_text_async (valent_clipboard_get_default (),
-                                   NULL,
-                                   (GAsyncReadyCallback)get_text_cb,
-                                   fixture);
+  valent_clipboard_read_text (valent_clipboard_get_default (),
+                              NULL,
+                              (GAsyncReadyCallback)get_text_cb,
+                              fixture);
   valent_test_fixture_run (fixture);
 
   g_assert_cmpstr (fixture->data, ==, "clipboard-content");
@@ -74,10 +74,10 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   packet = valent_test_fixture_lookup_packet (fixture, "clipboard-connect");
   valent_test_fixture_handle_packet (fixture, packet);
 
-  valent_clipboard_get_text_async (valent_clipboard_get_default (),
-                                   NULL,
-                                   (GAsyncReadyCallback)get_text_cb,
-                                   fixture);
+  valent_clipboard_read_text (valent_clipboard_get_default (),
+                              NULL,
+                              (GAsyncReadyCallback)get_text_cb,
+                              fixture);
   valent_test_fixture_run (fixture);
 
   g_assert_cmpstr (fixture->data, ==, "clipboard-connect");
@@ -89,10 +89,10 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   json_object_set_string_member (valent_packet_get_body (packet), "content", "old");
   valent_test_fixture_handle_packet (fixture, packet);
 
-  valent_clipboard_get_text_async (valent_clipboard_get_default (),
-                                   NULL,
-                                   (GAsyncReadyCallback)get_text_cb,
-                                   fixture);
+  valent_clipboard_read_text (valent_clipboard_get_default (),
+                              NULL,
+                              (GAsyncReadyCallback)get_text_cb,
+                              fixture);
   valent_test_fixture_run (fixture);
 
   g_assert_cmpstr (fixture->data, ==, "clipboard-connect");
@@ -114,7 +114,11 @@ test_clipboard_plugin_send_content (ValentTestFixture *fixture,
   json_node_unref (packet);
 
   /* Expect clipboard changes */
-  valent_clipboard_set_text (valent_clipboard_get_default (), "send-content");
+  valent_clipboard_write_text (valent_clipboard_get_default (),
+                               "send-content",
+                               NULL,
+                               NULL,
+                               NULL);
 
   packet = valent_test_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.clipboard");
@@ -142,10 +146,10 @@ test_clipboard_plugin_actions (ValentTestFixture *fixture,
   valent_test_fixture_handle_packet (fixture, packet);
 
   g_action_group_activate_action (actions, "clipboard.pull", NULL);
-  valent_clipboard_get_text_async (valent_clipboard_get_default (),
-                                   NULL,
-                                   (GAsyncReadyCallback)get_text_cb,
-                                   fixture);
+  valent_clipboard_read_text (valent_clipboard_get_default (),
+                              NULL,
+                              (GAsyncReadyCallback)get_text_cb,
+                              fixture);
   valent_test_fixture_run (fixture);
 
   g_assert_cmpstr (fixture->data, ==, "clipboard-content");


### PR DESCRIPTION
A hopefully final pass at the clipboard in Valent.

* add a generic getter/setter that exchanges `GBytes`
* add mime-types getter
* cleanup and expand the tests