### PR TITLE
fix: remove symbols from GLib included in future versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ project_c_args = [
 
   # These should be kept in sync (eg. GTK 4.4 requires GLib 2.66)
   '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_66',
+  '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_66',
   '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_6',
 
   # TODO: These should be fixed instead of downgraded to warnings

--- a/src/libvalent/ui/valent-ui-utils.c
+++ b/src/libvalent/ui/valent-ui-utils.c
@@ -35,7 +35,7 @@ valent_ui_replace_eval_uri (const GMatchInfo *info,
       escaped = g_markup_printf_escaped ("<a href=\"%s\">%s</a>",
                                          text, text);
     }
-  else if (g_regex_match (email_regex, text, G_REGEX_MATCH_DEFAULT, NULL))
+  else if (g_regex_match (email_regex, text, 0, NULL))
     {
       escaped = g_markup_printf_escaped ("<a href=\"mailto:%s\">%s</a>",
                                          text, text);
@@ -87,7 +87,7 @@ valent_string_to_markup (const char *text)
                                  text,
                                  text_len,
                                  0,
-                                 G_REGEX_MATCH_DEFAULT,
+                                 0,
                                  valent_ui_replace_eval_uri,
                                  NULL,
                                  &error);

--- a/src/plugins/fdo/valent-fdo-notifications.c
+++ b/src/plugins/fdo/valent-fdo-notifications.c
@@ -106,7 +106,9 @@ _g_icon_new_for_variant (GVariant *image_data)
     }
 
 #if GLIB_CHECK_VERSION (2, 68, 0)
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   data = g_memdup2 (g_variant_get_data (data_variant), data_len);
+  G_GNUC_END_IGNORE_DEPRECATIONS
 #else
   data = g_memdup (g_variant_get_data (data_variant), (guint)data_len);
 #endif /* GLIB_CHECK_VERSION (2, 68, 0) */

--- a/src/plugins/runcommand/valent-runcommand-utils.c
+++ b/src/plugins/runcommand/valent-runcommand-utils.c
@@ -33,7 +33,9 @@ valent_runcommand_can_spawn_host (void)
           g_spawn_command_line_sync ("flatpak-spawn --host true",
                                      NULL, NULL, &status, NULL);
 #if GLIB_CHECK_VERSION(2, 70, 0)
+          G_GNUC_BEGIN_IGNORE_DEPRECATIONS
           host = g_spawn_check_wait_status (status, NULL);
+          G_GNUC_END_IGNORE_DEPRECATIONS
 #else
           host = g_spawn_check_exit_status (status, NULL);
 #endif /* GLIB_CHECK_VERSION(2, 70, 0) */

--- a/tests/fixtures/glibtest.py
+++ b/tests/fixtures/glibtest.py
@@ -38,7 +38,7 @@ class _GLibTestCaseAttr:
     # pylint: disable-next=line-too-long
     def __get__(self, instance: Type[GLibTestCaseAttr], owner: Optional[Any]) -> Callable[[unittest.TestCase], None]:
         # pylint: disable-next=no-value-for-parameter
-        bound_method = self.__func.__get__(instance, owner) # type: ignore
+        bound_method = self.__func.__get__(instance, owner)
         partial_method = functools.partial(bound_method, self.path)
         partial_method.__doc__ = bound_method.__doc__
         partial_method.__qualname__ = f'{owner.__qualname__}.{self.path}' # type: ignore
@@ -80,7 +80,7 @@ class _GLibTestCaseMeta(type):
                                    env=env,
                                    timeout=15)
         except subprocess.TimeoutExpired as error:
-            sys.stderr.write(error.stdout.decode('utf-8'))
+            sys.stderr.write(error.stdout.decode('utf-8')) # type: ignore
             raise RuntimeError(f'Querying tests: {error}') from error
         except subprocess.CalledProcessError as error:
             sys.stderr.write(error.stdout)


### PR DESCRIPTION
Remove the `G_REGEX_MATCH_DEFAULT` flag from usage, since it's not available until `glib-2.74`.

Add the `-DGLIB_VERSION_MAX_ALLOWED` compile-time flag to prevent future mistakes, and wrap any exceptions to the rule in version-check and ignore-deprecation macros.