### PR TITLE
test: enable tests for bluez plugin

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -18,6 +18,7 @@
         "--socket=session-bus",
         "--socket=ssh-auth",
         "--socket=wayland",
+        "--system-talk-name=org.bluez",
         "--system-talk-name=org.freedesktop.Avahi",
         "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=org.freedesktop.login1",

--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -208,6 +208,7 @@
             "config-opts" : [
                 "--prefix=/app",
                 "--buildtype=debugoptimized",
+                "-Dplugin_bluez=true",
                 "-Dprofile=devel",
                 "-Dtests=true",
                 "-Dtracing=true"

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -17,6 +17,7 @@
         "--socket=session-bus",
         "--socket=ssh-auth",
         "--socket=wayland",
+        "--system-talk-name=org.bluez",
         "--system-talk-name=org.freedesktop.Avahi",
         "--system-talk-name=org.freedesktop.hostname1",
         "--system-talk-name=org.freedesktop.login1",

--- a/tests/extra/tsan.supp
+++ b/tests/extra/tsan.supp
@@ -9,6 +9,10 @@
 #mutex:valent_device_get_type_once
 mutex:valent_extension_get_type_once
 
+# src/plugins/bluez/valent-mux-io-stream.c
+race:valent_mux_io_stream_constructed
+race:valent_mux_io_stream_finalize
+
 # src/plugins/sms/valent-sms-store.c
 race:valent_sms_store_thread
 


### PR DESCRIPTION
Bluetooth has no official support in KDE Connect.

If you are interested in Bluetooth support for Valent, please to contribute to the development of this feature by engaging with the upstream community and [KDE Connect Team](https://community.kde.org/KDEConnect#Development).