### PR TITLE
refactor(media): refactor media players and properties

### DIFF
--- a/doc/schemas/kdeconnect.mpris.json
+++ b/doc/schemas/kdeconnect.mpris.json
@@ -95,6 +95,19 @@
                     "type": "boolean",
                     "description": "Whether playback is active."
                 },
+                "loopStatus": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "Track",
+                        "Playlist"
+                    ],
+                    "description": "The loop status."
+                },
+                "shuffle": {
+                    "type": "boolean",
+                    "description": "Whether shuffle is enabled."
+                },
                 "pos": {
                     "type": "number",
                     "minimum": 0,

--- a/doc/schemas/kdeconnect.mpris.request.json
+++ b/doc/schemas/kdeconnect.mpris.request.json
@@ -65,10 +65,23 @@
                     "type": "number",
                     "description": "A request to seek relative to the current position (ms)."
                 },
+                "setLoopStatus": {
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "Track",
+                        "Playlist"
+                    ],
+                    "description": "A request to set the loop status."
+                },
                 "SetPosition": {
                     "type": "number",
                     "minimum": 0,
                     "description": "A request to set the track position (ms)."
+                },
+                "setShuffle": {
+                    "type": "boolean",
+                    "description": "A request to set the shuffle mode."
                 },
                 "setVolume": {
                     "type": "number",

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -28,7 +28,6 @@ G_DEFINE_TYPE (ValentMediaPlayer, valent_media_player, G_TYPE_OBJECT)
  * ValentMediaPlayerClass:
  * @changed: the class closure for #ValentMediaPlayer::changed signal
  * @next: the virtual function pointer for valent_media_player_next()
- * @open_uri: the virtual function pointer for valent_media_player_open_uri()
  * @pause: the virtual function pointer for valent_media_player_pause()
  * @play: the virtual function pointer for valent_media_player_play()
  * @play_pause: the virtual function pointer for valent_media_player_play_pause()
@@ -746,50 +745,6 @@ valent_media_player_next (ValentMediaPlayer *player)
   g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
 
   VALENT_MEDIA_PLAYER_GET_CLASS (player)->next (player);
-
-  VALENT_EXIT;
-}
-
-/**
- * valent_media_player_open_uri: (virtual open_uri)
- * @player: a #ValentMediaPlayer
- * @uri: a URI
- *
- * Opens the @uri given as an argument.
- *
- * If the playback is stopped, starts playing. If the uri scheme or the
- * mime-type of the uri to open is not supported, this method does nothing. In
- * particular, if the list of available uri schemes is empty, this method may
- * not be implemented.
- *
- * Clients should not assume that @uri has been opened as soon as this method
- * returns. They should wait until the mpris:trackid field in
- * #ValentMediaPlayer:metadata property changes.
- *
- * If the media player implements the TrackList interface, then the opened track
- * should be made part of the tracklist, the
- * org.mpris.MediaPlayer2.TrackList.TrackAdded or
- * org.mpris.MediaPlayer2.TrackList.TrackListReplaced signal should be fired, as
- * well as the org.freedesktop.DBus.Properties.PropertiesChanged signal on the
- * tracklist interface.
- *
- * Since: 1.0
- */
-void
-valent_media_player_open_uri (ValentMediaPlayer *player,
-                              const char        *uri)
-{
-  ValentMediaPlayerClass *klass;
-
-  VALENT_ENTRY;
-
-  g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
-  g_return_if_fail (uri != NULL);
-
-  klass = VALENT_MEDIA_PLAYER_GET_CLASS (player);
-  g_return_if_fail (klass->open_uri);
-
-  klass->open_uri (player, uri);
 
   VALENT_EXIT;
 }

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -39,6 +39,8 @@ G_DEFINE_TYPE (ValentMediaPlayer, valent_media_player, G_TYPE_OBJECT)
  * @get_name: Getter for the #ValentMediaPlayer:name property.
  * @get_position: Getter for the #ValentMediaPlayer:position property.
  * @set_position: Setter for the #ValentMediaPlayer:position property.
+ * @get_repeat: Getter for the #ValentMediaPlayer:repeat property.
+ * @set_repeat: Setter for the #ValentMediaPlayer:repeat property.
  * @seeked: the class closure for the #ValentMediaPlayer::seeked signal
  * @get_state: Getter for the #ValentMediaPlayer:state property.
  * @set_state: Setter for the #ValentMediaPlayer:state property.
@@ -54,6 +56,7 @@ enum {
   PROP_METADATA,
   PROP_NAME,
   PROP_POSITION,
+  PROP_REPEAT,
   PROP_SHUFFLE,
   PROP_STATE,
   PROP_VOLUME,
@@ -99,6 +102,18 @@ valent_media_player_real_get_position (ValentMediaPlayer *player)
 static void
 valent_media_player_real_set_position (ValentMediaPlayer *player,
                                        gint64             position)
+{
+}
+
+static ValentMediaRepeat
+valent_media_player_real_get_repeat (ValentMediaPlayer *player)
+{
+  return VALENT_MEDIA_REPEAT_NONE;
+}
+
+static void
+valent_media_player_real_set_repeat (ValentMediaPlayer *player,
+                                     ValentMediaRepeat  repeat)
 {
 }
 
@@ -218,6 +233,10 @@ valent_media_player_get_property (GObject    *object,
       g_value_set_int64 (value, valent_media_player_get_position (self));
       break;
 
+    case PROP_REPEAT:
+      g_value_set_enum (value, valent_media_player_get_repeat (self));
+      break;
+
     case PROP_SHUFFLE:
       g_value_set_boolean (value, valent_media_player_get_shuffle (self));
       break;
@@ -247,6 +266,10 @@ valent_media_player_set_property (GObject      *object,
     {
     case PROP_POSITION:
       valent_media_player_set_position (self, g_value_get_int64 (value));
+      break;
+
+    case PROP_REPEAT:
+      valent_media_player_set_repeat (self, g_value_get_enum (value));
       break;
 
     case PROP_STATE:
@@ -280,6 +303,8 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
   player_class->get_name = valent_media_player_real_get_name;
   player_class->get_position = valent_media_player_real_get_position;
   player_class->set_position = valent_media_player_real_set_position;
+  player_class->get_repeat = valent_media_player_real_get_repeat;
+  player_class->set_repeat = valent_media_player_real_set_repeat;
   player_class->get_shuffle = valent_media_player_real_get_shuffle;
   player_class->set_shuffle = valent_media_player_real_set_shuffle;
   player_class->get_state = valent_media_player_real_get_state;
@@ -366,6 +391,25 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
                         (G_PARAM_READWRITE |
                          G_PARAM_EXPLICIT_NOTIFY |
                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentMediaPlayer:repeat: (getter get_repeat) (setter set_repeat)
+   *
+   * The repeat mode.
+   *
+   * If the player does not have the appropriate bitmask in
+   * [property@Valent.MediaPlayer:flags], setting this property should have no
+   * effect.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_REPEAT] =
+    g_param_spec_enum ("repeat", NULL, NULL,
+                       VALENT_TYPE_MEDIA_REPEAT,
+                       VALENT_MEDIA_REPEAT_NONE,
+                       (G_PARAM_READWRITE |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
 
   /**
    * ValentMediaPlayer:state: (getter get_state) (setter set_state)
@@ -667,6 +711,52 @@ valent_media_player_set_position (ValentMediaPlayer *player,
   g_return_if_fail (position >= 0);
 
   VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_position (player, position);
+
+  VALENT_EXIT;
+}
+
+/**
+ * valent_media_player_get_repeat: (virtual get_repeat) (get-property repeat)
+ * @player: a #ValentMediaPlayer
+ *
+ * Get the repeat mode for @player.
+ *
+ * Returns: #ValentMediaRepeat
+ *
+ * Since: 1.0
+ */
+ValentMediaRepeat
+valent_media_player_get_repeat (ValentMediaPlayer *player)
+{
+  ValentMediaRepeat ret;
+
+  VALENT_ENTRY;
+
+  g_return_val_if_fail (VALENT_IS_MEDIA_PLAYER (player), VALENT_MEDIA_REPEAT_NONE);
+
+  ret = VALENT_MEDIA_PLAYER_GET_CLASS (player)->get_repeat (player);
+
+  VALENT_RETURN (ret);
+}
+
+/**
+ * valent_media_player_set_repeat: (virtual set_repeat) (set-property repeat)
+ * @player: a #ValentMediaPlayer
+ * @repeat: a #ValentMediaRepeat
+ *
+ * Set the repeat mode of @player to @repeat.
+ *
+ * Since: 1.0
+ */
+void
+valent_media_player_set_repeat (ValentMediaPlayer *player,
+                               ValentMediaRepeat   repeat)
+{
+  VALENT_ENTRY;
+
+  g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
+
+  VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_repeat (player, repeat);
 
   VALENT_EXIT;
 }

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -54,6 +54,7 @@ enum {
   PROP_METADATA,
   PROP_NAME,
   PROP_POSITION,
+  PROP_SHUFFLE,
   PROP_STATE,
   PROP_VOLUME,
   N_PROPERTIES
@@ -98,6 +99,18 @@ valent_media_player_real_get_position (ValentMediaPlayer *player)
 static void
 valent_media_player_real_set_position (ValentMediaPlayer *player,
                                        gint64             position)
+{
+}
+
+static gboolean
+valent_media_player_real_get_shuffle (ValentMediaPlayer *player)
+{
+  return FALSE;
+}
+
+static void
+valent_media_player_real_set_shuffle (ValentMediaPlayer *player,
+                                      gboolean           shuffle)
 {
 }
 
@@ -205,6 +218,10 @@ valent_media_player_get_property (GObject    *object,
       g_value_set_int64 (value, valent_media_player_get_position (self));
       break;
 
+    case PROP_SHUFFLE:
+      g_value_set_boolean (value, valent_media_player_get_shuffle (self));
+      break;
+
     case PROP_STATE:
       g_value_set_flags (value, valent_media_player_get_state (self));
       break;
@@ -236,6 +253,10 @@ valent_media_player_set_property (GObject      *object,
       valent_media_player_set_state (self, g_value_get_flags (value));
       break;
 
+    case PROP_SHUFFLE:
+      valent_media_player_set_shuffle (self, g_value_get_boolean (value));
+      break;
+
     case PROP_VOLUME:
       valent_media_player_set_volume (self, g_value_get_double (value));
       break;
@@ -259,6 +280,8 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
   player_class->get_name = valent_media_player_real_get_name;
   player_class->get_position = valent_media_player_real_get_position;
   player_class->set_position = valent_media_player_real_set_position;
+  player_class->get_shuffle = valent_media_player_real_get_shuffle;
+  player_class->set_shuffle = valent_media_player_real_set_shuffle;
   player_class->get_state = valent_media_player_real_get_state;
   player_class->set_state = valent_media_player_real_set_state;
   player_class->get_volume = valent_media_player_real_get_volume;
@@ -362,6 +385,24 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
                         (G_PARAM_READWRITE |
                          G_PARAM_EXPLICIT_NOTIFY |
                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentMediaPlayer:shuffle: (getter get_shuffle) (setter set_shuffle)
+   *
+   * Whether playback order is shuffled.
+   *
+   * A value of %FALSE indicates that playback is progressing linearly through a
+   * playlist, while %TRUE means playback is progressing through a playlist in
+   * some other order.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_SHUFFLE] =
+    g_param_spec_boolean ("shuffle", NULL, NULL,
+                          FALSE,
+                          (G_PARAM_READWRITE |
+                           G_PARAM_EXPLICIT_NOTIFY |
+                           G_PARAM_STATIC_STRINGS));
 
   /**
    * ValentMediaPlayer:volume: (getter get_volume) (setter set_volume)
@@ -626,6 +667,52 @@ valent_media_player_set_position (ValentMediaPlayer *player,
   g_return_if_fail (position >= 0);
 
   VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_position (player, position);
+
+  VALENT_EXIT;
+}
+
+/**
+ * valent_media_player_get_shuffle: (virtual get_shuffle) (get-property shuffle)
+ * @player: a #ValentMediaPlayer
+ *
+ * Get whether playback order is shuffled.
+ *
+ * Returns: the shuffle state
+ *
+ * Since: 1.0
+ */
+gboolean
+valent_media_player_get_shuffle (ValentMediaPlayer *player)
+{
+  gboolean ret;
+
+  VALENT_ENTRY;
+
+  g_return_val_if_fail (VALENT_IS_MEDIA_PLAYER (player), FALSE);
+
+  ret = VALENT_MEDIA_PLAYER_GET_CLASS (player)->get_shuffle (player);
+
+  VALENT_RETURN (ret);
+}
+
+/**
+ * valent_media_player_set_shuffle: (virtual set_shuffle) (set-property shuffle)
+ * @player: a #ValentMediaPlayer
+ * @shuffle: shuffle state
+ *
+ * Set whether playback order is shuffled.
+ *
+ * Since: 1.0
+ */
+void
+valent_media_player_set_shuffle (ValentMediaPlayer *player,
+                                  gboolean           shuffle)
+{
+  VALENT_ENTRY;
+
+  g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
+
+  VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_shuffle (player, shuffle);
 
   VALENT_EXIT;
 }

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -33,12 +33,12 @@ G_DEFINE_TYPE (ValentMediaPlayer, valent_media_player, G_TYPE_OBJECT)
  * @play_pause: the virtual function pointer for valent_media_player_play_pause()
  * @previous: the virtual function pointer for valent_media_player_previous()
  * @seek: the virtual function pointer for valent_media_player_seek()
- * @set_position: the virtual function pointer for valent_media_player_set_position()
  * @stop: the virtual function pointer for valent_media_player_stop()
  * @get_flags: Getter for the #ValentMediaPlayer:flags property.
  * @get_metadata: Getter for the #ValentMediaPlayer:metadata property.
  * @get_name: Getter for the #ValentMediaPlayer:name property.
  * @get_position: Getter for the #ValentMediaPlayer:position property.
+ * @set_position: Setter for the #ValentMediaPlayer:position property.
  * @seeked: the class closure for the #ValentMediaPlayer::seeked signal
  * @get_state: Getter for the #ValentMediaPlayer:state property.
  * @set_state: Setter for the #ValentMediaPlayer:state property.
@@ -97,7 +97,6 @@ valent_media_player_real_get_position (ValentMediaPlayer *player)
 
 static void
 valent_media_player_real_set_position (ValentMediaPlayer *player,
-                                       const char        *track_id,
                                        gint64             position)
 {
 }
@@ -229,6 +228,10 @@ valent_media_player_set_property (GObject      *object,
 
   switch (prop_id)
     {
+    case PROP_POSITION:
+      valent_media_player_set_position (self, g_value_get_int64 (value));
+      break;
+
     case PROP_STATE:
       valent_media_player_set_state (self, g_value_get_flags (value));
       break;
@@ -337,7 +340,7 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
     g_param_spec_int64 ("position", NULL, NULL,
                         G_MININT64, G_MAXINT64,
                         0,
-                        (G_PARAM_READABLE |
+                        (G_PARAM_READWRITE |
                          G_PARAM_EXPLICIT_NOTIFY |
                          G_PARAM_STATIC_STRINGS));
 
@@ -607,7 +610,6 @@ valent_media_player_get_position (ValentMediaPlayer *player)
 /**
  * valent_media_player_set_position: (virtual set_position) (set-property position)
  * @player: a #ValentMediaPlayer
- * @track_id: track ID
  * @position: position offset
  *
  * Set the current position.
@@ -616,17 +618,14 @@ valent_media_player_get_position (ValentMediaPlayer *player)
  */
 void
 valent_media_player_set_position (ValentMediaPlayer *player,
-                                  const char        *track_id,
                                   gint64             position)
 {
   VALENT_ENTRY;
 
   g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
-  g_return_if_fail (track_id != NULL);
+  g_return_if_fail (position >= 0);
 
-  VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_position (player,
-                                                        track_id,
-                                                        position);
+  VALENT_MEDIA_PLAYER_GET_CLASS (player)->set_position (player, position);
 
   VALENT_EXIT;
 }

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -61,16 +61,9 @@ typedef enum
 
 /**
  * ValentMediaState:
- * @VALENT_MEDIA_STATE_UNKNOWN: The player state is unknown.
+ * @VALENT_MEDIA_STATE_STOPPED: The player state is unknown.
  * @VALENT_MEDIA_STATE_PLAYING: Playback is active.
  * @VALENT_MEDIA_STATE_PAUSED: Playback is paused.
- * @VALENT_MEDIA_STATE_STOPPED: Playback is halted.
- * @VALENT_MEDIA_STATE_REPEAT: The current item will be restarted when it finishes.
- * @VALENT_MEDIA_STATE_REPEAT_ALL: The item queue will be restarted when it finishes.
- * @VALENT_MEDIA_STATE_RESERVED1: Reserved
- * @VALENT_MEDIA_STATE_RESERVED2: Reserved
- * @VALENT_MEDIA_STATE_RESERVED3: Reserved
- * @VALENT_MEDIA_STATE_RESERVED4: Reserved
  *
  * Media state flags.
  *
@@ -79,14 +72,8 @@ typedef enum
 typedef enum
 {
   VALENT_MEDIA_STATE_STOPPED,
-  VALENT_MEDIA_STATE_PLAYING    = (1<<0),
-  VALENT_MEDIA_STATE_PAUSED     = (1<<1),
-  VALENT_MEDIA_STATE_REPEAT     = (1<<2),
-  VALENT_MEDIA_STATE_REPEAT_ALL = (1<<3),
-  VALENT_MEDIA_STATE_RESERVED1  = (1<<4),
-  VALENT_MEDIA_STATE_RESERVED2  = (1<<5),
-  VALENT_MEDIA_STATE_RESERVED3  = (1<<6),
-  VALENT_MEDIA_STATE_RESERVED4  = (1<<7)
+  VALENT_MEDIA_STATE_PAUSED,
+  VALENT_MEDIA_STATE_PLAYING,
 } ValentMediaState;
 
 
@@ -122,8 +109,6 @@ struct _ValentMediaPlayerClass
   void                 (*set_shuffle)  (ValentMediaPlayer *player,
                                         gboolean           shuffle);
   ValentMediaState     (*get_state)    (ValentMediaPlayer *player);
-  void                 (*set_state)    (ValentMediaPlayer *player,
-                                        ValentMediaState   state);
   double               (*get_volume)   (ValentMediaPlayer *player);
   void                 (*set_volume)   (ValentMediaPlayer *player,
                                         double             volume);
@@ -167,9 +152,6 @@ void                 valent_media_player_set_shuffle  (ValentMediaPlayer *player
                                                        gboolean           shuffle);
 VALENT_AVAILABLE_IN_1_0
 ValentMediaState     valent_media_player_get_state    (ValentMediaPlayer *player);
-VALENT_AVAILABLE_IN_1_0
-void                 valent_media_player_set_state    (ValentMediaPlayer *player,
-                                                       ValentMediaState   state);
 VALENT_AVAILABLE_IN_1_0
 double               valent_media_player_get_volume   (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -49,10 +49,10 @@ typedef enum
  * @VALENT_MEDIA_STATE_STOPPED: Playback is halted.
  * @VALENT_MEDIA_STATE_REPEAT: The current item will be restarted when it finishes.
  * @VALENT_MEDIA_STATE_REPEAT_ALL: The item queue will be restarted when it finishes.
- * @VALENT_MEDIA_STATE_SHUFFLE: Playback order is non-linear.
  * @VALENT_MEDIA_STATE_RESERVED1: Reserved
  * @VALENT_MEDIA_STATE_RESERVED2: Reserved
  * @VALENT_MEDIA_STATE_RESERVED3: Reserved
+ * @VALENT_MEDIA_STATE_RESERVED4: Reserved
  *
  * Media state flags.
  *
@@ -65,10 +65,10 @@ typedef enum
   VALENT_MEDIA_STATE_PAUSED     = (1<<1),
   VALENT_MEDIA_STATE_REPEAT     = (1<<2),
   VALENT_MEDIA_STATE_REPEAT_ALL = (1<<3),
-  VALENT_MEDIA_STATE_SHUFFLE    = (1<<4),
-  VALENT_MEDIA_STATE_RESERVED1  = (1<<5),
-  VALENT_MEDIA_STATE_RESERVED2  = (1<<6),
-  VALENT_MEDIA_STATE_RESERVED3  = (1<<7)
+  VALENT_MEDIA_STATE_RESERVED1  = (1<<4),
+  VALENT_MEDIA_STATE_RESERVED2  = (1<<5),
+  VALENT_MEDIA_STATE_RESERVED3  = (1<<6),
+  VALENT_MEDIA_STATE_RESERVED4  = (1<<7)
 } ValentMediaState;
 
 
@@ -97,6 +97,9 @@ struct _ValentMediaPlayerClass
   gint64               (*get_position) (ValentMediaPlayer *player);
   void                 (*set_position) (ValentMediaPlayer *player,
                                         gint64             position);
+  gboolean             (*get_shuffle)  (ValentMediaPlayer *player);
+  void                 (*set_shuffle)  (ValentMediaPlayer *player,
+                                        gboolean           shuffle);
   ValentMediaState     (*get_state)    (ValentMediaPlayer *player);
   void                 (*set_state)    (ValentMediaPlayer *player,
                                         ValentMediaState   state);
@@ -131,6 +134,11 @@ gint64               valent_media_player_get_position (ValentMediaPlayer *player
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_position (ValentMediaPlayer *player,
                                                        gint64             position);
+VALENT_AVAILABLE_IN_1_0
+gboolean             valent_media_player_get_shuffle  (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
+void                 valent_media_player_set_shuffle  (ValentMediaPlayer *player,
+                                                       gboolean           shuffle);
 VALENT_AVAILABLE_IN_1_0
 ValentMediaState     valent_media_player_get_state    (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -83,8 +83,6 @@ struct _ValentMediaPlayerClass
 
   /* virtual functions */
   void                 (*next)         (ValentMediaPlayer *player);
-  void                 (*open_uri)     (ValentMediaPlayer *player,
-                                        const char        *uri);
   void                 (*pause)        (ValentMediaPlayer *player);
   void                 (*play)         (ValentMediaPlayer *player);
   void                 (*play_pause)   (ValentMediaPlayer *player);
@@ -148,9 +146,6 @@ void                 valent_media_player_set_volume   (ValentMediaPlayer *player
 
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_next         (ValentMediaPlayer *player);
-VALENT_AVAILABLE_IN_1_0
-void                 valent_media_player_open_uri     (ValentMediaPlayer *player,
-                                                       const char        *uri);
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_pause        (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -44,8 +44,8 @@ typedef enum
 /**
  * ValentMediaRepeat:
  * @VALENT_MEDIA_REPEAT_NONE: Repeat off.
- * @VALENT_MEDIA_REPEAT_NONE: Repeat the current item.
- * @VALENT_MEDIA_REPEAT_NONE: Repeat all items.
+ * @VALENT_MEDIA_REPEAT_ALL: Repeat all items.
+ * @VALENT_MEDIA_REPEAT_ONE: Repeat one items.
  *
  * Enumeration of loop modes.
  *
@@ -54,8 +54,8 @@ typedef enum
 typedef enum
 {
   VALENT_MEDIA_REPEAT_NONE,
-  VALENT_MEDIA_REPEAT_ONE,
   VALENT_MEDIA_REPEAT_ALL,
+  VALENT_MEDIA_REPEAT_ONE,
 } ValentMediaRepeat;
 
 
@@ -72,8 +72,8 @@ typedef enum
 typedef enum
 {
   VALENT_MEDIA_STATE_STOPPED,
-  VALENT_MEDIA_STATE_PAUSED,
   VALENT_MEDIA_STATE_PLAYING,
+  VALENT_MEDIA_STATE_PAUSED,
 } ValentMediaState;
 
 

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -96,7 +96,6 @@ struct _ValentMediaPlayerClass
   const char         * (*get_name)     (ValentMediaPlayer *player);
   gint64               (*get_position) (ValentMediaPlayer *player);
   void                 (*set_position) (ValentMediaPlayer *player,
-                                        const char        *track_id,
                                         gint64             position);
   ValentMediaState     (*get_state)    (ValentMediaPlayer *player);
   void                 (*set_state)    (ValentMediaPlayer *player,
@@ -131,7 +130,6 @@ VALENT_AVAILABLE_IN_1_0
 gint64               valent_media_player_get_position (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_position (ValentMediaPlayer *player,
-                                                       const char        *track_id,
                                                        gint64             position);
 VALENT_AVAILABLE_IN_1_0
 ValentMediaState     valent_media_player_get_state    (ValentMediaPlayer *player);

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -42,6 +42,24 @@ typedef enum
 
 
 /**
+ * ValentMediaRepeat:
+ * @VALENT_MEDIA_REPEAT_NONE: Repeat off.
+ * @VALENT_MEDIA_REPEAT_NONE: Repeat the current item.
+ * @VALENT_MEDIA_REPEAT_NONE: Repeat all items.
+ *
+ * Enumeration of loop modes.
+ *
+ * Since: 1.0
+ */
+typedef enum
+{
+  VALENT_MEDIA_REPEAT_NONE,
+  VALENT_MEDIA_REPEAT_ONE,
+  VALENT_MEDIA_REPEAT_ALL,
+} ValentMediaRepeat;
+
+
+/**
  * ValentMediaState:
  * @VALENT_MEDIA_STATE_UNKNOWN: The player state is unknown.
  * @VALENT_MEDIA_STATE_PLAYING: Playback is active.
@@ -97,6 +115,9 @@ struct _ValentMediaPlayerClass
   gint64               (*get_position) (ValentMediaPlayer *player);
   void                 (*set_position) (ValentMediaPlayer *player,
                                         gint64             position);
+  ValentMediaRepeat    (*get_repeat)   (ValentMediaPlayer *player);
+  void                 (*set_repeat)   (ValentMediaPlayer *player,
+                                        ValentMediaRepeat  repeat);
   gboolean             (*get_shuffle)  (ValentMediaPlayer *player);
   void                 (*set_shuffle)  (ValentMediaPlayer *player,
                                         gboolean           shuffle);
@@ -129,6 +150,11 @@ VALENT_AVAILABLE_IN_1_0
 GVariant           * valent_media_player_get_metadata (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
 const char         * valent_media_player_get_name     (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
+ValentMediaRepeat    valent_media_player_get_repeat   (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
+void                 valent_media_player_set_repeat   (ValentMediaPlayer *player,
+                                                       ValentMediaRepeat  repeat);
 VALENT_AVAILABLE_IN_1_0
 gint64               valent_media_player_get_position (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/plugins/mpris/meson.build
+++ b/src/plugins/mpris/meson.build
@@ -14,6 +14,7 @@ plugin_mpris_sources = files([
   'valent-mpris-player.c',
   'valent-mpris-plugin.c',
   'valent-mpris-remote.c',
+  'valent-mpris-utils.c',
 ])
 
 plugin_mpris_include_directories = [include_directories('.')]

--- a/src/plugins/mpris/valent-mpris-adapter.c
+++ b/src/plugins/mpris/valent-mpris-adapter.c
@@ -8,9 +8,9 @@
 #include <libvalent-core.h>
 #include <libvalent-media.h>
 
-#include "valent-mpris-common.h"
-#include "valent-mpris-player.h"
 #include "valent-mpris-adapter.h"
+#include "valent-mpris-player.h"
+#include "valent-mpris-utils.h"
 
 
 struct _ValentMPRISAdapter
@@ -30,7 +30,7 @@ G_DEFINE_TYPE (ValentMPRISAdapter, valent_mpris_adapter, VALENT_TYPE_MEDIA_ADAPT
  */
 static void
 add_player (ValentMPRISAdapter *self,
-            ValentMPRISPlayer         *player)
+            ValentMPRISPlayer  *player)
 {
   g_autofree char *name = NULL;
 
@@ -40,12 +40,12 @@ add_player (ValentMPRISAdapter *self,
                        g_object_ref (player));
 
   valent_media_adapter_emit_player_added (VALENT_MEDIA_ADAPTER (self),
-                                                  VALENT_MEDIA_PLAYER (player));
+                                          VALENT_MEDIA_PLAYER (player));
 }
 
 static void
 remove_player (ValentMPRISAdapter *self,
-               const char                *name)
+               const char         *name)
 {
   ValentMediaAdapter *adapter = VALENT_MEDIA_ADAPTER (self);
   gpointer key, value;

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -483,7 +483,6 @@ valent_mpris_player_get_position (ValentMediaPlayer *player)
 
 static void
 valent_mpris_player_set_position (ValentMediaPlayer *player,
-                                  const char        *track_id,
                                   gint64             position)
 {
   ValentMPRISPlayer *self = VALENT_MPRIS_PLAYER (player);
@@ -495,7 +494,7 @@ valent_mpris_player_set_position (ValentMediaPlayer *player,
 
   g_dbus_proxy_call (self->player,
                      "SetPosition",
-                     g_variant_new ("(ox)", track_id, position),
+                     g_variant_new ("(ox)", "/", position),
                      G_DBUS_CALL_FLAGS_NONE,
                      -1,
                      NULL,

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -552,22 +552,6 @@ valent_mpris_player_next (ValentMediaPlayer *player)
 }
 
 static void
-valent_mpris_player_open_uri (ValentMediaPlayer *player,
-                              const char        *uri)
-{
-  ValentMPRISPlayer *self = VALENT_MPRIS_PLAYER (player);
-
-  g_dbus_proxy_call (self->player,
-                     "OpenUri",
-                     g_variant_new ("(s)", uri),
-                     G_DBUS_CALL_FLAGS_NONE,
-                     -1,
-                     NULL,
-                     NULL,
-                     NULL);
-}
-
-static void
 valent_mpris_player_pause (ValentMediaPlayer *player)
 {
   ValentMPRISPlayer *self = VALENT_MPRIS_PLAYER (player);
@@ -762,7 +746,6 @@ valent_mpris_player_class_init (ValentMPRISPlayerClass *klass)
   player_class->set_volume = valent_mpris_player_set_volume;
 
   player_class->next = valent_mpris_player_next;
-  player_class->open_uri = valent_mpris_player_open_uri;
   player_class->pause = valent_mpris_player_pause;
   player_class->play = valent_mpris_player_play;
   player_class->play_pause = valent_mpris_player_play_pause;

--- a/src/plugins/mpris/valent-mpris-player.h
+++ b/src/plugins/mpris/valent-mpris-player.h
@@ -11,12 +11,12 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ValentMPRISPlayer, valent_mpris_player, VALENT, MPRIS_PLAYER, ValentMediaPlayer)
 
-void                valent_mpris_player_new              (const char           *name,
-                                                          GCancellable         *cancellable,
-                                                          GAsyncReadyCallback   callback,
-                                                          gpointer              user_data);
-ValentMPRISPlayer * valent_mpris_player_new_finish       (GAsyncResult         *result,
-                                                          GError              **error);
+void                valent_mpris_player_new        (const char           *name,
+                                                    GCancellable         *cancellable,
+                                                    GAsyncReadyCallback   callback,
+                                                    gpointer              user_data);
+ValentMPRISPlayer * valent_mpris_player_new_finish (GAsyncResult         *result,
+                                                    GError              **error);
 
 G_END_DECLS
 

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -181,22 +181,22 @@ valent_mpris_plugin_handle_action (ValentMprisPlugin *self,
   g_assert (VALENT_IS_MEDIA_PLAYER (player));
   g_assert (action && *action);
 
-  if (g_str_equal (action, "Next"))
+  if (strcmp (action, "Next") == 0)
     valent_media_player_next (player);
 
-  else if (g_str_equal (action, "Pause"))
+  else if (strcmp (action, "Pause") == 0)
     valent_media_player_pause (player);
 
-  else if (g_str_equal (action, "Play"))
+  else if (strcmp (action, "Play") == 0)
     valent_media_player_play (player);
 
-  else if (g_str_equal (action, "PlayPause"))
+  else if (strcmp (action, "PlayPause") == 0)
     valent_media_player_play_pause (player);
 
-  else if (g_str_equal (action, "Previous"))
+  else if (strcmp (action, "Previous") == 0)
     valent_media_player_previous (player);
 
-  else if (g_str_equal (action, "Stop"))
+  else if (strcmp (action, "Stop") == 0)
     valent_media_player_stop (player);
 
   else
@@ -765,9 +765,11 @@ valent_mpris_plugin_handle_player_update (ValentMprisPlugin *self,
   GVariantDict metadata;
   const char *artist, *title, *album;
   gint64 length, position;
+  const char *loop_status = NULL;
+  gboolean shuffle = FALSE;
+  gboolean is_playing;
   gint64 volume;
   double volume_level = 100.0;
-  gboolean is_playing;
 
   /* Get the remote */
   if (!valent_packet_get_string (packet, "player", &player) ||
@@ -833,12 +835,14 @@ valent_mpris_plugin_handle_player_update (ValentMprisPlugin *self,
   if (valent_packet_get_int (packet, "volume", &volume))
     volume_level = volume / 100;
 
-  valent_mpris_remote_update_player (remote,
-                                     flags,
-                                     g_variant_dict_end (&metadata),
-                                     is_playing ? "Playing" : "Paused",
-                                     position,
-                                     volume_level);
+  valent_mpris_remote_update_full (remote,
+                                   flags,
+                                   g_variant_dict_end (&metadata),
+                                   is_playing ? "Playing" : "Paused",
+                                   position,
+                                   loop_status,
+                                   shuffle,
+                                   volume_level);
 }
 
 static void

--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -42,6 +42,7 @@ struct _ValentMprisRemote
   char                 *loop_status;
   GVariant             *metadata;
   gint64                position;
+  unsigned int          shuffle : 1;
   double                volume;
 };
 
@@ -524,7 +525,7 @@ player_get_property (GDBusConnection  *connection,
 
   if (g_strcmp0 (property_name, "Shuffle") == 0)
     {
-      value = g_variant_new_boolean ((self->state & VALENT_MEDIA_STATE_SHUFFLE) != 0);
+      value = g_variant_new_boolean (self->shuffle);
       g_hash_table_replace (self->cache,
                             g_strdup (property_name),
                             g_variant_ref_sink (value));
@@ -582,7 +583,7 @@ player_set_property (GDBusConnection  *connection,
     {
       gboolean shuffle = g_variant_get_boolean (value);
 
-      if (((self->state & VALENT_MEDIA_STATE_SHUFFLE) != 0) == shuffle)
+      if (self->shuffle == shuffle)
         return TRUE;
     }
 
@@ -779,6 +780,24 @@ valent_mpris_remote_get_position (ValentMediaPlayer *player)
   return self->position;
 }
 
+static gboolean
+valent_mpris_remote_get_shuffle (ValentMediaPlayer *player)
+{
+  ValentMprisRemote *self = VALENT_MPRIS_REMOTE (player);
+
+  return self->shuffle;
+}
+
+static void
+valent_mpris_remote_set_shuffle (ValentMediaPlayer *player,
+                                 gboolean           shuffle)
+{
+  g_autoptr (GVariant) value = NULL;
+
+  value = g_variant_ref_sink (g_variant_new ("(b)", shuffle));
+  g_signal_emit (G_OBJECT (player), signals [SET_PROPERTY], 0, "Shuffle", value);
+}
+
 static ValentMediaState
 valent_mpris_remote_get_state (ValentMediaPlayer *player)
 {
@@ -890,6 +909,8 @@ valent_mpris_remote_class_init (ValentMprisRemoteClass *klass)
   player_class->get_metadata = valent_mpris_remote_get_metadata;
   player_class->get_name = valent_mpris_remote_get_name;
   player_class->get_position = valent_mpris_remote_get_position;
+  player_class->get_shuffle = valent_mpris_remote_get_shuffle;
+  player_class->set_shuffle = valent_mpris_remote_set_shuffle;
   player_class->get_state = valent_mpris_remote_get_state;
   player_class->get_volume = valent_mpris_remote_get_volume;
   player_class->set_volume = valent_mpris_remote_set_volume;

--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -373,6 +373,17 @@ player_method_call (GDBusConnection       *connection,
 {
   ValentMprisRemote *self = VALENT_MPRIS_REMOTE (user_data);
 
+  /* Unsupported Methods */
+  if G_UNLIKELY (strcmp (method_name, "OpenUri") == 0)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             G_IO_ERROR,
+                                             G_IO_ERROR_NOT_SUPPORTED,
+                                             "Service does not implement %s",
+                                             method_name);
+      return;
+    }
+
   g_signal_emit (G_OBJECT (self),
                  signals [METHOD_CALL], 0,
                  method_name, parameters);
@@ -801,16 +812,6 @@ valent_mpris_remote_next (ValentMediaPlayer *player)
 }
 
 static void
-valent_mpris_remote_open_uri (ValentMediaPlayer *player,
-                              const char        *uri)
-{
-  g_autoptr (GVariant) value = NULL;
-
-  value = g_variant_ref_sink (g_variant_new ("(s)", uri));
-  g_signal_emit (G_OBJECT (player), signals [METHOD_CALL], 0, "OpenUri", value);
-}
-
-static void
 valent_mpris_remote_pause (ValentMediaPlayer *player)
 {
   g_signal_emit (G_OBJECT (player), signals [METHOD_CALL], 0, "Pause", NULL);
@@ -894,7 +895,6 @@ valent_mpris_remote_class_init (ValentMprisRemoteClass *klass)
   player_class->set_volume = valent_mpris_remote_set_volume;
 
   player_class->next = valent_mpris_remote_next;
-  player_class->open_uri = valent_mpris_remote_open_uri;
   player_class->pause = valent_mpris_remote_pause;
   player_class->play = valent_mpris_remote_play;
   player_class->previous = valent_mpris_remote_previous;

--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -511,9 +511,9 @@ player_get_property (GDBusConnection  *connection,
 
   if (g_strcmp0 (property_name, "PlaybackStatus") == 0)
     {
-      if ((self->state & VALENT_MEDIA_STATE_PAUSED) != 0)
+      if (self->state == VALENT_MEDIA_STATE_PAUSED)
         value = g_variant_new_string ("Paused");
-      if ((self->state & VALENT_MEDIA_STATE_PLAYING) != 0)
+      if (self->state == VALENT_MEDIA_STATE_PLAYING)
         value = g_variant_new_string ("Playing");
       else
         value = g_variant_new_string ("Stopped");
@@ -1390,30 +1390,26 @@ valent_mpris_remote_update_playback_status (ValentMprisRemote *remote,
 
   if (g_str_equal (status, "Paused"))
     {
-      if ((remote->state & VALENT_MEDIA_STATE_PAUSED) != 0)
+      if (remote->state == VALENT_MEDIA_STATE_PAUSED)
         return;
 
-      remote->state &= ~VALENT_MEDIA_STATE_PLAYING;
-      remote->state |= VALENT_MEDIA_STATE_PAUSED;
+      remote->state = VALENT_MEDIA_STATE_PAUSED;
     }
 
   else if (g_str_equal (status, "Playing"))
     {
-      if ((remote->state & VALENT_MEDIA_STATE_PLAYING) != 0)
+      if (remote->state == VALENT_MEDIA_STATE_PLAYING)
         return;
 
-      remote->state &= ~VALENT_MEDIA_STATE_PAUSED;
-      remote->state |= VALENT_MEDIA_STATE_PLAYING;
+      remote->state = VALENT_MEDIA_STATE_PLAYING;
     }
 
   else if (g_str_equal (status, "Stopped"))
     {
-      if ((remote->state & VALENT_MEDIA_STATE_PAUSED) == 0 &&
-          (remote->state & VALENT_MEDIA_STATE_PLAYING) == 0)
+      if (remote->state == VALENT_MEDIA_STATE_STOPPED)
         return;
 
-      remote->state &= ~VALENT_MEDIA_STATE_PAUSED;
-      remote->state &= ~VALENT_MEDIA_STATE_PLAYING;
+      remote->state = VALENT_MEDIA_STATE_STOPPED;
     }
 
   g_object_notify (G_OBJECT (remote), "state");

--- a/src/plugins/mpris/valent-mpris-remote.h
+++ b/src/plugins/mpris/valent-mpris-remote.h
@@ -11,40 +11,45 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ValentMprisRemote, valent_mpris_remote, VALENT, MPRIS_REMOTE, ValentMediaPlayer)
 
-ValentMprisRemote * valent_mpris_remote_new                    (void);
-void                valent_mpris_remote_export                 (ValentMprisRemote    *remote);
-void                valent_mpris_remote_export_full            (ValentMprisRemote    *remote,
-                                                                const char           *bus_name,
-                                                                GCancellable         *cancellable,
-                                                                GAsyncReadyCallback   callback,
-                                                                gpointer              user_data);
-gboolean            valent_mpris_remote_export_finish          (ValentMprisRemote    *remote,
-                                                                GAsyncResult         *result,
-                                                                GError              **error);
-void                valent_mpris_remote_unexport               (ValentMprisRemote    *remote);
-void                valent_mpris_remote_set_name               (ValentMprisRemote    *remote,
-                                                                const char           *identity);
-void                valent_mpris_remote_emit_seeked            (ValentMprisRemote    *remote,
-                                                                gint64                position);
-void                valent_mpris_remote_update_player          (ValentMprisRemote    *remote,
-                                                                ValentMediaActions    flags,
-                                                                GVariant             *metadata,
-                                                                const char           *playback_status,
-                                                                gint64                position,
-                                                                double                volume);
-
-void                valent_mpris_remote_update_art             (ValentMprisRemote    *remote,
-                                                                GFile                *file);
-void                valent_mpris_remote_update_flags           (ValentMprisRemote    *remote,
-                                                                ValentMediaActions    flags);
-void                valent_mpris_remote_update_metadata        (ValentMprisRemote    *remote,
-                                                                GVariant             *metadata);
-void                valent_mpris_remote_update_playback_status (ValentMprisRemote    *remote,
-                                                                const char           *status);
-void                valent_mpris_remote_update_position        (ValentMprisRemote    *remote,
-                                                                gint64                position);
-void                valent_mpris_remote_update_volume          (ValentMprisRemote    *remote,
-                                                                double                volume);
+ValentMprisRemote * valent_mpris_remote_new             (void);
+void                valent_mpris_remote_export          (ValentMprisRemote    *remote);
+void                valent_mpris_remote_export_full     (ValentMprisRemote    *remote,
+                                                         const char           *bus_name,
+                                                         GCancellable         *cancellable,
+                                                         GAsyncReadyCallback   callback,
+                                                         gpointer              user_data);
+gboolean            valent_mpris_remote_export_finish   (ValentMprisRemote    *remote,
+                                                         GAsyncResult         *result,
+                                                         GError              **error);
+void                valent_mpris_remote_unexport        (ValentMprisRemote    *remote);
+void                valent_mpris_remote_set_name        (ValentMprisRemote    *remote,
+                                                         const char           *identity);
+void                valent_mpris_remote_emit_seeked     (ValentMprisRemote    *remote,
+                                                         gint64                position);
+void                valent_mpris_remote_update_full     (ValentMprisRemote    *remote,
+                                                         ValentMediaActions    flags,
+                                                         GVariant             *metadata,
+                                                         const char           *playback_status,
+                                                         gint64                position,
+                                                         const char           *loop_status,
+                                                         gboolean              shuffle,
+                                                         double                volume);
+void                valent_mpris_remote_update_art      (ValentMprisRemote    *remote,
+                                                         GFile                *file);
+void                valent_mpris_remote_update_flags    (ValentMprisRemote    *remote,
+                                                         ValentMediaActions    flags);
+void                valent_mpris_remote_update_metadata (ValentMprisRemote    *remote,
+                                                         GVariant             *metadata);
+void                valent_mpris_remote_update_position (ValentMprisRemote    *remote,
+                                                         gint64                position);
+void                valent_mpris_remote_update_repeat   (ValentMprisRemote    *remote,
+                                                         const char           *loop_status);
+void                valent_mpris_remote_update_shuffle  (ValentMprisRemote    *remote,
+                                                         gboolean              shuffle);
+void                valent_mpris_remote_update_state    (ValentMprisRemote    *remote,
+                                                         const char           *playback_status);
+void                valent_mpris_remote_update_volume   (ValentMprisRemote    *remote,
+                                                         double                volume);
 
 G_END_DECLS
 

--- a/src/plugins/mpris/valent-mpris-utils.h
+++ b/src/plugins/mpris/valent-mpris-utils.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#include <libvalent-media.h>
+
+G_BEGIN_DECLS
+
+/**
+ * VALENT_MPRIS_DBUS_NAME: (value "org.mpris.MediaPlayer2.Valent")
+ *
+ * The well-known name Valent exports its MPRIS player on.
+ */
+#define VALENT_MPRIS_DBUS_NAME "org.mpris.MediaPlayer2.Valent"
+
+/**
+ * VALENT_MPRIS_APPLICATION_INFO:
+ *
+ * A #GDBusInterfaceInfo describing the `org.mpris.MediaPlayer2` interface.
+ */
+#define VALENT_MPRIS_APPLICATION_INFO (valent_mpris_get_application_iface())
+
+/**
+ * VALENT_MPRIS_PLAYER_INFO:
+ *
+ * A #GDBusInterfaceInfo describing the `org.mpris.MediaPlayer2.Player`
+ * interface.
+ */
+#define VALENT_MPRIS_PLAYER_INFO (valent_mpris_get_player_iface())
+
+
+GDBusInterfaceInfo * valent_mpris_get_application_iface (void);
+GDBusInterfaceInfo * valent_mpris_get_player_iface      (void);
+
+ValentMediaRepeat    valent_mpris_repeat_from_string    (const char        *loop_status);
+const char         * valent_mpris_repeat_to_string      (ValentMediaRepeat  repeat);
+ValentMediaState     valent_mpris_state_from_string     (const char        *playback_status);
+const char         * valent_mpris_state_to_string       (ValentMediaState   state);
+
+G_END_DECLS

--- a/src/tests/data/plugin-mpris.json
+++ b/src/tests/data/plugin-mpris.json
@@ -81,6 +81,22 @@
       "action": "Stop"
     }
   },
+  "request-repeat": {
+    "id": 0,
+    "type": "kdeconnect.mpris.request",
+    "body": {
+      "player": "Test Player",
+      "setLoopStatus": "Track"
+    }
+  },
+  "request-shuffle": {
+    "id": 0,
+    "type": "kdeconnect.mpris.request",
+    "body": {
+      "player": "Test Player",
+      "setShuffle": true
+    }
+  },
   "request-volume": {
     "id": 0,
     "type": "kdeconnect.mpris.request",
@@ -118,6 +134,8 @@
       "canSeek": false,
       "isPlaying": false,
       "pos": 0,
+      "loopStatus": "None",
+      "shuffle": false,
       "nowPlaying": "Unknown",
       "volume": 100
     }
@@ -134,6 +152,8 @@
       "canSeek": true,
       "isPlaying": true,
       "pos": 0,
+      "loopStatus": "None",
+      "shuffle": false,
       "albumArtUrl": "/path/to/image.png",
       "nowPlaying": "Unknown",
       "artist": "Test Artist",

--- a/src/tests/extra/cppcheck.supp
+++ b/src/tests/extra/cppcheck.supp
@@ -19,12 +19,6 @@ memleak:src/plugins/sms/valent-sms-store.c:859
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:583
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:588
 
-
-# src/tests/fixtures/
-# "Allocation with g_variant_new_*, g_signal_emit doesn't release it."
-leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:117
-leakNoVarFunctionCall:src/tests/fixtures/valent-mock-media-player.c:173
-
 # src/tests/plugins/connectivity_report/
 leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:268
 leakNoVarFunctionCall:src/plugins/connectivity_report/valent-connectivity_report-plugin.c:270

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -18,6 +18,7 @@ struct _ValentMockMediaPlayer
   /* org.mpris.MediaPlayer2 */
   GVariant          *metadata;
   gint64             position;
+  gboolean           shuffle;
   ValentMediaState   state;
   double             volume;
 };
@@ -63,6 +64,23 @@ valent_mock_media_player_set_position (ValentMediaPlayer *player,
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
 
   self->position = position;
+}
+
+static gboolean
+valent_mock_media_player_get_shuffle (ValentMediaPlayer *player)
+{
+  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
+
+  return self->shuffle;
+}
+
+static void
+valent_mock_media_player_set_shuffle (ValentMediaPlayer *player,
+                                      gboolean           shuffle)
+{
+  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
+
+  self->shuffle = shuffle;
 }
 
 static ValentMediaState
@@ -195,6 +213,8 @@ valent_mock_media_player_class_init (ValentMockMediaPlayerClass *klass)
   player_class->get_metadata = valent_mock_media_player_get_metadata;
   player_class->get_position = valent_mock_media_player_get_position;
   player_class->set_position = valent_mock_media_player_set_position;
+  player_class->get_shuffle = valent_mock_media_player_get_shuffle;
+  player_class->set_shuffle = valent_mock_media_player_set_shuffle;
   player_class->get_state = valent_mock_media_player_get_state;
   player_class->set_state = valent_mock_media_player_set_state;
   player_class->get_volume = valent_mock_media_player_get_volume;

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -178,8 +178,10 @@ valent_mock_media_player_seek (ValentMediaPlayer *player,
                                gint64             offset)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
+  g_autoptr (GVariant) value = NULL;
 
-  g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "Seek", g_variant_new_int64 (offset));
+  value = g_variant_ref_sink (g_variant_new_int64 (offset));
+  g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "Seek", value);
 }
 
 static void
@@ -254,7 +256,6 @@ valent_mock_media_player_init (ValentMockMediaPlayer *self)
   GVariantDict dict;
 
   g_variant_dict_init (&dict, NULL);
-  self->metadata = g_variant_dict_end (&dict);
-  g_variant_ref_sink (self->metadata);
+  self->metadata = g_variant_ref_sink (g_variant_dict_end (&dict));
 }
 

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -109,15 +109,6 @@ valent_mock_media_player_get_state (ValentMediaPlayer *player)
   return self->state;
 }
 
-static void
-valent_mock_media_player_set_state (ValentMediaPlayer *player,
-                                    ValentMediaState   state)
-{
-  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
-
-  self->state = state;
-}
-
 static double
 valent_mock_media_player_get_volume (ValentMediaPlayer *player)
 {
@@ -148,8 +139,7 @@ valent_mock_media_player_pause (ValentMediaPlayer *player)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
 
-  self->state &= ~VALENT_MEDIA_STATE_PLAYING;
-  self->state |= VALENT_MEDIA_STATE_PAUSED;
+  self->state = VALENT_MEDIA_STATE_PAUSED;
   g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "Pause", NULL);
 }
 
@@ -158,8 +148,7 @@ valent_mock_media_player_play (ValentMediaPlayer *player)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
 
-  self->state &= ~VALENT_MEDIA_STATE_PAUSED;
-  self->state |= VALENT_MEDIA_STATE_PLAYING;
+  self->state = VALENT_MEDIA_STATE_PLAYING;
   g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "Play", NULL);
 }
 
@@ -168,16 +157,10 @@ valent_mock_media_player_play_pause (ValentMediaPlayer *player)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
 
-  if ((self->state & VALENT_MEDIA_STATE_PAUSED) != 0)
-    {
-      self->state &= ~VALENT_MEDIA_STATE_PAUSED;
-      self->state |= VALENT_MEDIA_STATE_PLAYING;
-    }
-  else if ((self->state & VALENT_MEDIA_STATE_PLAYING) != 0)
-    {
-      self->state &= ~VALENT_MEDIA_STATE_PLAYING;
-      self->state |= VALENT_MEDIA_STATE_PAUSED;
-    }
+  if (self->state == VALENT_MEDIA_STATE_PAUSED)
+    self->state = VALENT_MEDIA_STATE_PLAYING;
+  else if (self->state == VALENT_MEDIA_STATE_PLAYING)
+    self->state = VALENT_MEDIA_STATE_PAUSED;
 
   g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "PlayPause", NULL);
 }
@@ -236,7 +219,6 @@ valent_mock_media_player_class_init (ValentMockMediaPlayerClass *klass)
   player_class->get_shuffle = valent_mock_media_player_get_shuffle;
   player_class->set_shuffle = valent_mock_media_player_set_shuffle;
   player_class->get_state = valent_mock_media_player_get_state;
-  player_class->set_state = valent_mock_media_player_set_state;
   player_class->get_volume = valent_mock_media_player_get_volume;
   player_class->set_volume = valent_mock_media_player_set_volume;
 

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -109,15 +109,6 @@ valent_mock_media_player_next (ValentMediaPlayer *player)
 }
 
 static void
-valent_mock_media_player_open_uri (ValentMediaPlayer *player,
-                                   const char        *uri)
-{
-  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
-
-  g_signal_emit (G_OBJECT (self), signals [PLAYER_METHOD], 0, "OpenUri", g_variant_new_string (uri));
-}
-
-static void
 valent_mock_media_player_pause (ValentMediaPlayer *player)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
@@ -211,7 +202,6 @@ valent_mock_media_player_class_init (ValentMockMediaPlayerClass *klass)
   player_class->set_volume = valent_mock_media_player_set_volume;
 
   player_class->next = valent_mock_media_player_next;
-  player_class->open_uri = valent_mock_media_player_open_uri;
   player_class->pause = valent_mock_media_player_pause;
   player_class->play = valent_mock_media_player_play;
   player_class->play_pause = valent_mock_media_player_play_pause;

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -58,7 +58,6 @@ valent_mock_media_player_get_position (ValentMediaPlayer *player)
 
 static void
 valent_mock_media_player_set_position (ValentMediaPlayer *player,
-                                       const char        *track_id,
                                        gint64             position)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);

--- a/src/tests/fixtures/valent-mock-media-player.c
+++ b/src/tests/fixtures/valent-mock-media-player.c
@@ -18,6 +18,7 @@ struct _ValentMockMediaPlayer
   /* org.mpris.MediaPlayer2 */
   GVariant          *metadata;
   gint64             position;
+  ValentMediaRepeat  repeat;
   gboolean           shuffle;
   ValentMediaState   state;
   double             volume;
@@ -64,6 +65,23 @@ valent_mock_media_player_set_position (ValentMediaPlayer *player,
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
 
   self->position = position;
+}
+
+static ValentMediaRepeat
+valent_mock_media_player_get_repeat (ValentMediaPlayer *player)
+{
+  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
+
+  return self->repeat;
+}
+
+static void
+valent_mock_media_player_set_repeat (ValentMediaPlayer *player,
+                                     ValentMediaRepeat  repeat)
+{
+  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
+
+  self->repeat = repeat;
 }
 
 static gboolean
@@ -213,6 +231,8 @@ valent_mock_media_player_class_init (ValentMockMediaPlayerClass *klass)
   player_class->get_metadata = valent_mock_media_player_get_metadata;
   player_class->get_position = valent_mock_media_player_get_position;
   player_class->set_position = valent_mock_media_player_set_position;
+  player_class->get_repeat = valent_mock_media_player_get_repeat;
+  player_class->set_repeat = valent_mock_media_player_set_repeat;
   player_class->get_shuffle = valent_mock_media_player_get_shuffle;
   player_class->set_shuffle = valent_mock_media_player_set_shuffle;
   player_class->get_state = valent_mock_media_player_get_state;

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -265,7 +265,7 @@ test_media_component_self (MediaComponentFixture *fixture,
   g_assert_true (player == fixture->player);
   g_assert_true (player == g_ptr_array_index (players, 0));
 
-  valent_media_player_set_state (fixture->player, VALENT_MEDIA_STATE_PLAYING);
+  valent_media_player_play (fixture->player);
   valent_media_pause (fixture->media);
   g_assert_false (valent_media_player_is_playing (fixture->player));
   valent_media_unpause (fixture->media);

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -132,6 +132,7 @@ test_media_component_player (MediaComponentFixture *fixture,
   char *name;
   g_autoptr (GVariant) metadata = NULL;
   gint64 position;
+  gboolean shuffle;
 
   /* Add Player */
   g_signal_connect (fixture->adapter,
@@ -144,26 +145,28 @@ test_media_component_player (MediaComponentFixture *fixture,
 
   /* Test Player Properties */
   g_object_get (fixture->player,
-                "flags",           &flags,
-                "state",           &state,
-                "volume",          &volume,
-                "name",            &name,
-                "metadata",        &metadata,
-                "position",        &position,
+                "name",     &name,
+                "flags",    &flags,
+                "metadata", &metadata,
+                "position", &position,
+                "shuffle",  &shuffle,
+                "state",    &state,
+                "volume",   &volume,
                 NULL);
 
+  g_assert_cmpstr (name, ==, "Media Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
+  g_assert_cmpint (position, ==, 0);
+  g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 0.0);
-
-  g_assert_cmpstr (name, ==, "Media Player");
-  g_free (name);
-  g_assert_cmpint (position, ==, 0);
+  g_clear_pointer (&name, g_free);
+  g_clear_pointer (&metadata, g_variant_unref);
 
   g_object_set (fixture->player,
-                "state",       (VALENT_MEDIA_STATE_REPEAT_ALL |
-                                VALENT_MEDIA_STATE_SHUFFLE),
-                "volume",      1.0,
+                "shuffle", TRUE,
+                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "volume",  1.0,
                 NULL);
 
   /* Test Player Methods */

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -200,7 +200,7 @@ test_media_component_player (MediaComponentFixture *fixture,
   g_assert_cmpstr (fixture->data, ==, "Seek");
   g_clear_pointer (&fixture->data, g_free);
 
-  valent_media_player_set_position (fixture->player, "track-id", 5);
+  valent_media_player_set_position (fixture->player, 5);
   g_assert_cmpint (valent_media_player_get_position (fixture->player), ==, 5);
 
   /* Test signal propagation */

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -127,6 +127,7 @@ test_media_component_player (MediaComponentFixture *fixture,
 {
   /* org.mpris.MediaPlayer2.Player */
   ValentMediaActions flags;
+  ValentMediaState repeat;
   ValentMediaState state;
   double volume;
   char *name;
@@ -149,6 +150,7 @@ test_media_component_player (MediaComponentFixture *fixture,
                 "flags",    &flags,
                 "metadata", &metadata,
                 "position", &position,
+                "repeat",   &repeat,
                 "shuffle",  &shuffle,
                 "state",    &state,
                 "volume",   &volume,
@@ -157,6 +159,7 @@ test_media_component_player (MediaComponentFixture *fixture,
   g_assert_cmpstr (name, ==, "Media Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
   g_assert_cmpint (position, ==, 0);
+  g_assert_cmpuint (repeat, ==, VALENT_MEDIA_REPEAT_NONE);
   g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 0.0);
@@ -165,7 +168,7 @@ test_media_component_player (MediaComponentFixture *fixture,
 
   g_object_set (fixture->player,
                 "shuffle", TRUE,
-                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "repeat",  VALENT_MEDIA_REPEAT_ALL,
                 "volume",  1.0,
                 NULL);
 

--- a/src/tests/libvalent/media/test-media-component.c
+++ b/src/tests/libvalent/media/test-media-component.c
@@ -196,10 +196,6 @@ test_media_component_player (MediaComponentFixture *fixture,
   g_assert_cmpstr (fixture->data, ==, "Previous");
   g_clear_pointer (&fixture->data, g_free);
 
-  valent_media_player_open_uri (fixture->player, "https://andyholmes.ca");
-  g_assert_cmpstr (fixture->data, ==, "OpenUri");
-  g_clear_pointer (&fixture->data, g_free);
-
   valent_media_player_seek (fixture->player, 1000);
   g_assert_cmpstr (fixture->data, ==, "Seek");
   g_clear_pointer (&fixture->data, g_free);

--- a/src/tests/plugins/mpris/test-mpris-common.h
+++ b/src/tests/plugins/mpris/test-mpris-common.h
@@ -114,6 +114,9 @@ test_mpris_remote_set_property (ValentMprisRemote *remote,
                                 GVariant          *value,
                                 gpointer           user_data)
 {
+  if (g_strcmp0 (name, "LoopStatus") == 0)
+    valent_mpris_remote_update_repeat (remote, g_variant_get_string (value, NULL));
+
   if (g_strcmp0 (name, "Shuffle") == 0)
     valent_mpris_remote_update_shuffle (remote, g_variant_get_boolean (value));
 

--- a/src/tests/plugins/mpris/test-mpris-common.h
+++ b/src/tests/plugins/mpris/test-mpris-common.h
@@ -32,12 +32,14 @@ test_mpris_remote_method (ValentMprisRemote *remote,
                 VALENT_MEDIA_ACTION_PAUSE |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Playing",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Playing",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake track next */
@@ -53,29 +55,32 @@ test_mpris_remote_method (ValentMprisRemote *remote,
                 VALENT_MEDIA_ACTION_PAUSE |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Playing",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Playing",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake playback pause */
   else if (g_strcmp0 (method, "Pause") == 0)
     {
-
       flags |= (VALENT_MEDIA_ACTION_NEXT |
                 VALENT_MEDIA_ACTION_PREVIOUS |
                 VALENT_MEDIA_ACTION_PLAY |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         NULL,
-                                         "Paused",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       NULL,
+                                       "Paused",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake seek */
@@ -92,12 +97,14 @@ test_mpris_remote_method (ValentMprisRemote *remote,
     {
       g_variant_dict_init (&dict, NULL);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Stopped",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Stopped",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 }
 
@@ -107,6 +114,9 @@ test_mpris_remote_set_property (ValentMprisRemote *remote,
                                 GVariant          *value,
                                 gpointer           user_data)
 {
+  if (g_strcmp0 (name, "Shuffle") == 0)
+    valent_mpris_remote_update_shuffle (remote, g_variant_get_boolean (value));
+
   if (g_strcmp0 (name, "Volume") == 0)
     valent_mpris_remote_update_volume (remote, g_variant_get_double (value));
 }

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -208,7 +208,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
   g_assert_cmpstr (fixture->data, ==, "Seek");
   g_clear_pointer (&fixture->data, g_free);
 
-  valent_media_player_set_position (fixture->player, "/dbus/path", 5);
+  valent_media_player_set_position (fixture->player, 5);
   //g_assert_cmpint (valent_media_player_get_position (fixture->player), ==, 5);
 
   /* Remove Player */

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -127,6 +127,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
   char *name;
   g_autoptr (GVariant) metadata = NULL;
   gint64 position;
+  gboolean shuffle;
 
   /* Watch for the player */
   g_signal_connect (fixture->media,
@@ -145,26 +146,28 @@ test_mpris_component_player (MprisComponentFixture *fixture,
 
   /* Test Player Properties */
   g_object_get (fixture->player,
-                "flags",    &flags,
-                "state",    &state,
-                "volume",   &volume,
                 "name",     &name,
+                "flags",    &flags,
                 "metadata", &metadata,
                 "position", &position,
+                "shuffle",  &shuffle,
+                "state",    &state,
+                "volume",   &volume,
                 NULL);
 
+  g_assert_cmpstr (name, ==, "Test Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
+  g_assert_cmpint (position, ==, 0);
+  g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 1.0);
-
-  g_assert_cmpstr (name, ==, "Test Player");
-  g_free (name);
-  g_assert_cmpint (position, ==, 0);
+  g_clear_pointer (&name, g_free);
+  g_clear_pointer (&metadata, g_variant_unref);
 
   g_object_set (fixture->player,
-                "state",  (VALENT_MEDIA_STATE_REPEAT_ALL |
-                           VALENT_MEDIA_STATE_SHUFFLE),
-                "volume", 1.0,
+                "shuffle", TRUE,
+                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "volume",  1.0,
                 NULL);
 
   /* Test Player Methods */

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -203,11 +203,6 @@ test_mpris_component_player (MprisComponentFixture *fixture,
   g_assert_cmpstr (fixture->data, ==, "Previous");
   g_clear_pointer (&fixture->data, g_free);
 
-  valent_media_player_open_uri (fixture->player, "https://andyholmes.ca");
-  g_main_loop_run (fixture->loop);
-  g_assert_cmpstr (fixture->data, ==, "OpenUri");
-  g_clear_pointer (&fixture->data, g_free);
-
   valent_media_player_seek (fixture->player, 1000);
   g_main_loop_run (fixture->loop);
   g_assert_cmpstr (fixture->data, ==, "Seek");

--- a/src/tests/plugins/mpris/test-mpris-component.c
+++ b/src/tests/plugins/mpris/test-mpris-component.c
@@ -122,6 +122,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
 {
   g_autoptr (ValentMprisRemote) remote = NULL;
   ValentMediaActions flags;
+  ValentMediaRepeat repeat;
   ValentMediaState state;
   double volume;
   char *name;
@@ -150,6 +151,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
                 "flags",    &flags,
                 "metadata", &metadata,
                 "position", &position,
+                "repeat",   &repeat,
                 "shuffle",  &shuffle,
                 "state",    &state,
                 "volume",   &volume,
@@ -158,6 +160,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
   g_assert_cmpstr (name, ==, "Test Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
   g_assert_cmpint (position, ==, 0);
+  g_assert_cmpuint (repeat, ==, VALENT_MEDIA_REPEAT_NONE);
   g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 1.0);
@@ -166,7 +169,7 @@ test_mpris_component_player (MprisComponentFixture *fixture,
 
   g_object_set (fixture->player,
                 "shuffle", TRUE,
-                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "repeat",  VALENT_MEDIA_REPEAT_ALL,
                 "volume",  1.0,
                 NULL);
 

--- a/src/tests/plugins/mpris/test-mpris-plugin.c
+++ b/src/tests/plugins/mpris/test-mpris-plugin.c
@@ -580,8 +580,7 @@ test_mpris_plugin_handle_player (ValentTestFixture *fixture,
   v_assert_packet_cmpint (packet, "Seek", ==, 1);
   json_node_unref (packet);
 
-  valent_media_player_set_position (VALENT_MEDIA_PLAYER (proxy),
-                                    "/dbus/path/ignored", 1000);
+  valent_media_player_set_position (VALENT_MEDIA_PLAYER (proxy), 1000);
   packet = valent_test_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.mpris.request");
   v_assert_packet_cmpint (packet, "SetPosition", ==, 1);

--- a/src/tests/plugins/mpris/test-mpris-plugin.c
+++ b/src/tests/plugins/mpris/test-mpris-plugin.c
@@ -55,12 +55,14 @@ on_remote_method (ValentMprisRemote *remote,
                 VALENT_MEDIA_ACTION_PAUSE |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Playing",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Playing",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake track next */
@@ -77,12 +79,14 @@ on_remote_method (ValentMprisRemote *remote,
                 VALENT_MEDIA_ACTION_PAUSE |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Playing",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Playing",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake playback pause */
@@ -94,12 +98,14 @@ on_remote_method (ValentMprisRemote *remote,
                 VALENT_MEDIA_ACTION_PLAY |
                 VALENT_MEDIA_ACTION_SEEK);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         NULL,
-                                         "Paused",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       NULL,
+                                       "Paused",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 
   /* Fake seek */
@@ -116,12 +122,14 @@ on_remote_method (ValentMprisRemote *remote,
     {
       g_variant_dict_init (&dict, NULL);
 
-      valent_mpris_remote_update_player (remote,
-                                         flags,
-                                         g_variant_dict_end (&dict),
-                                         "Stopped",
-                                         0,
-                                         1.0);
+      valent_mpris_remote_update_full (remote,
+                                       flags,
+                                       g_variant_dict_end (&dict),
+                                       "Stopped",
+                                       0,
+                                       "None",
+                                       FALSE,
+                                       1.0);
     }
 }
 

--- a/src/tests/plugins/mpris/test-mpris-remote.c
+++ b/src/tests/plugins/mpris/test-mpris-remote.c
@@ -280,6 +280,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
 
   /* org.mpris.MediaPlayer2.Player */
   ValentMediaActions flags;
+  ValentMediaState repeat;
   ValentMediaState state;
   double volume;
   char *name;
@@ -324,6 +325,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
                 "flags",    &flags,
                 "metadata", &metadata,
                 "position", &position,
+                "repeat",  &repeat,
                 "shuffle",  &shuffle,
                 "state",    &state,
                 "volume",   &volume,
@@ -332,6 +334,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
   g_assert_cmpstr (name, ==, "Test Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
   g_assert_cmpint (position, ==, 0);
+  g_assert_cmpuint (repeat, ==, VALENT_MEDIA_REPEAT_NONE);
   g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 1.0);
@@ -340,7 +343,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
 
   g_object_set (remote,
                 "shuffle", TRUE,
-                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "repeat",  VALENT_MEDIA_REPEAT_ALL,
                 "volume",  1.0,
                 NULL);
 

--- a/src/tests/plugins/mpris/test-mpris-remote.c
+++ b/src/tests/plugins/mpris/test-mpris-remote.c
@@ -366,10 +366,6 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
   g_assert_true (fixture->state);
   fixture->state = FALSE;
 
-  valent_media_player_open_uri (player, "https://andyholmes.ca");
-  g_assert_true (fixture->state);
-  fixture->state = FALSE;
-
   valent_media_player_seek (player, 1000);
   g_assert_true (fixture->state);
   fixture->state = FALSE;

--- a/src/tests/plugins/mpris/test-mpris-remote.c
+++ b/src/tests/plugins/mpris/test-mpris-remote.c
@@ -370,7 +370,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
   g_assert_true (fixture->state);
   fixture->state = FALSE;
 
-  //valent_media_player_set_position (player, "/dbus/path", 5);
+  //valent_media_player_set_position (player, 5);
   //g_assert_cmpint (valent_media_player_get_position (player), ==, 5);
 
   /* Remove Player */

--- a/src/tests/plugins/mpris/test-mpris-remote.c
+++ b/src/tests/plugins/mpris/test-mpris-remote.c
@@ -285,6 +285,7 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
   char *name;
   g_autoptr (GVariant) metadata = NULL;
   gint64 position;
+  gboolean shuffle;
 
   /* Create a new remote */
   remote = valent_mpris_remote_new ();
@@ -319,26 +320,28 @@ test_mpris_remote_player (MprisRemoteFixture *fixture,
 
   /* Test Player Properties */
   g_object_get (remote,
-                "flags",    &flags,
-                "state",    &state,
-                "volume",   &volume,
                 "name",     &name,
+                "flags",    &flags,
                 "metadata", &metadata,
                 "position", &position,
+                "shuffle",  &shuffle,
+                "state",    &state,
+                "volume",   &volume,
                 NULL);
 
+  g_assert_cmpstr (name, ==, "Test Player");
   g_assert_cmpuint (flags, ==, VALENT_MEDIA_ACTION_NONE);
+  g_assert_cmpint (position, ==, 0);
+  g_assert_false (shuffle);
   g_assert_cmpuint (state, ==, VALENT_MEDIA_STATE_STOPPED);
   g_assert_cmpfloat (volume, ==, 1.0);
-
-  g_assert_cmpstr (name, ==, "Test Player");
-  g_free (name);
-  g_assert_cmpint (position, ==, 0);
+  g_clear_pointer (&name, g_free);
+  g_clear_pointer (&metadata, g_variant_unref);
 
   g_object_set (remote,
-                "state",  (VALENT_MEDIA_STATE_REPEAT_ALL |
-                           VALENT_MEDIA_STATE_SHUFFLE),
-                "volume", 1.0,
+                "shuffle", TRUE,
+                "state",   VALENT_MEDIA_STATE_REPEAT_ALL,
+                "volume",  1.0,
                 NULL);
 
   /* Test Player Methods */


### PR DESCRIPTION
There are some oddities in the API for `ValentMediaPlayer`, some
specific to MPRIS and others just clever mistakes.

Cleanup the API in general and break out the properties so cleverly
amalgamated in `ValentMediaPlayer::state`.