### PR TITLE
refactor: more API and code style cleanups

### DIFF
--- a/src/libvalent/clipboard/meson.build
+++ b/src/libvalent/clipboard/meson.build
@@ -22,7 +22,7 @@ libvalent_clipboard_enum_headers = [
 ]
 
 install_headers(libvalent_clipboard_public_headers,
-  subdir: libvalent_clipboard_header_subdir
+  subdir: libvalent_clipboard_header_subdir,
 )
 
 
@@ -44,9 +44,8 @@ libvalent_clipboard = static_library('valent-clipboard-' + valent_api_version,
                                      libvalent_clipboard_public_sources,
                                      libvalent_clipboard_generated_sources,
                                      libvalent_clipboard_generated_headers,
-  dependencies: libvalent_clipboard_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_CLIPBOARD_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_clipboard_deps,
 )
 
 libvalent_clipboard_dep = declare_dependency(
@@ -64,6 +63,6 @@ libvalent_public_headers += files(libvalent_clipboard_public_headers)
 libvalent_private_headers += files(libvalent_clipboard_private_headers)
 libvalent_generated_headers += libvalent_clipboard_generated_headers
 libvalent_generated_sources += libvalent_clipboard_generated_sources
-libvalent_include_subdirs += libvalent_clipboard_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_clipboard_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-clipboard.h', '-DVALENT_CLIPBOARD_COMPILATION']
 

--- a/src/libvalent/contacts/meson.build
+++ b/src/libvalent/contacts/meson.build
@@ -25,7 +25,7 @@ libvalent_contacts_enum_headers = [
 ]
 
 install_headers(libvalent_contacts_public_headers,
-  subdir: libvalent_contacts_header_subdir
+  subdir: libvalent_contacts_header_subdir,
 )
 
 
@@ -52,9 +52,8 @@ libvalent_contacts = static_library('valent-contacts-' + valent_api_version,
                                     libvalent_contacts_public_sources,
                                     libvalent_contacts_generated_sources,
                                     libvalent_contacts_generated_headers,
-  dependencies: libvalent_contacts_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_CONTACTS_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_contacts_deps,
 )
 
 libvalent_contacts_dep = declare_dependency(
@@ -72,6 +71,6 @@ libvalent_public_headers += files(libvalent_contacts_public_headers)
 libvalent_private_headers += files(libvalent_contacts_private_headers)
 libvalent_generated_headers += libvalent_contacts_generated_headers
 libvalent_generated_sources += libvalent_contacts_generated_sources
-libvalent_include_subdirs += libvalent_contacts_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_contacts_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-contacts.h', '-DVALENT_CONTACTS_COMPILATION']
 

--- a/src/libvalent/contacts/valent-contacts.c
+++ b/src/libvalent/contacts/valent-contacts.c
@@ -180,7 +180,7 @@ valent_contacts_unbind_extension (ValentComponent *component,
   /* Simulate removal */
   stores = valent_contacts_adapter_get_stores (adapter);
 
-  for (unsigned int i = 0; i < stores->len; i++)
+  for (unsigned int i = 0, len = stores->len; i < len; i++)
     valent_contacts_adapter_store_removed (adapter, g_ptr_array_index (stores, i));
 
   g_signal_handlers_disconnect_by_func (adapter, on_store_added, self);
@@ -305,8 +305,13 @@ valent_contacts_ensure_store (ValentContacts *contacts,
   g_return_val_if_fail (name != NULL && *name != '\0', NULL);
 
   /* Try to find an existing store */
-  if ((ret = valent_contacts_lookup_store (contacts, uid)) != NULL)
-    VALENT_RETURN (ret);
+  for (unsigned int i = 0, len = contacts->stores->len; i < len; i++)
+    {
+      ret = g_ptr_array_index (contacts->stores, i);
+
+      if (g_strcmp0 (valent_contact_store_get_uid (ret), uid) == 0)
+        VALENT_RETURN (ret);
+    }
 
   /* Create a new store */
   ret = valent_contacts_create_store (uid, name, NULL);
@@ -337,7 +342,7 @@ valent_contacts_lookup_store (ValentContacts *contacts,
   g_return_val_if_fail (VALENT_IS_CONTACTS (contacts), NULL);
   g_return_val_if_fail (uid != NULL, NULL);
 
-  for (unsigned int i = 0; i < contacts->stores->len; i++)
+  for (unsigned int i = 0, len = contacts->stores->len; i < len; i++)
     {
       ValentContactStore *store = g_ptr_array_index (contacts->stores, i);
 

--- a/src/libvalent/core/meson.build
+++ b/src/libvalent/core/meson.build
@@ -11,7 +11,6 @@ libvalent_core_generated_sources = []
 # Headers
 libvalent_core_public_headers = [
   'libvalent-core.h',
-  # 'valent-application-plugin.h',
   'valent-certificate.h',
   'valent-component.h',
   'valent-data.h',
@@ -30,7 +29,7 @@ libvalent_core_enum_headers = [
 ]
 
 install_headers(libvalent_core_public_headers,
-  subdir: libvalent_core_header_subdir
+  subdir: libvalent_core_header_subdir,
 )
 
 
@@ -125,9 +124,8 @@ libvalent_core = static_library('valent-core-' + valent_api_version,
                                 libvalent_core_public_sources,
                                 libvalent_core_generated_sources,
                                 libvalent_core_generated_headers,
-         dependencies: libvalent_core_deps,
                c_args: libvalent_c_args + release_args + ['-DVALENT_CORE_COMPILATION'],
-                  pic: true,
+         dependencies: libvalent_core_deps,
   include_directories: [config_h_inc, include_directories('.')],
 )
 
@@ -146,6 +144,6 @@ libvalent_public_headers += files(libvalent_core_public_headers)
 libvalent_private_headers += files(libvalent_core_private_headers)
 libvalent_generated_headers += libvalent_core_generated_headers
 libvalent_generated_sources += libvalent_core_generated_sources
-libvalent_include_subdirs += libvalent_core_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_core_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-core.h', '-DVALENT_CORE_COMPILATION']
 

--- a/src/libvalent/core/valent-macros.h
+++ b/src/libvalent/core/valent-macros.h
@@ -44,7 +44,7 @@ valent_set_string (char       **ptr,
 
   g_assert (ptr != NULL);
 
-  if (*ptr == str || g_strcmp0 (*ptr, str) == 0)
+  if (*ptr == str || (*ptr && str && strcmp (*ptr, str) == 0))
     return FALSE;
 
   copy = g_strdup (str);

--- a/src/libvalent/device/libvalent-device.h
+++ b/src/libvalent/device/libvalent-device.h
@@ -7,9 +7,9 @@
 
 G_BEGIN_DECLS
 
-#define VALENT_DEVICE_INSIDE
-
 #include "valent-device-enums.h"
+
+#define VALENT_DEVICE_INSIDE
 
 #include "valent-channel.h"
 #include "valent-channel-service.h"

--- a/src/libvalent/device/meson.build
+++ b/src/libvalent/device/meson.build
@@ -30,7 +30,7 @@ libvalent_device_enum_headers = [
 ]
 
 install_headers(libvalent_device_public_headers,
-  subdir: libvalent_device_header_subdir
+  subdir: libvalent_device_header_subdir,
 )
 
 
@@ -72,17 +72,15 @@ libvalent_device = static_library('valent-device-' + valent_api_version,
                                   libvalent_device_public_sources,
                                   libvalent_device_generated_sources,
                                   libvalent_device_generated_headers,
-         dependencies: libvalent_device_deps,
-               c_args: libvalent_c_args + release_args + ['-DVALENT_DEVICE_COMPILATION'],
-                  pic: true,
-  include_directories: [config_h_inc, include_directories('.')],
+        c_args: libvalent_c_args + release_args + ['-DVALENT_DEVICE_COMPILATION'],
+  dependencies: libvalent_device_deps,
 )
 
 libvalent_device_dep = declare_dependency(
-              sources: libvalent_device_private_headers + libvalent_device_generated_headers,
+              sources: [libvalent_device_private_headers, libvalent_device_generated_headers],
          dependencies: libvalent_device_deps,
             link_with: libvalent_device,
-  include_directories: [config_h_inc, include_directories('.')],
+  include_directories: include_directories('.'),
 )
 
 
@@ -93,6 +91,6 @@ libvalent_public_headers += files(libvalent_device_public_headers)
 libvalent_private_headers += files(libvalent_device_private_headers)
 libvalent_generated_headers += libvalent_device_generated_headers
 libvalent_generated_sources += libvalent_device_generated_sources
-libvalent_include_subdirs += libvalent_device_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_device_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-device.h', '-DVALENT_DEVICE_COMPILATION']
 

--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -271,7 +271,7 @@ valent_device_manager_check_device (ValentDeviceManager *self,
   if ((valent_device_get_state (device) & VALENT_DEVICE_STATE_PAIRED) != 0)
     return TRUE;
 
-  for (unsigned int i = 0; i < self->devices->len; i++)
+  for (unsigned int i = 0, len = self->devices->len; i < len; i++)
     {
       ValentDevice *check = g_ptr_array_index (self->devices, i);
 
@@ -522,7 +522,7 @@ valent_device_manager_lookup (ValentDeviceManager *manager,
   g_assert (VALENT_IS_DEVICE_MANAGER (manager));
   g_assert (id != NULL);
 
-  for (unsigned int i = 0; i < manager->devices->len; i++)
+  for (unsigned int i = 0, len = manager->devices->len; i < len; i++)
     {
       ValentDevice *device = g_ptr_array_index (manager->devices, i);
 
@@ -1230,7 +1230,7 @@ valent_device_manager_export (ValentDeviceManager *manager,
   manager->dbus = g_dbus_object_manager_server_new (object_path);
   g_dbus_object_manager_server_set_connection (manager->dbus, connection);
 
-  for (unsigned int i = 0; i < manager->devices->len; i++)
+  for (unsigned int i = 0, len = manager->devices->len; i < len; i++)
     {
       ValentDevice *device = g_ptr_array_index (manager->devices, i);
 
@@ -1264,7 +1264,7 @@ valent_device_manager_unexport (ValentDeviceManager *manager)
   if (manager->dbus == NULL)
     VALENT_EXIT;
 
-  for (unsigned int i = 0; i < manager->devices->len; i++)
+  for (unsigned int i = 0, len = manager->devices->len; i < len; i++)
     {
       ValentDevice *device = g_ptr_array_index (manager->devices, i);
 

--- a/src/libvalent/device/valent-device-plugin.h
+++ b/src/libvalent/device/valent-device-plugin.h
@@ -83,18 +83,6 @@ GSettings *    valent_device_plugin_create_settings     (PeasPluginInfo        *
 
 /* TODO: GMenuModel XML */
 VALENT_AVAILABLE_IN_1_0
-int             valent_device_plugin_find_menu_item     (ValentDevicePlugin    *plugin,
-                                                         const char            *attribute,
-                                                         const GVariant        *value);
-VALENT_AVAILABLE_IN_1_0
-int             valent_device_plugin_remove_menu_item   (ValentDevicePlugin    *plugin,
-                                                         const char            *attribute,
-                                                         const GVariant        *value);
-VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_replace_menu_item  (ValentDevicePlugin    *plugin,
-                                                         GMenuItem             *item,
-                                                         const char            *attribute);
-VALENT_AVAILABLE_IN_1_0
 void           valent_device_plugin_add_menu_entries    (ValentDevicePlugin    *plugin,
                                                          const ValentMenuEntry *entries,
                                                          int                    n_entries);
@@ -102,6 +90,10 @@ VALENT_AVAILABLE_IN_1_0
 void           valent_device_plugin_remove_menu_entries (ValentDevicePlugin    *plugin,
                                                          const ValentMenuEntry *entries,
                                                          int                    n_entries);
+VALENT_AVAILABLE_IN_1_0
+void            valent_device_plugin_replace_menu_item  (ValentDevicePlugin    *plugin,
+                                                         GMenuItem             *item,
+                                                         const char            *attribute);
 
 /* Miscellaneous Helpers */
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -1652,10 +1652,9 @@ valent_device_set_paired (ValentDevice *device,
   valent_object_lock (VALENT_OBJECT (device));
 
   /* If nothing's changed, only reset pending pair timeouts */
-  valent_device_reset_pair (device);
-
   if (device->paired == paired)
     {
+      valent_device_reset_pair (device);
       valent_object_unlock (VALENT_OBJECT (device));
       return;
     }
@@ -1673,7 +1672,7 @@ valent_device_set_paired (ValentDevice *device,
 
   /* Update plugins and notify */
   valent_device_update_plugins (device);
-  g_object_notify_by_pspec (G_OBJECT (device), properties [PROP_STATE]);
+  valent_device_reset_pair (device);
 }
 
 /**

--- a/src/libvalent/input/meson.build
+++ b/src/libvalent/input/meson.build
@@ -23,7 +23,7 @@ libvalent_input_enum_headers = [
 ]
 
 install_headers(libvalent_input_public_headers,
-  subdir: libvalent_input_header_subdir
+  subdir: libvalent_input_header_subdir,
 )
 
 
@@ -45,9 +45,8 @@ libvalent_input = static_library('valent-input-' + valent_api_version,
                                  libvalent_input_public_sources,
                                  libvalent_input_generated_sources,
                                  libvalent_input_generated_headers,
-  dependencies: libvalent_input_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_INPUT_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_input_deps,
 )
 
 libvalent_input_dep = declare_dependency(
@@ -65,6 +64,6 @@ libvalent_public_headers += files(libvalent_input_public_headers)
 libvalent_private_headers += files(libvalent_input_private_headers)
 libvalent_generated_headers += libvalent_input_generated_headers
 libvalent_generated_sources += libvalent_input_generated_sources
-libvalent_include_subdirs += libvalent_input_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_input_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-input.h', '-DVALENT_INPUT_COMPILATION']
 

--- a/src/libvalent/media/meson.build
+++ b/src/libvalent/media/meson.build
@@ -24,7 +24,7 @@ libvalent_media_enum_headers = [
 ]
 
 install_headers(libvalent_media_public_headers,
-  subdir: libvalent_media_header_subdir
+  subdir: libvalent_media_header_subdir,
 )
 
 
@@ -60,9 +60,8 @@ libvalent_media = static_library('valent-media-' + valent_api_version,
                                  libvalent_media_public_sources,
                                  libvalent_media_generated_sources,
                                  libvalent_media_generated_headers,
-  dependencies: libvalent_media_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_MEDIA_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_media_deps,
 )
 
 libvalent_media_dep = declare_dependency(
@@ -80,6 +79,6 @@ libvalent_public_headers += files(libvalent_media_public_headers)
 libvalent_private_headers += files(libvalent_media_private_headers)
 libvalent_generated_headers += libvalent_media_generated_headers
 libvalent_generated_sources += libvalent_media_generated_sources
-libvalent_include_subdirs += libvalent_media_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_media_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-media.h', '-DVALENT_MEDIA_COMPILATION']
 

--- a/src/libvalent/meson.build
+++ b/src/libvalent/meson.build
@@ -14,7 +14,7 @@ libvalent_private_sources = []
 libvalent_private_headers = []
 libvalent_generated_sources = []
 libvalent_generated_headers = []
-libvalent_include_subdirs = []
+libvalent_pkgconfig_subdirs = []
 libvalent_static = []
 libvalent_deps = []
 
@@ -36,18 +36,18 @@ subdir('ui')
 libvalent = shared_library('valent',
               version: valent_api_version,
             soversion: '0',
-  include_directories: [include_directories('.')],
+               c_args: libvalent_c_args + release_args,
          dependencies: libvalent_deps,
            link_whole: libvalent_static,
-               c_args: libvalent_c_args + release_args,
+  include_directories: libvalent_include_directories,
               install: true,
           install_dir: libdir,
 )
 
 libvalent_dep = declare_dependency(
+         dependencies: libvalent_deps,
             link_with: libvalent,
-  include_directories: [include_directories('.')],
-         dependencies: libvalent_deps
+  include_directories: libvalent_include_directories,
 )
 
 # pkgconfig
@@ -64,7 +64,7 @@ pkgconfig.generate(
        'libpeas-1.0',
        'libebook-contacts-1.2',
      ],
-      subdirs: libvalent_include_subdirs,
+      subdirs: libvalent_pkgconfig_subdirs,
      filebase: valent_api_name,
   install_dir: join_paths(libdir, 'pkgconfig'),
 )
@@ -82,10 +82,10 @@ if get_option('introspection')
   ]
 
   libvalent_gir_sources = [
-    libvalent_public_sources +
-    libvalent_public_headers +
-    libvalent_generated_headers +
-    libvalent_generated_sources
+    libvalent_public_sources,
+    libvalent_public_headers,
+    libvalent_generated_headers,
+    libvalent_generated_sources,
   ]
 
   libvalent_gir = gnome.generate_gir(libvalent,

--- a/src/libvalent/mixer/meson.build
+++ b/src/libvalent/mixer/meson.build
@@ -24,7 +24,7 @@ libvalent_mixer_enum_headers = [
 ]
 
 install_headers(libvalent_mixer_public_headers,
-  subdir: libvalent_mixer_header_subdir
+  subdir: libvalent_mixer_header_subdir,
 )
 
 
@@ -60,9 +60,8 @@ libvalent_mixer = static_library('valent-mixer-' + valent_api_version,
                                  libvalent_mixer_public_sources,
                                  libvalent_mixer_generated_sources,
                                  libvalent_mixer_generated_headers,
-  dependencies: libvalent_mixer_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_MIXER_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_mixer_deps,
 )
 
 libvalent_mixer_dep = declare_dependency(
@@ -80,6 +79,6 @@ libvalent_public_headers += files(libvalent_mixer_public_headers)
 libvalent_private_headers += files(libvalent_mixer_private_headers)
 libvalent_generated_headers += libvalent_mixer_generated_headers
 libvalent_generated_sources += libvalent_mixer_generated_sources
-libvalent_include_subdirs += libvalent_mixer_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_mixer_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-mixer.h', '-DVALENT_MIXER_COMPILATION']
 

--- a/src/libvalent/notifications/meson.build
+++ b/src/libvalent/notifications/meson.build
@@ -20,7 +20,7 @@ libvalent_notifications_private_headers = [
 ]
 
 install_headers(libvalent_notifications_public_headers,
-  subdir: libvalent_notifications_header_subdir
+  subdir: libvalent_notifications_header_subdir,
 )
 
 
@@ -43,9 +43,8 @@ libvalent_notifications = static_library('valent-notifications-' + valent_api_ve
                                          libvalent_notifications_public_sources,
                                          libvalent_notifications_generated_sources,
                                          libvalent_notifications_generated_headers,
-  dependencies: libvalent_notifications_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_NOTIFICATIONS_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_notifications_deps,
 )
 
 libvalent_notifications_dep = declare_dependency(
@@ -63,6 +62,6 @@ libvalent_public_headers += files(libvalent_notifications_public_headers)
 libvalent_private_headers += files(libvalent_notifications_private_headers)
 libvalent_generated_headers += libvalent_notifications_generated_headers
 libvalent_generated_sources += libvalent_notifications_generated_sources
-libvalent_include_subdirs += libvalent_notifications_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_notifications_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-notifications.h', '-DVALENT_NOTIFICATIONS_COMPILATION']
 

--- a/src/libvalent/session/meson.build
+++ b/src/libvalent/session/meson.build
@@ -22,7 +22,7 @@ libvalent_session_enum_headers = [
 ]
 
 install_headers(libvalent_session_public_headers,
-  subdir: libvalent_session_header_subdir
+  subdir: libvalent_session_header_subdir,
 )
 
 
@@ -44,9 +44,8 @@ libvalent_session = static_library('valent-session-' + valent_api_version,
                                    libvalent_session_public_sources,
                                    libvalent_session_generated_sources,
                                    libvalent_session_generated_headers,
-  dependencies: libvalent_session_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_SESSION_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_session_deps,
 )
 
 libvalent_session_dep = declare_dependency(
@@ -64,6 +63,6 @@ libvalent_public_headers += files(libvalent_session_public_headers)
 libvalent_private_headers += files(libvalent_session_private_headers)
 libvalent_generated_headers += libvalent_session_generated_headers
 libvalent_generated_sources += libvalent_session_generated_sources
-libvalent_include_subdirs += libvalent_session_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_session_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-session.h', '-DVALENT_SESSION_COMPILATION']
 

--- a/src/libvalent/ui/meson.build
+++ b/src/libvalent/ui/meson.build
@@ -31,7 +31,7 @@ libvalent_ui_private_headers = [
 ]
 
 install_headers(libvalent_ui_public_headers,
-  subdir: libvalent_ui_header_subdir
+  subdir: libvalent_ui_header_subdir,
 )
 
 
@@ -85,9 +85,8 @@ libvalent_ui = static_library('valent-ui-' + valent_api_version,
                               libvalent_ui_public_sources,
                               libvalent_ui_generated_sources,
                               libvalent_ui_generated_headers,
-  dependencies: libvalent_ui_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_UI_COMPILATION'],
-           pic: true,
+  dependencies: libvalent_ui_deps,
 )
 
 libvalent_ui_dep = declare_dependency(
@@ -105,6 +104,6 @@ libvalent_public_headers += files(libvalent_ui_public_headers)
 libvalent_private_headers += files(libvalent_ui_private_headers)
 libvalent_generated_headers += libvalent_ui_generated_headers
 libvalent_generated_sources += libvalent_ui_generated_sources
-libvalent_include_subdirs += libvalent_ui_header_subdir
+libvalent_pkgconfig_subdirs += libvalent_ui_header_subdir
 libvalent_gir_extra_args += ['--c-include=libvalent-ui.h', '-DVALENT_UI_COMPILATION']
 

--- a/src/libvalent/ui/valent-device-preferences-window.c
+++ b/src/libvalent/ui/valent-device-preferences-window.c
@@ -8,7 +8,6 @@
 #include <glib/gi18n.h>
 #include <adwaita.h>
 #include <gtk/gtk.h>
-#include <pango/pango.h>
 #include <libvalent-core.h>
 #include <libvalent-device.h>
 

--- a/src/plugins/battery/meson.build
+++ b/src/plugins/battery/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_battery_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/bluez/meson.build
+++ b/src/plugins/bluez/meson.build
@@ -3,8 +3,7 @@
 
 # Dependencies
 plugin_bluez_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/clipboard/meson.build
+++ b/src/plugins/clipboard/meson.build
@@ -3,10 +3,7 @@
 
 # Dependencies
 plugin_clipboard_deps = [
-  libvalent_core_dep,
-  libvalent_clipboard_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/connectivity_report/meson.build
+++ b/src/plugins/connectivity_report/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_connectivity_report_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/contacts/meson.build
+++ b/src/plugins/contacts/meson.build
@@ -3,10 +3,7 @@
 
 # Dependencies
 plugin_contacts_deps = [
-  libvalent_core_dep,
-  libvalent_contacts_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/eds/meson.build
+++ b/src/plugins/eds/meson.build
@@ -3,8 +3,7 @@
 
 # Dependencies
 plugin_eds_deps = [
-  libvalent_core_dep,
-  libvalent_contacts_dep,
+  libvalent_dep,
 
   libebook_dep,
   libebook_contacts_dep,

--- a/src/plugins/fdo/meson.build
+++ b/src/plugins/fdo/meson.build
@@ -10,9 +10,7 @@ endif
 
 # Dependencies
 plugin_fdo_deps = [
-  libvalent_core_dep,
-  libvalent_notifications_dep,
-  libvalent_session_dep,
+  libvalent_dep,
 
   gdk_pixbuf_dep,
 ]

--- a/src/plugins/findmyphone/meson.build
+++ b/src/plugins/findmyphone/meson.build
@@ -10,10 +10,7 @@ endif
 
 # Dependencies
 plugin_findmyphone_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_session_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 
   gstreamer_dep
 ]

--- a/src/plugins/gtk/meson.build
+++ b/src/plugins/gtk/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_gtk_deps = [
-  libvalent_core_dep,
-  libvalent_clipboard_dep,
-  libvalent_notifications_dep,
+  libvalent_dep,
 
   gtk_dep,
 ]

--- a/src/plugins/lan/meson.build
+++ b/src/plugins/lan/meson.build
@@ -3,8 +3,7 @@
 
 # Dependencies
 plugin_lan_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/lock/meson.build
+++ b/src/plugins/lock/meson.build
@@ -3,10 +3,7 @@
 
 # Dependencies
 plugin_lock_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_session_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/mousepad/meson.build
+++ b/src/plugins/mousepad/meson.build
@@ -3,10 +3,7 @@
 
 # Dependencies
 plugin_mousepad_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_input_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/mpris/meson.build
+++ b/src/plugins/mpris/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_mpris_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_media_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/notification/meson.build
+++ b/src/plugins/notification/meson.build
@@ -3,11 +3,7 @@
 
 # Dependencies
 plugin_notification_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_notifications_dep,
-  libvalent_session_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/photo/meson.build
+++ b/src/plugins/photo/meson.build
@@ -10,8 +10,7 @@ endif
 
 # Dependencies
 plugin_photo_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
+  libvalent_dep,
   gstreamer_video_dep,
 ]
 

--- a/src/plugins/ping/meson.build
+++ b/src/plugins/ping/meson.build
@@ -3,8 +3,7 @@
 
 # Dependencies
 plugin_ping_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/presenter/meson.build
+++ b/src/plugins/presenter/meson.build
@@ -3,10 +3,7 @@
 
 # Dependencies
 plugin_presenter_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_input_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/pulseaudio/meson.build
+++ b/src/plugins/pulseaudio/meson.build
@@ -17,8 +17,7 @@ endif
 
 # Dependencies
 plugin_pulseaudio_deps = [
-  libvalent_core_dep,
-  libvalent_mixer_dep,
+  libvalent_dep,
 
   libgvc_dep,
 ]

--- a/src/plugins/runcommand/meson.build
+++ b/src/plugins/runcommand/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_runcommand_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/runcommand/valent-runcommand-editor.c
+++ b/src/plugins/runcommand/valent-runcommand-editor.c
@@ -252,3 +252,4 @@ valent_runcommand_editor_clear (ValentRuncommandEditor *editor)
   gtk_editable_set_text (GTK_EDITABLE (editor->name_entry), "");
   gtk_editable_set_text (GTK_EDITABLE (editor->command_entry), "");
 }
+

--- a/src/plugins/sftp/meson.build
+++ b/src/plugins/sftp/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_sftp_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -196,11 +196,8 @@ sftp_session_find (ValentSftpPlugin *self)
           if (self->session == NULL)
             self->session = g_new0 (ValentSftpSession, 1);
 
-          g_clear_object (&self->session->mount);
-          self->session->mount = g_object_ref (G_MOUNT (iter->data));
-
-          g_clear_pointer (&self->session->uri, g_free);
-          self->session->uri = g_steal_pointer (&uri);
+          g_set_object (&self->session->mount, iter->data);
+          valent_set_string (&self->session->uri, uri);
 
           return TRUE;
         }

--- a/src/plugins/share/meson.build
+++ b/src/plugins/share/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_share_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/sms/meson.build
+++ b/src/plugins/sms/meson.build
@@ -4,10 +4,7 @@
 
 # Dependencies
 plugin_sms_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
-  libvalent_contacts_dep,
+  libvalent_dep,
 
   sqlite_dep,
 ]

--- a/src/plugins/systemvolume/meson.build
+++ b/src/plugins/systemvolume/meson.build
@@ -3,9 +3,7 @@
 
 # Dependencies
 plugin_systemvolume_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_mixer_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/telephony/meson.build
+++ b/src/plugins/telephony/meson.build
@@ -4,9 +4,7 @@
 
 # Dependencies
 plugin_telephony_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 ]
 
 # Sources

--- a/src/plugins/xdp/meson.build
+++ b/src/plugins/xdp/meson.build
@@ -33,9 +33,7 @@ endif
 
 # Dependencies
 plugin_xdp_deps = [
-  libvalent_core_dep,
-  libvalent_input_dep,
-  libvalent_ui_dep,
+  libvalent_dep,
 
   gtk_dep,
   libportal_dep,

--- a/tests/fixtures/meson.build
+++ b/tests/fixtures/meson.build
@@ -64,16 +64,7 @@ libvalent_test_generated_headers = [libvalent_test_resources[1]]
 
 # Dependencies
 libvalent_test_deps = [
-  libvalent_core_dep,
-  libvalent_clipboard_dep,
-  libvalent_contacts_dep,
-  libvalent_device_dep,
-  libvalent_input_dep,
-  libvalent_media_dep,
-  libvalent_mixer_dep,
-  libvalent_notifications_dep,
-  libvalent_session_dep,
-  libvalent_ui_dep,
+  libvalent_deps,
 ]
 
 if get_option('fuzz_tests') and libwalbottle_dep.found()
@@ -87,8 +78,8 @@ libvalent_test = static_library('valent-test-' + valent_api_version,
                                 libvalent_test_public_sources,
                                 libvalent_test_generated_sources,
                                 libvalent_test_generated_headers,
-  dependencies: libvalent_test_deps,
         c_args: libvalent_c_args + release_args + ['-DVALENT_TEST_COMPILATION'],
+  dependencies: libvalent_test_deps,
 )
 
 libvalent_test_dep = declare_dependency(

--- a/tests/fixtures/valent-test-utils.c
+++ b/tests/fixtures/valent-test-utils.c
@@ -9,6 +9,7 @@
 #include <adwaita.h>
 #include <json-glib/json-glib.h>
 #include <libvalent-core.h>
+#include <libvalent-device.h>
 #include <libvalent-contacts.h>
 #include <libvalent-clipboard.h>
 #include <libvalent-input.h>

--- a/tests/libvalent/clipboard/meson.build
+++ b/tests/libvalent/clipboard/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_clipboard_test_deps = [
-  libvalent_core_dep,
-  libvalent_clipboard_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/contacts/meson.build
+++ b/tests/libvalent/contacts/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_contacts_test_deps = [
-  libvalent_core_dep,
-  libvalent_contacts_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/core/meson.build
+++ b/tests/libvalent/core/meson.build
@@ -3,7 +3,6 @@
 
 # Dependencies
 libvalent_core_test_deps = [
-  libvalent_core_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/device/meson.build
+++ b/tests/libvalent/device/meson.build
@@ -2,12 +2,11 @@
 # SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
 
 # Dependencies
-libvalent_core_test_deps = [
-  libvalent_core_dep,
+libvalent_device_test_deps = [
   libvalent_test_dep,
 ]
 
-libvalent_core_tests = [
+libvalent_device_tests = [
   'test-channel-service',
   'test-device',
   'test-device-manager',
@@ -16,19 +15,19 @@ libvalent_core_tests = [
   'test-packet',
 ]
 
-foreach test : libvalent_core_tests
+foreach test : libvalent_device_tests
   test_program = executable(test, '@0@.c'.format(test),
                  c_args: test_c_args,
-           dependencies: libvalent_core_test_deps,
+           dependencies: libvalent_device_test_deps,
     include_directories: libvalent_include_directories,
               link_args: test_link_args,
-             link_whole: [libvalent_test, libvalent_core],
+             link_whole: [libvalent_test, libvalent_device],
   )
 
   test(test, test_program,
             env: tests_env,
     is_parallel: false,
-          suite: ['libvalent', 'core'],
+          suite: ['libvalent', 'device'],
   )
 endforeach
 

--- a/tests/libvalent/input/meson.build
+++ b/tests/libvalent/input/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_input_test_deps = [
-  libvalent_core_dep,
-  libvalent_input_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/media/meson.build
+++ b/tests/libvalent/media/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_media_test_deps = [
-  libvalent_core_dep,
-  libvalent_media_dep,
   libvalent_test_dep,
 ]
 
@@ -27,3 +25,4 @@ foreach test : libvalent_media_tests
           suite: ['libvalent', 'media'],
   )
 endforeach
+

--- a/tests/libvalent/mixer/meson.build
+++ b/tests/libvalent/mixer/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_mixer_test_deps = [
-  libvalent_core_dep,
-  libvalent_mixer_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/notifications/meson.build
+++ b/tests/libvalent/notifications/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_notifications_test_deps = [
-  libvalent_core_dep,
-  libvalent_notifications_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/session/meson.build
+++ b/tests/libvalent/session/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 libvalent_session_test_deps = [
-  libvalent_core_dep,
-  libvalent_session_dep,
   libvalent_test_dep,
 ]
 

--- a/tests/libvalent/ui/meson.build
+++ b/tests/libvalent/ui/meson.build
@@ -3,9 +3,6 @@
 
 # Dependencies
 libvalent_ui_test_deps = [
-  libvalent_core_dep,
-  libvalent_device_dep,
-  libvalent_ui_dep,
   libvalent_test_dep,
 ]
 
@@ -35,3 +32,4 @@ foreach test : libvalent_ui_tests
           suite: ['libvalent', 'ui'],
   )
 endforeach
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,7 @@ tests_env = [
   'TSAN_OPTIONS=force_seq_cst_atomics=1,history_size=5,suppressions=@0@'.format(
     join_paths(meson.current_source_dir(), 'extra', 'tsan.supp')),
   'UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1',
+  'PYTHONDONTWRITEBYTECODE=yes',
 ]
 
 test_c_args = [

--- a/tests/plugins/bluez/meson.build
+++ b/tests/plugins/bluez/meson.build
@@ -3,8 +3,8 @@
 
 # Dependencies
 plugin_bluez_test_deps = [
-  libvalent_core_dep,
   libvalent_test_dep,
+  plugin_bluez_deps,
 ]
 
 plugin_bluez_tests = {

--- a/tests/plugins/lan/meson.build
+++ b/tests/plugins/lan/meson.build
@@ -3,8 +3,8 @@
 
 # Dependencies
 plugin_lan_test_deps = [
-  libvalent_core_dep,
   libvalent_test_dep,
+  plugin_lan_deps,
 ]
 
 plugin_lan_tests = [

--- a/tests/plugins/sms/meson.build
+++ b/tests/plugins/sms/meson.build
@@ -3,8 +3,6 @@
 
 # Dependencies
 plugin_sms_test_deps = [
-  libvalent_core_dep,
-  libvalent_contacts_dep,
   libvalent_test_dep,
   plugin_sms_deps,
 ]


### PR DESCRIPTION
* refactor: remove a handful of nearly-defunct GMenu helpers
* refactor: consistently use a pseudo-optimized for-loop pattern
* refactor: optimize `valent_set_string()`
* build: meson cleanups and linker restructuring
* various code style and formatting cleanups