### PR TITLE
style: various cleanups and refactoring

### DIFF
--- a/src/libvalent/core/valent-channel.c
+++ b/src/libvalent/core/valent-channel.c
@@ -105,10 +105,10 @@ valent_channel_real_download (ValentChannel  *channel,
 }
 
 static void
-valent_channel_download_task (GTask        *task,
-                              gpointer      source_object,
-                              gpointer      task_data,
-                              GCancellable *cancellable)
+valent_channel_real_download_task (GTask        *task,
+                                   gpointer      source_object,
+                                   gpointer      task_data,
+                                   GCancellable *cancellable)
 {
   ValentChannel *self = source_object;
   JsonNode *packet = task_data;
@@ -147,7 +147,7 @@ valent_channel_real_download_async (ValentChannel       *channel,
   g_task_set_task_data (task,
                         json_node_ref (packet),
                         (GDestroyNotify)json_node_unref);
-  g_task_run_in_thread (task, valent_channel_download_task);
+  g_task_run_in_thread (task, valent_channel_real_download_task);
 }
 
 static GIOStream *

--- a/src/libvalent/core/valent-device-manager.h
+++ b/src/libvalent/core/valent-device-manager.h
@@ -40,8 +40,7 @@ VALENT_AVAILABLE_IN_1_0
 void                  valent_device_manager_set_name         (ValentDeviceManager  *manager,
                                                               const char           *name);
 VALENT_AVAILABLE_IN_1_0
-void                  valent_device_manager_identify         (ValentDeviceManager  *manager,
-                                                              const char           *uri);
+void                  valent_device_manager_refresh          (ValentDeviceManager  *manager);
 VALENT_AVAILABLE_IN_1_0
 void                  valent_device_manager_start            (ValentDeviceManager  *manager);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/core/valent-device.c
+++ b/src/libvalent/core/valent-device.c
@@ -1703,7 +1703,7 @@ valent_device_get_plugins (ValentDevice *device)
  *
  * Get the state of the device.
  *
- * Returns: #ValentDeviceStateFlags describing the state of the device
+ * Returns: #ValentDeviceState flags describing the state of the device
  *
  * Since: 1.0
  */
@@ -1792,8 +1792,6 @@ valent_device_handle_packet (ValentDevice *device,
  *
  * Check each available plugin and load or unload them if the required
  * capabilities have changed.
- *
- * Since: 1.0
  */
 static void
 valent_device_reload_plugins (ValentDevice *device)
@@ -1820,8 +1818,6 @@ valent_device_reload_plugins (ValentDevice *device)
  * Update all plugins.
  *
  * Call [method@Valent.DevicePlugin.update_state] on each enabled plugin.
- *
- * Since: 1.0
  */
 static void
 valent_device_update_plugins (ValentDevice *device)
@@ -1854,8 +1850,6 @@ valent_device_update_plugins (ValentDevice *device)
  * Check if @device supports the plugin described by @info.
  *
  * Returns: %TRUE if supported, or %FALSE if not
- *
- * Since: 1.0
  */
 static gboolean
 valent_device_supports_plugin (ValentDevice   *device,

--- a/src/libvalent/ui/valent-application.c
+++ b/src/libvalent/ui/valent-application.c
@@ -292,7 +292,7 @@ refresh_action (GSimpleAction *action,
 
   g_assert (VALENT_IS_APPLICATION (self));
 
-  valent_device_manager_identify (self->manager, NULL);
+  valent_device_manager_refresh (self->manager);
 }
 
 static void

--- a/src/libvalent/ui/valent-window.c
+++ b/src/libvalent/ui/valent-window.c
@@ -338,7 +338,7 @@ refresh_action (GtkWidget  *widget,
   if (self->refresh_id > 0)
     return;
 
-  valent_device_manager_identify (self->manager, NULL);
+  valent_device_manager_refresh (self->manager);
   self->refresh_id = g_timeout_add_seconds (5, refresh_cb, self);
 }
 

--- a/src/plugins/lan/valent-lan-utils.h
+++ b/src/plugins/lan/valent-lan-utils.h
@@ -53,24 +53,24 @@ G_BEGIN_DECLS
 #define VALENT_LAN_TRANSFER_PORT_MAX (1764)
 
 
-GIOStream * valent_lan_encrypt_new_client (GSocketConnection  *connection,
-                                           GTlsCertificate    *certificate,
-                                           GCancellable       *cancellable,
-                                           GError            **error);
-GIOStream * valent_lan_encrypt_client     (GSocketConnection  *connection,
-                                           GTlsCertificate    *certificate,
-                                           GTlsCertificate    *peer_cert,
-                                           GCancellable       *cancellable,
-                                           GError            **error);
-GIOStream * valent_lan_encrypt_new_server (GSocketConnection  *connection,
-                                           GTlsCertificate    *certificate,
-                                           GCancellable       *cancellable,
-                                           GError            **error);
-GIOStream * valent_lan_encrypt_server     (GSocketConnection  *connection,
-                                           GTlsCertificate    *certificate,
-                                           GTlsCertificate    *peer_cert,
-                                           GCancellable       *cancellable,
-                                           GError            **error);
+GIOStream * valent_lan_encrypt_client            (GSocketConnection  *connection,
+                                                  GTlsCertificate    *certificate,
+                                                  GTlsCertificate    *peer_cert,
+                                                  GCancellable       *cancellable,
+                                                  GError            **error);
+GIOStream * valent_lan_encrypt_client_connection (GSocketConnection  *connection,
+                                                  GTlsCertificate    *certificate,
+                                                  GCancellable       *cancellable,
+                                                  GError            **error);
+GIOStream * valent_lan_encrypt_server            (GSocketConnection  *connection,
+                                                  GTlsCertificate    *certificate,
+                                                  GTlsCertificate    *peer_cert,
+                                                  GCancellable       *cancellable,
+                                                  GError            **error);
+GIOStream * valent_lan_encrypt_server_connection (GSocketConnection  *connection,
+                                                  GTlsCertificate    *certificate,
+                                                  GCancellable       *cancellable,
+                                                  GError            **error);
 
 G_END_DECLS
 

--- a/src/plugins/share/valent-share-target-chooser.c
+++ b/src/plugins/share/valent-share-target-chooser.c
@@ -152,7 +152,7 @@ refresh_cb (gpointer data)
 
   g_assert (VALENT_IS_SHARE_TARGET_CHOOSER (self));
 
-  valent_device_manager_identify (self->manager, NULL);
+  valent_device_manager_refresh (self->manager);
 
   return TRUE;
 }
@@ -174,7 +174,7 @@ valent_share_target_chooser_constructed (GObject *object)
                            NULL, NULL);
 
   /* Broadcast every 5 seconds to re-connect devices that may have gone idle */
-  valent_device_manager_identify (self->manager, NULL);
+  valent_device_manager_refresh (self->manager);
   self->refresh_id = g_timeout_add_seconds (5, refresh_cb, self);
 
   G_OBJECT_CLASS (valent_share_target_chooser_parent_class)->constructed (object);

--- a/tests/libvalent/clipboard/test-clipboard-component.c
+++ b/tests/libvalent/clipboard/test-clipboard-component.c
@@ -344,13 +344,13 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/clipboard/adapter",
+  g_test_add ("/libvalent/clipboard/adapter",
               ClipboardComponentFixture, NULL,
               clipboard_component_fixture_set_up,
               test_clipboard_component_adapter,
               clipboard_component_fixture_tear_down);
 
-  g_test_add ("/components/clipboard/self",
+  g_test_add ("/libvalent/clipboard/self",
               ClipboardComponentFixture, NULL,
               clipboard_component_fixture_set_up,
               test_clipboard_component_self,

--- a/tests/libvalent/contacts/test-contacts-component.c
+++ b/tests/libvalent/contacts/test-contacts-component.c
@@ -385,19 +385,19 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/contacts/adapter",
+  g_test_add ("/libvalent/contacts/adapter",
               ContactsComponentFixture, NULL,
               contacts_component_fixture_set_up,
               test_contacts_component_adapter,
               contacts_component_fixture_tear_down);
 
-  g_test_add ("/components/contacts/store",
+  g_test_add ("/libvalent/contacts/store",
               ContactsComponentFixture, NULL,
               contacts_component_fixture_set_up,
               test_contacts_component_store,
               contacts_component_fixture_tear_down);
 
-  g_test_add ("/components/contacts/self",
+  g_test_add ("/libvalent/contacts/self",
               ContactsComponentFixture, NULL,
               contacts_component_fixture_set_up,
               test_contacts_component_self,

--- a/tests/libvalent/core/test-application-plugin.c
+++ b/tests/libvalent/core/test-application-plugin.c
@@ -77,7 +77,7 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/core/application-plugin/basic",
+  g_test_add ("/libvalent/core/application-plugin/basic",
               ApplicationPluginFixture, NULL,
               application_fixture_set_up,
               test_application_plugin_basic,

--- a/tests/libvalent/core/test-channel-service.c
+++ b/tests/libvalent/core/test-channel-service.c
@@ -446,13 +446,13 @@ main (int   argc,
   g_test_add_func ("/core/channel-service/basic",
                    test_channel_service_basic);
 
-  g_test_add ("/core/channel-service/identify",
+  g_test_add ("/libvalent/core/channel-service/identify",
               ChannelServiceFixture, NULL,
               channel_service_fixture_set_up,
               test_channel_service_identify,
               channel_service_fixture_tear_down);
 
-  g_test_add ("/core/channel-service/channel",
+  g_test_add ("/libvalent/core/channel-service/channel",
               ChannelServiceFixture, NULL,
               channel_service_fixture_set_up,
               test_channel_service_channel,

--- a/tests/libvalent/core/test-data.c
+++ b/tests/libvalent/core/test-data.c
@@ -93,13 +93,13 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/core/data/basic",
+  g_test_add ("/libvalent/core/data/basic",
               DataFixture, NULL,
               data_fixture_set_up,
               test_data_basic,
               data_fixture_tear_down);
 
-  g_test_add ("/core/data/directories",
+  g_test_add ("/libvalent/core/data/directories",
               DataFixture, NULL,
               data_fixture_set_up,
               test_data_directories,

--- a/tests/libvalent/core/test-device-manager.c
+++ b/tests/libvalent/core/test-device-manager.c
@@ -155,7 +155,7 @@ test_manager_management (ManagerFixture *fixture,
   g_assert_cmpuint (n_devices, ==, 0);
 
   /* Adds devices from channels */
-  valent_device_manager_identify (fixture->manager, NULL);
+  valent_device_manager_refresh (fixture->manager);
   g_assert_true (VALENT_IS_DEVICE (fixture->device));
 
   n_devices = g_list_model_get_n_items (G_LIST_MODEL (fixture->manager));
@@ -163,29 +163,6 @@ test_manager_management (ManagerFixture *fixture,
 
   /* Retains paired devices that disconnect */
   g_object_notify (G_OBJECT (fixture->device), "state");
-  g_assert_true (VALENT_IS_DEVICE (fixture->device));
-}
-
-static void
-test_manager_identify_uri (ManagerFixture *fixture,
-                           gconstpointer   user_data)
-{
-  g_signal_connect (fixture->manager,
-                    "items-changed",
-                    G_CALLBACK (on_devices_changed),
-                    fixture);
-
-  /* Wait for the manager to start */
-  valent_device_manager_start (fixture->manager);
-
-  while (fixture->device == NULL)
-    g_main_context_iteration (NULL, FALSE);
-
-  /* Drop the cached device */
-  g_object_notify (G_OBJECT (fixture->device), "state");
-
-  /* Forwards URIs to the correct service */
-  valent_device_manager_identify (fixture->manager, "mock://127.0.0.1");
   g_assert_true (VALENT_IS_DEVICE (fixture->device));
 }
 
@@ -384,12 +361,6 @@ main (int   argc,
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_management,
-              manager_fixture_tear_down);
-
-  g_test_add ("/libvalent/core/device-manager/identify-uri",
-              ManagerFixture, NULL,
-              manager_fixture_set_up,
-              test_manager_identify_uri,
               manager_fixture_tear_down);
 
   g_test_add ("/libvalent/core/device-manager/dbus",

--- a/tests/libvalent/core/test-device-manager.c
+++ b/tests/libvalent/core/test-device-manager.c
@@ -374,31 +374,31 @@ main (int   argc,
 
   g_test_add_func ("/core/manager/new", test_manager_new);
 
-  g_test_add ("/core/manager/basic",
+  g_test_add ("/libvalent/core/device-manager/basic",
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_basic,
               manager_fixture_tear_down);
 
-  g_test_add ("/core/manager/management",
+  g_test_add ("/libvalent/core/device-manager/management",
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_management,
               manager_fixture_tear_down);
 
-  g_test_add ("/core/manager/identify-uri",
+  g_test_add ("/libvalent/core/device-manager/identify-uri",
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_identify_uri,
               manager_fixture_tear_down);
 
-  g_test_add ("/core/manager/dbus",
+  g_test_add ("/libvalent/core/device-manager/dbus",
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_dbus,
               manager_fixture_tear_down);
 
-  g_test_add ("/core/manager/dispose",
+  g_test_add ("/libvalent/core/device-manager/dispose",
               ManagerFixture, NULL,
               manager_fixture_set_up,
               test_manager_dispose,

--- a/tests/libvalent/core/test-device-plugin.c
+++ b/tests/libvalent/core/test-device-plugin.c
@@ -227,13 +227,13 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/core/device-plugin/basic",
+  g_test_add ("/libvalent/core/device-plugin/basic",
               DevicePluginFixture, NULL,
               device_fixture_set_up,
               test_device_plugin_basic,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device-plugin/actions",
+  g_test_add ("/libvalent/core/device-plugin/actions",
               DevicePluginFixture, NULL,
               device_fixture_set_up,
               test_device_plugin_actions,

--- a/tests/libvalent/core/test-device.c
+++ b/tests/libvalent/core/test-device.c
@@ -716,61 +716,61 @@ main (int   argc,
   g_test_add_func ("/core/device/new",
                    test_device_new);
 
-  g_test_add ("/core/device/basic",
+  g_test_add ("/libvalent/core/device/basic",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_device_basic,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/connecting",
+  g_test_add ("/libvalent/core/device/connecting",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_device_connecting,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/pairing",
+  g_test_add ("/libvalent/core/device/pairing",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_device_pairing,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/actions",
+  g_test_add ("/libvalent/core/device/actions",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_device_actions,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/plugins",
+  g_test_add ("/libvalent/core/device/plugins",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_device_plugins,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/handle-packet",
+  g_test_add ("/libvalent/core/device/handle-packet",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_handle_packet,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/queue-packet-available",
+  g_test_add ("/libvalent/core/device/queue-packet-available",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_queue_packet_available,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/queue-packet-disconnected",
+  g_test_add ("/libvalent/core/device/queue-packet-disconnected",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_queue_packet_disconnected,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/queue-packet-unpaired",
+  g_test_add ("/libvalent/core/device/queue-packet-unpaired",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_queue_packet_unpaired,
               device_fixture_tear_down);
 
-  g_test_add ("/core/device/send-packet",
+  g_test_add ("/libvalent/core/device/send-packet",
               DeviceFixture, NULL,
               device_fixture_set_up,
               test_send_packet,

--- a/tests/libvalent/core/test-packet.c
+++ b/tests/libvalent/core/test-packet.c
@@ -314,19 +314,19 @@ main (int   argc,
   g_test_add_func ("/core/packet/get",
                    test_packet_get);
 
-  g_test_add ("/core/packet/invalid",
+  g_test_add ("/libvalent/core/packet/invalid",
               PacketFixture, NULL,
               packet_fixture_set_up,
               test_packet_invalid,
               packet_fixture_tear_down);
 
-  g_test_add ("/core/packet/serializing",
+  g_test_add ("/libvalent/core/packet/serializing",
               PacketFixture, NULL,
               packet_fixture_set_up,
               test_packet_serializing,
               packet_fixture_tear_down);
 
-  g_test_add ("/core/packet/streaming",
+  g_test_add ("/libvalent/core/packet/streaming",
               PacketFixture, NULL,
               packet_fixture_set_up,
               test_packet_streaming,

--- a/tests/libvalent/input/test-input-component.c
+++ b/tests/libvalent/input/test-input-component.c
@@ -97,13 +97,13 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/input/adapter",
+  g_test_add ("/libvalent/input/adapter",
               InputComponentFixture, NULL,
               input_component_fixture_set_up,
               test_input_component_adapter,
               input_component_fixture_tear_down);
 
-  g_test_add ("/components/input/self",
+  g_test_add ("/libvalent/input/self",
               InputComponentFixture, NULL,
               input_component_fixture_set_up,
               test_input_component_self,

--- a/tests/libvalent/media/test-media-component.c
+++ b/tests/libvalent/media/test-media-component.c
@@ -297,19 +297,19 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/media/adapter",
+  g_test_add ("/libvalent/media/adapter",
               MediaComponentFixture, NULL,
               media_component_fixture_set_up,
               test_media_component_adapter,
               media_component_fixture_tear_down);
 
-  g_test_add ("/components/media/player",
+  g_test_add ("/libvalent/media/player",
               MediaComponentFixture, NULL,
               media_component_fixture_set_up,
               test_media_component_player,
               media_component_fixture_tear_down);
 
-  g_test_add ("/components/media/self",
+  g_test_add ("/libvalent/media/self",
               MediaComponentFixture, NULL,
               media_component_fixture_set_up,
               test_media_component_self,

--- a/tests/libvalent/mixer/test-mixer-component.c
+++ b/tests/libvalent/mixer/test-mixer-component.c
@@ -406,19 +406,19 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/mixer/adapter",
+  g_test_add ("/libvalent/mixer/adapter",
               MixerComponentFixture, NULL,
               mixer_component_fixture_set_up,
               test_mixer_component_adapter,
               mixer_component_fixture_tear_down);
 
-  g_test_add ("/components/mixer/stream",
+  g_test_add ("/libvalent/mixer/stream",
               MixerComponentFixture, NULL,
               mixer_component_fixture_set_up,
               test_mixer_component_stream,
               mixer_component_fixture_tear_down);
 
-  g_test_add ("/components/mixer/self",
+  g_test_add ("/libvalent/mixer/self",
               MixerComponentFixture, NULL,
               mixer_component_fixture_set_up,
               test_mixer_component_self,

--- a/tests/libvalent/notifications/test-notifications-component.c
+++ b/tests/libvalent/notifications/test-notifications-component.c
@@ -198,19 +198,19 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/notifications/adapter",
+  g_test_add ("/libvalent/notifications/adapter",
               NotificationsComponentFixture, NULL,
               notifications_component_fixture_set_up,
               test_notifications_component_adapter,
               notifications_component_fixture_tear_down);
 
-  g_test_add ("/components/notifications/notification",
+  g_test_add ("/libvalent/notifications/notification",
               NotificationsComponentFixture, NULL,
               notifications_component_fixture_set_up,
               test_notifications_component_notification,
               notifications_component_fixture_tear_down);
 
-  g_test_add ("/components/notifications/self",
+  g_test_add ("/libvalent/notifications/self",
               NotificationsComponentFixture, NULL,
               notifications_component_fixture_set_up,
               test_notifications_component_self,

--- a/tests/libvalent/session/test-session-component.c
+++ b/tests/libvalent/session/test-session-component.c
@@ -112,13 +112,13 @@ main (int   argc,
 {
   valent_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/components/session/adapter",
+  g_test_add ("/libvalent/session/adapter",
               SessionComponentFixture, NULL,
               session_component_fixture_set_up,
               test_session_component_adapter,
               session_component_fixture_tear_down);
 
-  g_test_add ("/components/session/self",
+  g_test_add ("/libvalent/session/self",
               SessionComponentFixture, NULL,
               session_component_fixture_set_up,
               test_session_component_self,

--- a/tests/plugins/bluez/test-bluez-plugin.c
+++ b/tests/plugins/bluez/test-bluez-plugin.c
@@ -380,14 +380,14 @@ main (int   argc,
   g_type_ensure (VALENT_TYPE_BLUEZ_CHANNEL);
   g_type_ensure (VALENT_TYPE_BLUEZ_CHANNEL_SERVICE);
 
-  g_test_add ("/plugin/bluez/new-connection",
+  g_test_add ("/plugins/bluez/new-connection",
               BluezBackendFixture, NULL,
               bluez_service_fixture_set_up,
               test_bluez_service_new_connection,
               bluez_service_fixture_tear_down);
 
 #if 0
-  g_test_add ("/backends/bluez-backend/channel",
+  g_test_add ("/plugins/bluez/channel",
               BluezBackendFixture, NULL,
               bluez_service_fixture_set_up,
               test_bluez_service_channel,

--- a/tests/plugins/lan/test-lan-plugin.c
+++ b/tests/plugins/lan/test-lan-plugin.c
@@ -156,10 +156,10 @@ g_socket_listener_accept_cb (GSocketListener   *listener,
   valent_packet_get_string (peer_identity, "deviceId", &device_id);
   g_assert_true (device_id != NULL && *device_id != '\0');
 
-  tls_stream = valent_lan_encrypt_new_client (connection,
-                                              fixture->certificate,
-                                              NULL,
-                                              &error);
+  tls_stream = valent_lan_encrypt_client_connection (connection,
+                                                     fixture->certificate,
+                                                     NULL,
+                                                     &error);
   g_assert_no_error (error);
   g_assert_true (G_IS_TLS_CONNECTION (tls_stream));
 
@@ -469,10 +469,10 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
         await_timeout (1100);
     }
 
-  tls_stream = valent_lan_encrypt_new_server (connection,
-                                              fixture->certificate,
-                                              NULL,
-                                              &error);
+  tls_stream = valent_lan_encrypt_server_connection (connection,
+                                                     fixture->certificate,
+                                                     NULL,
+                                                     &error);
   g_assert_no_error (error);
   g_assert_true (G_IS_TLS_CONNECTION (tls_stream));
 
@@ -529,10 +529,10 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
        *       identity, but the certificate itself is different
        */
       g_object_get (fixture->service, "certificate", &bad_certificate, NULL);
-      bad_stream = valent_lan_encrypt_new_server (bad_connection,
-                                                  bad_certificate,
-                                                  NULL,
-                                                  &error);
+      bad_stream = valent_lan_encrypt_server_connection (bad_connection,
+                                                         bad_certificate,
+                                                         NULL,
+                                                         &error);
       g_assert_no_error (error);
       g_assert_true (G_IS_TLS_CONNECTION (bad_stream));
     }
@@ -760,34 +760,34 @@ main (int   argc,
   g_type_ensure (VALENT_TYPE_LAN_CHANNEL);
   g_type_ensure (VALENT_TYPE_LAN_CHANNEL_SERVICE);
 
-  g_test_add ("/backends/lan-backend/incoming-broadcast",
+  g_test_add ("/plugins/lan/incoming-broadcast",
               LanBackendFixture, NULL,
               lan_service_fixture_set_up,
               test_lan_service_incoming_broadcast,
               lan_service_fixture_tear_down);
 
-  g_test_add_func ("/backends/lan-backend/incoming-broadcast-oversize",
+  g_test_add_func ("/plugins/lan/incoming-broadcast-oversize",
                    test_lan_service_incoming_broadcast_oversize);
 
-  g_test_add ("/backends/lan-backend/outgoing-broadcast",
+  g_test_add ("/plugins/lan/outgoing-broadcast",
               LanBackendFixture, NULL,
               lan_service_fixture_set_up,
               test_lan_service_outgoing_broadcast,
               lan_service_fixture_tear_down);
 
-  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-oversize",
+  g_test_add_func ("/plugins/lan/outgoing-broadcast-oversize",
                    test_lan_service_outgoing_broadcast_oversize);
 
-  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-timeout",
+  g_test_add_func ("/plugins/lan/outgoing-broadcast-timeout",
                    test_lan_service_outgoing_broadcast_timeout);
 
-  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-tls-auth",
+  g_test_add_func ("/plugins/lan/outgoing-broadcast-tls-auth",
                    test_lan_service_outgoing_broadcast_tls_timeout);
 
-  g_test_add_func ("/backends/lan-backend/outgoing-broadcast-tls-cert",
+  g_test_add_func ("/plugins/lan/outgoing-broadcast-tls-cert",
                    test_lan_service_outgoing_broadcast_tls_spoofer);
 
-  g_test_add ("/backends/lan-backend/channel",
+  g_test_add ("/plugins/lan/channel",
               LanBackendFixture, NULL,
               lan_service_fixture_set_up,
               test_lan_service_channel,

--- a/tests/plugins/share/test-share-target-chooser.c
+++ b/tests/plugins/share/test-share-target-chooser.c
@@ -50,7 +50,7 @@ test_share_target_chooser (void)
     g_main_context_iteration (NULL, FALSE);
 
   /* ... */
-  valent_device_manager_identify (manager, NULL);
+  valent_device_manager_refresh (manager);
 
   while (g_main_context_iteration (NULL, FALSE))
     continue;


### PR DESCRIPTION
* cleanups and refactoring for the `lan` plugin
* remove `target` argument from `Valent.DeviceManager.identify`
* various miscellaneous doc and annotation cleanups