### PR TITLE
refactor(device-plugin): rename and refactor GSettings convenience

### DIFF
--- a/src/libvalent/core/valent-device-plugin.h
+++ b/src/libvalent/core/valent-device-plugin.h
@@ -60,6 +60,8 @@ void           valent_device_plugin_update_state        (ValentDevicePlugin    *
 VALENT_AVAILABLE_IN_1_0
 ValentDevice * valent_device_plugin_get_device          (ValentDevicePlugin    *plugin);
 VALENT_AVAILABLE_IN_1_0
+GSettings *    valent_device_plugin_get_settings        (ValentDevicePlugin    *plugin);
+VALENT_AVAILABLE_IN_1_0
 void           valent_device_plugin_queue_packet        (ValentDevicePlugin    *plugin,
                                                          JsonNode              *packet);
 VALENT_AVAILABLE_IN_1_0
@@ -75,12 +77,12 @@ void           valent_device_plugin_toggle_actions      (ValentDevicePlugin    *
 
 /* Utilities */
 VALENT_AVAILABLE_IN_1_0
+GSettings *    valent_device_plugin_create_settings     (PeasPluginInfo        *plugin_info,
+                                                         const char            *device_id);
+VALENT_AVAILABLE_IN_1_0
 GStrv          valent_device_plugin_get_incoming        (PeasPluginInfo        *info);
 VALENT_AVAILABLE_IN_1_0
 GStrv          valent_device_plugin_get_outgoing        (PeasPluginInfo        *info);
-VALENT_AVAILABLE_IN_1_0
-GSettings *    valent_device_plugin_new_settings        (const char            *device_id,
-                                                         const char            *module_name);
 
 /* TODO: GMenuModel XML */
 VALENT_AVAILABLE_IN_1_0

--- a/src/plugins/battery/battery.plugin.desktop.in
+++ b/src/plugins/battery/battery.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_battery_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.battery
 X-IncomingCapabilities=kdeconnect.battery;kdeconnect.battery.request
 X-OutgoingCapabilities=kdeconnect.battery;kdeconnect.battery.request
 

--- a/src/plugins/battery/valent-battery-preferences.c
+++ b/src/plugins/battery/valent-battery-preferences.c
@@ -61,8 +61,8 @@ valent_battery_preferences_constructed (GObject *object)
   ValentBatteryPreferences *self = VALENT_BATTERY_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "battery");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_settings_bind (self->settings,    "share-state",
                    self->share_state, "active",

--- a/src/plugins/clipboard/clipboard.plugin.desktop.in
+++ b/src/plugins/clipboard/clipboard.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_clipboard_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.clipboard
 X-IncomingCapabilities=kdeconnect.clipboard;kdeconnect.clipboard.connect
 X-OutgoingCapabilities=kdeconnect.clipboard;kdeconnect.clipboard.connect
 

--- a/src/plugins/clipboard/valent-clipboard-preferences.c
+++ b/src/plugins/clipboard/valent-clipboard-preferences.c
@@ -58,8 +58,8 @@ valent_clipboard_preferences_constructed (GObject *object)
   ValentClipboardPreferences *self = VALENT_CLIPBOARD_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "clipboard");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_settings_bind (self->settings,  "auto-pull",
                    self->sync_pull, "active",

--- a/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
+++ b/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_connectivity_report_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.connectivity_report
 X-IncomingCapabilities=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
 X-OutgoingCapabilities=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
 

--- a/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
@@ -59,8 +59,9 @@ valent_connectivity_report_preferences_constructed (GObject *object)
 {
   ValentConnectivityReportPreferences *self = VALENT_CONNECTIVITY_REPORT_PREFERENCES (object);
 
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "connectivity_report");
+  /* Setup GSettings */
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_settings_bind (self->settings,    "share-state",
                    self->share_state, "active",

--- a/src/plugins/contacts/contacts.plugin.desktop.in
+++ b/src/plugins/contacts/contacts.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_contacts_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.contacts
 X-IncomingCapabilities=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
 X-OutgoingCapabilities=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
 

--- a/src/plugins/contacts/valent-contacts-preferences.c
+++ b/src/plugins/contacts/valent-contacts-preferences.c
@@ -191,8 +191,8 @@ valent_contacts_preferences_constructed (GObject *object)
   g_autoptr (GPtrArray) stores = NULL;
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "contacts");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_settings_bind (self->settings,    "remote-sync",
                    self->remote_sync, "active",

--- a/src/plugins/notification/notification.plugin.desktop.in
+++ b/src/plugins/notification/notification.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_notification_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.notification
 X-IncomingCapabilities=kdeconnect.notification;kdeconnect.notification.request
 X-OutgoingCapabilities=kdeconnect.notification;kdeconnect.notification.action;kdeconnect.notification.reply;kdeconnect.notification.request
 

--- a/src/plugins/notification/valent-notification-preferences.c
+++ b/src/plugins/notification/valent-notification-preferences.c
@@ -211,8 +211,8 @@ valent_notification_preferences_constructed (GObject *object)
   ValentNotificationPreferences *self = VALENT_NOTIFICATION_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "notification");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   /* Forwarding Settings */
   g_settings_bind (self->settings,              "forward-notifications",

--- a/src/plugins/runcommand/runcommand.plugin.desktop.in
+++ b/src/plugins/runcommand/runcommand.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_runcommand_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.runcommand
 X-IncomingCapabilities=kdeconnect.runcommand;kdeconnect.runcommand.request
 X-OutgoingCapabilities=kdeconnect.runcommand;kdeconnect.runcommand.request
 

--- a/src/plugins/runcommand/valent-runcommand-preferences.c
+++ b/src/plugins/runcommand/valent-runcommand-preferences.c
@@ -425,8 +425,8 @@ valent_runcommand_preferences_constructed (GObject *object)
   ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "runcommand");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_signal_connect (self->settings,
                     "changed::commands",

--- a/src/plugins/sftp/sftp.plugin.desktop.in
+++ b/src/plugins/sftp/sftp.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_sftp_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.sftp
 X-IncomingCapabilities=kdeconnect.sftp;kdeconnect.sftp.request
 X-OutgoingCapabilities=kdeconnect.sftp;kdeconnect.sftp.request
 X-ChannelProtocol=tcp

--- a/src/plugins/sftp/valent-sftp-preferences.c
+++ b/src/plugins/sftp/valent-sftp-preferences.c
@@ -78,8 +78,8 @@ valent_sftp_preferences_constructed (GObject *object)
   ValentSftpPreferences *self = VALENT_SFTP_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "sftp");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   g_settings_bind (self->settings,   "auto-mount",
                    self->auto_mount, "active",

--- a/src/plugins/share/share.plugin.desktop.in
+++ b/src/plugins/share/share.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_share_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.share
 X-IncomingCapabilities=kdeconnect.share.request;kdeconnect.share.request.update
 X-OutgoingCapabilities=kdeconnect.share.request;kdeconnect.share.request.update
 

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -20,8 +20,6 @@ struct _ValentSharePlugin
 {
   ValentDevicePlugin  parent_instance;
 
-  GSettings          *settings;
-
   GHashTable         *transfers;
   ValentTransfer     *upload;
   ValentTransfer     *download;
@@ -35,12 +33,14 @@ valent_share_plugin_create_download_file (ValentSharePlugin *self,
                                           const char        *filename,
                                           gboolean           unique)
 {
+  GSettings *settings;
   g_autofree char *download_folder = NULL;
 
   g_return_val_if_fail (VALENT_IS_SHARE_PLUGIN (self), NULL);
   g_return_val_if_fail (filename != NULL, NULL);
 
-  download_folder = g_settings_get_string (self->settings, "download-folder");
+  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  download_folder = g_settings_get_string (settings, "download-folder");
 
   if (download_folder == NULL || *download_folder == '\0')
     {
@@ -1093,15 +1093,7 @@ valent_share_plugin_handle_url (ValentSharePlugin *self,
 static void
 valent_share_plugin_enable (ValentDevicePlugin *plugin)
 {
-  ValentSharePlugin *self = VALENT_SHARE_PLUGIN (plugin);
-  ValentDevice *device;
-  const char *device_id;
-
-  g_assert (VALENT_IS_SHARE_PLUGIN (self));
-
-  device = valent_device_plugin_get_device (plugin);
-  device_id = valent_device_get_id (device);
-  self->settings = valent_device_plugin_new_settings (device_id, "share");
+  g_assert (VALENT_IS_SHARE_PLUGIN (plugin));
 
   g_action_map_add_action_entries (G_ACTION_MAP (plugin),
                                    actions,
@@ -1215,7 +1207,6 @@ valent_share_plugin_finalize (GObject *object)
 {
   ValentSharePlugin *self = VALENT_SHARE_PLUGIN (object);
 
-  g_clear_object (&self->settings);
   g_clear_pointer (&self->transfers, g_hash_table_unref);
 
   G_OBJECT_CLASS (valent_share_plugin_parent_class)->finalize (object);

--- a/src/plugins/share/valent-share-preferences.c
+++ b/src/plugins/share/valent-share-preferences.c
@@ -142,7 +142,9 @@ valent_share_preferences_constructed (GObject *object)
   g_autofree char *download_folder = NULL;
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id, "share");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
+
   download_folder = g_settings_get_string (self->settings, "download-folder");
 
   if (download_folder == NULL || *download_folder == '\0')

--- a/src/plugins/systemvolume/systemvolume.plugin.desktop.in
+++ b/src/plugins/systemvolume/systemvolume.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_systemvolume_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.systemvolume
 X-IncomingCapabilities=kdeconnect.systemvolume.request
 X-OutgoingCapabilities=kdeconnect.systemvolume
 

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -16,8 +16,6 @@ struct _ValentSystemvolumePlugin
 {
   ValentDevicePlugin  parent_instance;
 
-  GSettings          *settings;
-
   ValentMixer        *mixer;
   unsigned int        mixer_watch : 1;
   GHashTable         *states;
@@ -362,14 +360,8 @@ static void
 valent_systemvolume_plugin_enable (ValentDevicePlugin *plugin)
 {
   ValentSystemvolumePlugin *self = VALENT_SYSTEMVOLUME_PLUGIN (plugin);
-  ValentDevice *device;
-  const char *device_id;
 
   g_assert (VALENT_IS_SYSTEMVOLUME_PLUGIN (self));
-
-  device = valent_device_plugin_get_device (plugin);
-  device_id = valent_device_get_id (device);
-  self->settings = valent_device_plugin_new_settings (device_id, "systemvolume");
 
   /* Setup stream state cache */
   self->states = g_hash_table_new_full (g_str_hash,
@@ -386,8 +378,6 @@ valent_systemvolume_plugin_disable (ValentDevicePlugin *plugin)
   /* Clear stream state cache */
   valent_systemvolume_plugin_watch_mixer (self, FALSE);
   g_clear_pointer (&self->states, g_hash_table_unref);
-
-  g_clear_object (&self->settings);
 }
 
 static void

--- a/src/plugins/telephony/telephony.plugin.desktop.in
+++ b/src/plugins/telephony/telephony.plugin.desktop.in
@@ -11,6 +11,7 @@ Embedded=valent_telephony_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginSettings=ca.andyholmes.valent.telephony
 X-IncomingCapabilities=kdeconnect.telephony
 X-OutgoingCapabilities=kdeconnect.telephony.request_mute
 

--- a/src/plugins/telephony/valent-telephony-preferences.c
+++ b/src/plugins/telephony/valent-telephony-preferences.c
@@ -160,8 +160,8 @@ valent_telephony_preferences_constructed (GObject *object)
   ValentTelephonyPreferences *self = VALENT_TELEPHONY_PREFERENCES (object);
 
   /* Setup GSettings */
-  self->settings = valent_device_plugin_new_settings (self->device_id,
-                                                      "telephony");
+  self->settings = valent_device_plugin_create_settings (self->plugin_info,
+                                                         self->device_id);
 
   /* Incoming Calls */
   g_settings_bind (self->settings,      "ringing-pause",

--- a/src/tests/extra/cppcheck.supp
+++ b/src/tests/extra/cppcheck.supp
@@ -26,14 +26,14 @@ leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:117
 leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:173
 
 # src/tests/plugins/connectivity_report/
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:265
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:267
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:269
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:271
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:275
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:284
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:286
-leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:288
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:268
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:270
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:272
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:274
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:278
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:287
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:289
+leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:291
 
 # src/tests/plugins/bluez/
 memleak:src/tests/plugins/bluez/test-bluez-plugin.c:183

--- a/src/tests/fixtures/valent-test-fixture.c
+++ b/src/tests/fixtures/valent-test-fixture.c
@@ -176,13 +176,16 @@ void
 valent_test_fixture_init_settings (ValentTestFixture *fixture,
                                    const char        *name)
 {
+  PeasPluginInfo *plugin_info = NULL;
   const char *device_id;
 
   g_assert (fixture != NULL);
   g_assert (name != NULL);
 
+  plugin_info = peas_engine_get_plugin_info (valent_get_plugin_engine (), name);
   device_id = valent_device_get_id (fixture->device);
-  fixture->settings = valent_device_plugin_new_settings (device_id, name);
+  fixture->settings = valent_device_plugin_create_settings (plugin_info,
+                                                            device_id);
 }
 
 /**

--- a/src/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
+++ b/src/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
@@ -42,6 +42,14 @@ dbusmock_modemmanager (GDBusConnection *connection,
 }
 
 static void
+connectivity_report_plugin_fixture_set_up (ValentTestFixture *fixture,
+                                           gconstpointer      user_data)
+{
+  valent_test_fixture_init (fixture, user_data);
+  valent_test_fixture_init_settings (fixture, "connectivity_report");
+}
+
+static void
 test_connectivity_report_plugin_actions (ValentTestFixture *fixture,
                                          gconstpointer      user_data)
 {
@@ -82,7 +90,6 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
                                                gconstpointer      user_data)
 {
   GActionGroup *actions = G_ACTION_GROUP (fixture->device);
-  g_autoptr (GSettings) settings = NULL;
   JsonNode *packet;
   GVariant *state;
   GVariant *signal_strengths;
@@ -92,9 +99,7 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
   gint64 signal_strength;
 
   /* Setup GSettings */
-  settings = valent_device_plugin_new_settings (valent_device_get_id (fixture->device),
-                                                "connectivity_report");
-  g_settings_set_boolean (settings, "offline-notification", TRUE);
+  g_settings_set_boolean (fixture->settings, "offline-notification", TRUE);
 
   /* Modem is in the default state so the action should be disabled */
   g_assert_false (g_action_group_get_action_enabled (actions, "connectivity_report.state"));
@@ -417,31 +422,31 @@ main (int   argc,
 
   g_test_add ("/plugins/connectivity_report/actions",
               ValentTestFixture, path,
-              valent_test_fixture_init,
+              connectivity_report_plugin_fixture_set_up,
               test_connectivity_report_plugin_actions,
               valent_test_fixture_clear);
 
   g_test_add ("/plugins/connectivity_report/connect",
               ValentTestFixture, path,
-              valent_test_fixture_init,
+              connectivity_report_plugin_fixture_set_up,
               test_connectivity_report_plugin_connect,
               valent_test_fixture_clear);
 
   g_test_add ("/plugins/connectivity_report/handle-update",
               ValentTestFixture, path,
-              valent_test_fixture_init,
+              connectivity_report_plugin_fixture_set_up,
               test_connectivity_report_plugin_handle_update,
               valent_test_fixture_clear);
 
   g_test_add ("/plugins/connectivity_report/handle-request",
               ValentTestFixture, path,
-              valent_test_fixture_init,
+              connectivity_report_plugin_fixture_set_up,
               test_connectivity_report_plugin_handle_request,
               valent_test_fixture_clear);
 
   g_test_add ("/plugins/connectivity_report/fuzz",
               ValentTestFixture, path,
-              valent_test_fixture_init,
+              connectivity_report_plugin_fixture_set_up,
               test_connectivity_report_plugin_fuzz,
               valent_test_fixture_clear);
 

--- a/src/tests/plugins/share/test-share-download.c
+++ b/src/tests/plugins/share/test-share-download.c
@@ -13,6 +13,7 @@ static void
 test_share_download_single (ValentTestFixture *fixture,
                             gconstpointer      user_data)
 {
+  PeasPluginInfo *plugin_info = NULL;
   g_autoptr (GSettings) settings = NULL;
   g_autoptr (GFile) file = NULL;
   g_autoptr (GFile) dest = NULL;
@@ -23,7 +24,10 @@ test_share_download_single (ValentTestFixture *fixture,
   valent_test_fixture_connect (fixture, TRUE);
 
   /* Ensure the download directory is at it's default */
-  settings = valent_device_plugin_new_settings ("test-device", "share");
+  plugin_info = peas_engine_get_plugin_info (valent_get_plugin_engine (),
+                                             "share");
+  settings = valent_device_plugin_create_settings (plugin_info,
+                                                   "test-device");
   g_settings_reset (settings, "download-folder");
 
   file = g_file_new_for_uri (test_file);
@@ -44,6 +48,7 @@ static void
 test_share_download_multiple (ValentTestFixture *fixture,
                               gconstpointer      user_data)
 {
+  PeasPluginInfo *plugin_info = NULL;
   g_autoptr (GSettings) settings = NULL;
   g_autoptr (GFile) file = NULL;
   g_autoptr (GFile) dest = NULL;
@@ -54,7 +59,10 @@ test_share_download_multiple (ValentTestFixture *fixture,
   valent_test_fixture_connect (fixture, TRUE);
 
   /* Ensure the download directory is at it's default */
-  settings = valent_device_plugin_new_settings ("test-device", "share");
+  plugin_info = peas_engine_get_plugin_info (valent_get_plugin_engine (),
+                                             "share");
+  settings = valent_device_plugin_create_settings (plugin_info,
+                                                   "test-device");
   g_settings_reset (settings, "download-folder");
 
   file = g_file_new_for_uri (test_file);


### PR DESCRIPTION
Refactor the plugin GSettings convenience to take a `PeasPluginInfo` and
automatically create GSettings for plugins that specify the
`X-DevicePluginSchema` key in their `.plugin` file.

The new method uses the fallback from `peas_plugin_info_get_settings()`,
attempting to compile GSchemas for third-party plugins when possible.

* rename `valent_device_plugin_new_settings()` to
  `valent_device_plugin_create_settings()`
* add `X-DevicePluginSettings` key for automatic GSettings convenience