### PR TITLE
ci: use container image from current repository

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
     concurrency:
       group: gh_pages
     permissions:
@@ -90,7 +90,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
     concurrency:
       group: gh_pages
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     needs: [pre-test]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
 
     steps:
       - name: Checkout
@@ -123,7 +123,7 @@ jobs:
     needs: [pre-test]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
 
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
     needs: [pre-test]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
 
     strategy:
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
     name: Static Analysis (CodeQL)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
     permissions:
       security-events: write
 


### PR DESCRIPTION
Modify workflows to use `${{ github.repository }}` in place of `andyholmes/valent`, so that forks can pull their own images if they make relevant changes.