### PR TITLE
refactor(device-plugin): rename incoming/outgoing packet fields

### DIFF
--- a/src/libvalent/core/valent-channel-service.c
+++ b/src/libvalent/core/valent-channel-service.c
@@ -205,7 +205,7 @@ collect_capabilities (PeasPluginInfo *info,
 {
   const char *data = NULL;
 
-  if ((data = peas_plugin_info_get_external_data (info, "IncomingCapabilities")) != NULL)
+  if ((data = peas_plugin_info_get_external_data (info, "DevicePluginIncoming")) != NULL)
     {
       g_autofree char **capabilities = NULL;
 
@@ -215,7 +215,7 @@ collect_capabilities (PeasPluginInfo *info,
         g_hash_table_add (incoming, g_steal_pointer (&capabilities[i]));
     }
 
-  if ((data = peas_plugin_info_get_external_data (info, "OutgoingCapabilities")) != NULL)
+  if ((data = peas_plugin_info_get_external_data (info, "DevicePluginOutgoing")) != NULL)
     {
       g_autofree char **capabilities = NULL;
 

--- a/src/libvalent/core/valent-device-plugin.c
+++ b/src/libvalent/core/valent-device-plugin.c
@@ -14,6 +14,10 @@
 #include "valent-device-plugin.h"
 #include "valent-packet.h"
 
+#define PLUGIN_SETTINGS_KEY "X-DevicePluginSettings"
+#define PLUGIN_INCOMING_KEY "X-DevicePluginIncoming"
+#define PLUGIN_OUTGOING_KEY "X-DevicePluginOutgoing"
+
 
 /**
  * ValentDevicePlugin:
@@ -52,10 +56,10 @@
  *
  * ## Implementation Notes
  *
- * Implementations that define `X-IncomingCapabilities` in the `.plugin` file
+ * Implementations that define `X-DevicePluginIncoming` in the `.plugin` file
  * must override [vfunc@Valent.DevicePlugin.handle_packet] to handle incoming
  * packets. Implementations that depend on the device state, especially those
- * that define `X-OutgoingCapabilities` in the `.plugin` file, should override
+ * that define `X-DevicePluginOutgoing` in the `.plugin` file, should override
  * [vfunc@Valent.DevicePlugin.update_state].
  *
  * For device plugin preferences see [iface@Valent.DevicePreferencesPage].
@@ -64,20 +68,20 @@
  *
  * Implementations may define the following extra fields in the `.plugin` file:
  *
- * - `X-DevicePluginSettings`
- *
- *     A [class@Gio.Settings] schema ID for the plugin's settings. See
- *     [func@Valent.DevicePlugin.create_settings] for more information.
- *
- * - `X-IncomingCapabilities`
+ * - `X-DevicePluginIncoming`
  *
  *     A list of packet types (eg. `kdeconnect.ping`) separated by semi-colons
  *     indicating the packets that the plugin can handle.
  *
- * - `X-OutgoingCapabilities`
+ * - `X-DevicePluginOutgoing`
  *
  *     A list of packet types (eg. `kdeconnect.share.request`) separated by
  *     semi-colons indicating the packets that the plugin may send.
+ *
+ * - `X-DevicePluginSettings`
+ *
+ *     A [class@Gio.Settings] schema ID for the plugin's settings. See
+ *     [func@Valent.DevicePlugin.create_settings] for more information.
  *
  * - `X-ChannelProtocol`
  *
@@ -773,7 +777,7 @@ valent_device_plugin_get_incoming (PeasPluginInfo *info)
 
   g_return_val_if_fail (info != NULL, NULL);
 
-  data = peas_plugin_info_get_external_data (info, "IncomingCapabilities");
+  data = peas_plugin_info_get_external_data (info, "DevicePluginIncoming");
 
   return (data == NULL) ? NULL : g_strsplit (data, ";", -1);
 }
@@ -796,7 +800,7 @@ valent_device_plugin_get_outgoing (PeasPluginInfo *info)
 
   g_return_val_if_fail (info != NULL, NULL);
 
-  data = peas_plugin_info_get_external_data (info, "OutgoingCapabilities");
+  data = peas_plugin_info_get_external_data (info, "DevicePluginOutgoing");
 
   return (data == NULL) ? NULL : g_strsplit (data, ";", -1);
 }
@@ -1109,7 +1113,7 @@ valent_device_plugin_disable (ValentDevicePlugin *plugin)
  * Handle a packet from the device the plugin is bound to.
  *
  * This is called when the device receives a packet type included in the
- * `X-IncomingCapabilities` field of the `.plugin` file.
+ * `X-DevicePluginIncoming` field of the `.plugin` file.
  *
  * This is optional for implementations which do not register any incoming
  * capabilities, such as plugins that do not provide packet-based functionality.

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1881,8 +1881,8 @@ valent_device_supports_plugin (ValentDevice   *device,
     return FALSE;
 
   /* Packet-less plugins aren't dependent on device capabilities */
-  in_str = peas_plugin_info_get_external_data (info, "IncomingCapabilities");
-  out_str = peas_plugin_info_get_external_data (info, "OutgoingCapabilities");
+  in_str = peas_plugin_info_get_external_data (info, "DevicePluginIncoming");
+  out_str = peas_plugin_info_get_external_data (info, "DevicePluginOutgoing");
 
   if (in_str == NULL && out_str == NULL)
     return TRUE;

--- a/src/plugins/battery/battery.plugin.desktop.in
+++ b/src/plugins/battery/battery.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_battery_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.battery;kdeconnect.battery.request
+X-DevicePluginOutgoing=kdeconnect.battery;kdeconnect.battery.request
 X-DevicePluginSettings=ca.andyholmes.valent.battery
-X-IncomingCapabilities=kdeconnect.battery;kdeconnect.battery.request
-X-OutgoingCapabilities=kdeconnect.battery;kdeconnect.battery.request
 

--- a/src/plugins/clipboard/clipboard.plugin.desktop.in
+++ b/src/plugins/clipboard/clipboard.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_clipboard_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.clipboard;kdeconnect.clipboard.connect
+X-DevicePluginOutgoing=kdeconnect.clipboard;kdeconnect.clipboard.connect
 X-DevicePluginSettings=ca.andyholmes.valent.clipboard
-X-IncomingCapabilities=kdeconnect.clipboard;kdeconnect.clipboard.connect
-X-OutgoingCapabilities=kdeconnect.clipboard;kdeconnect.clipboard.connect
 

--- a/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
+++ b/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_connectivity_report_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
+X-DevicePluginOutgoing=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
 X-DevicePluginSettings=ca.andyholmes.valent.connectivity_report
-X-IncomingCapabilities=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
-X-OutgoingCapabilities=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
 

--- a/src/plugins/contacts/contacts.plugin.desktop.in
+++ b/src/plugins/contacts/contacts.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_contacts_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
+X-DevicePluginOutgoing=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
 X-DevicePluginSettings=ca.andyholmes.valent.contacts
-X-IncomingCapabilities=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
-X-OutgoingCapabilities=kdeconnect.contacts.request_all_uids_timestamps;kdeconnect.contacts.request_vcards_by_uid;kdeconnect.contacts.response_uids_timestamps;kdeconnect.contacts.response_vcards
 

--- a/src/plugins/findmyphone/findmyphone.plugin.desktop.in
+++ b/src/plugins/findmyphone/findmyphone.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_findmyphone_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.findmyphone.request
-X-OutgoingCapabilities=kdeconnect.findmyphone.request
+X-DevicePluginIncoming=kdeconnect.findmyphone.request
+X-DevicePluginOutgoing=kdeconnect.findmyphone.request
 

--- a/src/plugins/lock/lock.plugin.desktop.in
+++ b/src/plugins/lock/lock.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_lock_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.lock;kdeconnect.lock.request
-X-OutgoingCapabilities=kdeconnect.lock;kdeconnect.lock.request
+X-DevicePluginIncoming=kdeconnect.lock;kdeconnect.lock.request
+X-DevicePluginOutgoing=kdeconnect.lock;kdeconnect.lock.request
 

--- a/src/plugins/mousepad/mousepad.plugin.desktop.in
+++ b/src/plugins/mousepad/mousepad.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_mousepad_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.mousepad.echo;kdeconnect.mousepad.request;kdeconnect.mousepad.keyboardstate
-X-OutgoingCapabilities=kdeconnect.mousepad.echo;kdeconnect.mousepad.request;kdeconnect.mousepad.keyboardstate
+X-DevicePluginIncoming=kdeconnect.mousepad.echo;kdeconnect.mousepad.request;kdeconnect.mousepad.keyboardstate
+X-DevicePluginOutgoing=kdeconnect.mousepad.echo;kdeconnect.mousepad.request;kdeconnect.mousepad.keyboardstate
 

--- a/src/plugins/mpris/mpris.plugin.desktop.in
+++ b/src/plugins/mpris/mpris.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_mpris_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.mpris;kdeconnect.mpris.request
-X-OutgoingCapabilities=kdeconnect.mpris;kdeconnect.mpris.request
+X-DevicePluginIncoming=kdeconnect.mpris;kdeconnect.mpris.request
+X-DevicePluginOutgoing=kdeconnect.mpris;kdeconnect.mpris.request
 

--- a/src/plugins/notification/notification.plugin.desktop.in
+++ b/src/plugins/notification/notification.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_notification_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.notification;kdeconnect.notification.request
+X-DevicePluginOutgoing=kdeconnect.notification;kdeconnect.notification.action;kdeconnect.notification.reply;kdeconnect.notification.request
 X-DevicePluginSettings=ca.andyholmes.valent.notification
-X-IncomingCapabilities=kdeconnect.notification;kdeconnect.notification.request
-X-OutgoingCapabilities=kdeconnect.notification;kdeconnect.notification.action;kdeconnect.notification.reply;kdeconnect.notification.request
 

--- a/src/plugins/photo/photo.plugin.desktop.in
+++ b/src/plugins/photo/photo.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_photo_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.photo;kdeconnect.photo.request
-X-OutgoingCapabilities=kdeconnect.photo;kdeconnect.photo.request
+X-DevicePluginIncoming=kdeconnect.photo;kdeconnect.photo.request
+X-DevicePluginOutgoing=kdeconnect.photo;kdeconnect.photo.request
 

--- a/src/plugins/ping/ping.plugin.desktop.in
+++ b/src/plugins/ping/ping.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_ping_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.ping
-X-OutgoingCapabilities=kdeconnect.ping
+X-DevicePluginIncoming=kdeconnect.ping
+X-DevicePluginOutgoing=kdeconnect.ping
 

--- a/src/plugins/presenter/presenter.plugin.desktop.in
+++ b/src/plugins/presenter/presenter.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_presenter_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.presenter
-X-OutgoingCapabilities=kdeconnect.presenter
+X-DevicePluginIncoming=kdeconnect.presenter
+X-DevicePluginOutgoing=kdeconnect.presenter
 

--- a/src/plugins/runcommand/runcommand.plugin.desktop.in
+++ b/src/plugins/runcommand/runcommand.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_runcommand_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.runcommand;kdeconnect.runcommand.request
+X-DevicePluginOutgoing=kdeconnect.runcommand;kdeconnect.runcommand.request
 X-DevicePluginSettings=ca.andyholmes.valent.runcommand
-X-IncomingCapabilities=kdeconnect.runcommand;kdeconnect.runcommand.request
-X-OutgoingCapabilities=kdeconnect.runcommand;kdeconnect.runcommand.request
 

--- a/src/plugins/sftp/sftp.plugin.desktop.in
+++ b/src/plugins/sftp/sftp.plugin.desktop.in
@@ -11,8 +11,8 @@ Embedded=valent_sftp_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.sftp;kdeconnect.sftp.request
+X-DevicePluginOutgoing=kdeconnect.sftp;kdeconnect.sftp.request
 X-DevicePluginSettings=ca.andyholmes.valent.sftp
-X-IncomingCapabilities=kdeconnect.sftp;kdeconnect.sftp.request
-X-OutgoingCapabilities=kdeconnect.sftp;kdeconnect.sftp.request
 X-ChannelProtocol=tcp
 

--- a/src/plugins/share/share.plugin.desktop.in
+++ b/src/plugins/share/share.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_share_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.share.request;kdeconnect.share.request.update
+X-DevicePluginOutgoing=kdeconnect.share.request;kdeconnect.share.request.update
 X-DevicePluginSettings=ca.andyholmes.valent.share
-X-IncomingCapabilities=kdeconnect.share.request;kdeconnect.share.request.update
-X-OutgoingCapabilities=kdeconnect.share.request;kdeconnect.share.request.update
 

--- a/src/plugins/sms/sms.plugin.desktop.in
+++ b/src/plugins/sms/sms.plugin.desktop.in
@@ -11,6 +11,6 @@ Embedded=valent_sms_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.sms.messages
-X-OutgoingCapabilities=kdeconnect.sms.request;kdeconnect.sms.request_conversation;kdeconnect.sms.request_conversations
+X-DevicePluginIncoming=kdeconnect.sms.messages
+X-DevicePluginOutgoing=kdeconnect.sms.request;kdeconnect.sms.request_conversation;kdeconnect.sms.request_conversations
 

--- a/src/plugins/systemvolume/systemvolume.plugin.desktop.in
+++ b/src/plugins/systemvolume/systemvolume.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_systemvolume_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.systemvolume.request
+X-DevicePluginOutgoing=kdeconnect.systemvolume
 X-DevicePluginSettings=ca.andyholmes.valent.systemvolume
-X-IncomingCapabilities=kdeconnect.systemvolume.request
-X-OutgoingCapabilities=kdeconnect.systemvolume
 

--- a/src/plugins/telephony/telephony.plugin.desktop.in
+++ b/src/plugins/telephony/telephony.plugin.desktop.in
@@ -11,7 +11,7 @@ Embedded=valent_telephony_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
+X-DevicePluginIncoming=kdeconnect.telephony
+X-DevicePluginOutgoing=kdeconnect.telephony.request_mute
 X-DevicePluginSettings=ca.andyholmes.valent.telephony
-X-IncomingCapabilities=kdeconnect.telephony
-X-OutgoingCapabilities=kdeconnect.telephony.request_mute
 

--- a/src/tests/fixtures/mock.plugin
+++ b/src/tests/fixtures/mock.plugin
@@ -11,8 +11,8 @@ Embedded=valent_mock_plugin_register_types
 Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
-X-IncomingCapabilities=kdeconnect.mock.echo;kdeconnect.mock.transfer
-X-OutgoingCapabilities=kdeconnect.mock.echo;kdeconnect.mock.transfer
+X-DevicePluginIncoming=kdeconnect.mock.echo;kdeconnect.mock.transfer
+X-DevicePluginOutgoing=kdeconnect.mock.echo;kdeconnect.mock.transfer
 # The mock plugins should be lowest priority
 X-ClipboardAdapterPriority=1000000
 X-ContactsAdapterPriority=1000000


### PR DESCRIPTION
Rename `X-IncomingCapabilities` and `X-OutgoingCapabilities` fields to
`X-DevicePluginIncoming` and `X-DevicePluginOutgoing` respectively, to
better reflect that these are plugin attributes.