### PR TITLE
chore: miscellaneous cleanups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,8 +26,6 @@ MINOR_VERSION = version_split[1].to_int()
 MICRO_VERSION = version_split[2].to_int()
 
 valent_version = '@0@.@1@.@2@'.format(MAJOR_VERSION, MINOR_VERSION, MICRO_VERSION)
-valent_api_version = '@0@.@1@'.format(MAJOR_VERSION, MINOR_VERSION)
-valent_api_name = 'valent-@0@'.format(valent_api_version)
 
 
 #

--- a/src/libvalent/clipboard/meson.build
+++ b/src/libvalent/clipboard/meson.build
@@ -40,7 +40,7 @@ libvalent_clipboard_deps = [
 
 
 # Library Definitions
-libvalent_clipboard = static_library('valent-clipboard-' + valent_api_version,
+libvalent_clipboard = static_library('valent-clipboard-@0@'.format(libvalent_api_version),
                                      libvalent_clipboard_public_sources,
                                      libvalent_clipboard_generated_sources,
                                      libvalent_clipboard_generated_headers,

--- a/src/libvalent/contacts/meson.build
+++ b/src/libvalent/contacts/meson.build
@@ -47,7 +47,7 @@ libvalent_contacts_deps = [
 
 
 # Library Definitions
-libvalent_contacts = static_library('valent-contacts-' + valent_api_version,
+libvalent_contacts = static_library('valent-contacts-@0@'.format(libvalent_api_version),
                                     libvalent_contacts_public_sources,
                                     libvalent_contacts_generated_sources,
                                     libvalent_contacts_generated_headers,

--- a/src/libvalent/core/meson.build
+++ b/src/libvalent/core/meson.build
@@ -120,7 +120,7 @@ endif
 
 
 # Library Definitions
-libvalent_core = static_library('valent-core-' + valent_api_version,
+libvalent_core = static_library('valent-core-@0@'.format(libvalent_api_version),
                                 libvalent_core_public_sources,
                                 libvalent_core_generated_sources,
                                 libvalent_core_generated_headers,

--- a/src/libvalent/device/meson.build
+++ b/src/libvalent/device/meson.build
@@ -68,7 +68,7 @@ libvalent_device_deps = [
 ]
 
 # Library Definitions
-libvalent_device = static_library('valent-device-' + valent_api_version,
+libvalent_device = static_library('valent-device-@0@'.format(libvalent_api_version),
                                   libvalent_device_public_sources,
                                   libvalent_device_generated_sources,
                                   libvalent_device_generated_headers,

--- a/src/libvalent/device/valent-channel.c
+++ b/src/libvalent/device/valent-channel.c
@@ -772,9 +772,9 @@ valent_channel_read_packet_finish (ValentChannel  *channel,
 
   VALENT_ENTRY;
 
-  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), FALSE);
-  g_return_val_if_fail (g_task_is_valid (result, channel), FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), NULL);
+  g_return_val_if_fail (g_task_is_valid (result, channel), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   ret = g_task_propagate_pointer (G_TASK (result), error);
 
@@ -976,10 +976,10 @@ valent_channel_download (ValentChannel  *channel,
 
   VALENT_ENTRY;
 
-  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), FALSE);
-  g_return_val_if_fail (VALENT_IS_PACKET (packet), FALSE);
-  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), NULL);
+  g_return_val_if_fail (VALENT_IS_PACKET (packet), NULL);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   ret = VALENT_CHANNEL_GET_CLASS (channel)->download (channel,
                                                       packet,
@@ -1048,9 +1048,9 @@ valent_channel_download_finish (ValentChannel  *channel,
 
   VALENT_ENTRY;
 
-  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), FALSE);
-  g_return_val_if_fail (g_task_is_valid (result, channel), FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), NULL);
+  g_return_val_if_fail (g_task_is_valid (result, channel), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   ret = VALENT_CHANNEL_GET_CLASS (channel)->download_finish (channel,
                                                              result,
@@ -1091,10 +1091,10 @@ valent_channel_upload (ValentChannel  *channel,
 
   VALENT_ENTRY;
 
-  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), FALSE);
-  g_return_val_if_fail (VALENT_IS_PACKET (packet), FALSE);
-  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), NULL);
+  g_return_val_if_fail (VALENT_IS_PACKET (packet), NULL);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   ret = VALENT_CHANNEL_GET_CLASS (channel)->upload (channel,
                                                     packet,
@@ -1163,9 +1163,9 @@ valent_channel_upload_finish (ValentChannel  *channel,
 
   VALENT_ENTRY;
 
-  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), FALSE);
-  g_return_val_if_fail (g_task_is_valid (result, channel), FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (VALENT_IS_CHANNEL (channel), NULL);
+  g_return_val_if_fail (g_task_is_valid (result, channel), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   ret = VALENT_CHANNEL_GET_CLASS (channel)->upload_finish (channel,
                                                            result,

--- a/src/libvalent/input/meson.build
+++ b/src/libvalent/input/meson.build
@@ -41,7 +41,7 @@ libvalent_input_deps = [
 
 
 # Library Definitions
-libvalent_input = static_library('valent-input-' + valent_api_version,
+libvalent_input = static_library('valent-input-@0@'.format(libvalent_api_version),
                                  libvalent_input_public_sources,
                                  libvalent_input_generated_sources,
                                  libvalent_input_generated_headers,

--- a/src/libvalent/media/meson.build
+++ b/src/libvalent/media/meson.build
@@ -56,7 +56,7 @@ libvalent_media_deps = [
 
 
 # Library Definitions
-libvalent_media = static_library('valent-media-' + valent_api_version,
+libvalent_media = static_library('valent-media-@0@'.format(libvalent_api_version),
                                  libvalent_media_public_sources,
                                  libvalent_media_generated_sources,
                                  libvalent_media_generated_headers,

--- a/src/libvalent/meson.build
+++ b/src/libvalent/meson.build
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2021 Andy Holmes <andrew.g.r.holmes@gmail.com>
 
+libvalent_api_version = meson.project_version().split('.')[0]
+libvalent_api_name = 'libvalent-@0@'.format(libvalent_api_version)
+libvalent_so_version = valent_version
+
 # The subdirs update these before libvalent is compiled
 libvalent_c_args = []
 libvalent_link_args = []
-libvalent_gir_extra_args = ['--pkg-export=@0@'.format(valent_api_name)]
+libvalent_gir_extra_args = ['--pkg-export=@0@'.format(libvalent_api_name)]
 
-libvalent_header_subdir = join_paths(valent_api_name, 'libvalent')
+libvalent_header_subdir = join_paths(libvalent_api_name, 'libvalent')
 libvalent_header_dir = join_paths(includedir, libvalent_header_subdir)
 libvalent_include_directories = []
 libvalent_public_sources = []
@@ -34,29 +38,28 @@ subdir('ui')
 #
 # Shared library
 #
-libvalent = shared_library('valent',
-              version: valent_api_version,
-            soversion: '0',
-               c_args: libvalent_c_args + release_args,
-            link_args: libvalent_link_args,
-           link_whole: libvalent_static,
-         dependencies: libvalent_deps,
-              install: true,
-          install_dir: libdir,
+libvalent = shared_library('valent-@0@'.format(libvalent_api_version),
+       version: libvalent_api_version,
+     soversion: libvalent_so_version,
+        c_args: libvalent_c_args + release_args,
+     link_args: libvalent_link_args,
+    link_whole: libvalent_static,
+  dependencies: libvalent_deps,
+       install: true,
 )
 
 libvalent_dep = declare_dependency(
-         dependencies: libvalent_deps,
             link_with: libvalent,
   include_directories: libvalent_include_directories,
+         dependencies: libvalent_deps,
 )
 
 # pkgconfig
 pkgconfig.generate(
          name: 'Valent',
   description: 'Core implementation and plugin API for Valent.',
-      version: valent_version,
-     filebase: valent_api_name,
+      version: libvalent_so_version,
+     filebase: libvalent_api_name,
     libraries: [libvalent],
       subdirs: libvalent_pkgconfig_subdirs,
      requires: [
@@ -95,7 +98,7 @@ if get_option('introspection')
   libvalent_gir = gnome.generate_gir(libvalent,
                 sources: libvalent_gir_sources,
               namespace: 'Valent',
-              nsversion: valent_api_version,
+              nsversion: libvalent_api_version,
           symbol_prefix: meson.project_name(),
       identifier_prefix: 'Valent',
                includes: libvalent_gir_includes,

--- a/src/libvalent/mixer/meson.build
+++ b/src/libvalent/mixer/meson.build
@@ -56,7 +56,7 @@ libvalent_mixer_deps = [
 
 
 # Library Definitions
-libvalent_mixer = static_library('valent-mixer-' + valent_api_version,
+libvalent_mixer = static_library('valent-mixer-@0@'.format(libvalent_api_version),
                                  libvalent_mixer_public_sources,
                                  libvalent_mixer_generated_sources,
                                  libvalent_mixer_generated_headers,

--- a/src/libvalent/notifications/meson.build
+++ b/src/libvalent/notifications/meson.build
@@ -39,7 +39,7 @@ libvalent_notifications_deps = [
 
 
 # Library Definitions
-libvalent_notifications = static_library('valent-notifications-' + valent_api_version,
+libvalent_notifications = static_library('valent-notifications-@0@'.format(libvalent_api_version),
                                          libvalent_notifications_public_sources,
                                          libvalent_notifications_generated_sources,
                                          libvalent_notifications_generated_headers,

--- a/src/libvalent/session/meson.build
+++ b/src/libvalent/session/meson.build
@@ -40,7 +40,7 @@ libvalent_session_deps = [
 
 
 # Library Definitions
-libvalent_session = static_library('valent-session-' + valent_api_version,
+libvalent_session = static_library('valent-session-@0@'.format(libvalent_api_version),
                                    libvalent_session_public_sources,
                                    libvalent_session_generated_sources,
                                    libvalent_session_generated_headers,

--- a/src/libvalent/ui/meson.build
+++ b/src/libvalent/ui/meson.build
@@ -81,7 +81,7 @@ libvalent_ui_deps = [
 
 
 # Library Definitions
-libvalent_ui = static_library('valent-ui-' + valent_api_version,
+libvalent_ui = static_library('valent-ui-@0@'.format(libvalent_api_version),
                               libvalent_ui_public_sources,
                               libvalent_ui_generated_sources,
                               libvalent_ui_generated_headers,

--- a/src/libvalent/ui/valent-device-gadget.c
+++ b/src/libvalent/ui/valent-device-gadget.c
@@ -7,34 +7,82 @@
 
 #include <gtk/gtk.h>
 #include <libvalent-core.h>
+#include <libvalent-device.h>
 
 #include "valent-device-gadget.h"
 
 
-/**
- * ValentDeviceGadget:
- *
- * An interface for small device widgets.
- *
- * #ValentDeviceGadget is an interface for plugins that want a small widget to
- * display controls, such as a battery level icon.
- *
- * Since: 1.0
- */
+typedef struct
+{
+  GtkWidget     parent_instance;
 
-G_DEFINE_INTERFACE (ValentDeviceGadget, valent_device_gadget, GTK_TYPE_WIDGET)
+  ValentDevice *device;
+} ValentDeviceGadgetPrivate;
 
-/**
- * ValentDeviceGadgetInterface:
- *
- * The virtual function table for #ValentDeviceGadget.
- *
- * Since: 1.0
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentDeviceGadget, valent_device_gadget, GTK_TYPE_WIDGET)
+
+
+enum {
+  PROP_0,
+  PROP_DEVICE,
+  N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { NULL, };
+
+
+/*
+ * GObject
  */
+static void
+valent_device_gadget_get_property (GObject    *object,
+                                   guint       prop_id,
+                                   GValue     *value,
+                                   GParamSpec *pspec)
+{
+  ValentDeviceGadget *self = VALENT_DEVICE_GADGET (object);
+  ValentDeviceGadgetPrivate *priv = valent_device_gadget_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE:
+      g_value_set_object (value, priv->device);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
 
 static void
-valent_device_gadget_default_init (ValentDeviceGadgetInterface *iface)
+valent_device_gadget_set_property (GObject      *object,
+                                   guint         prop_id,
+                                   const GValue *value,
+                                   GParamSpec   *pspec)
 {
+  ValentDeviceGadget *self = VALENT_DEVICE_GADGET (object);
+  ValentDeviceGadgetPrivate *priv = valent_device_gadget_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_DEVICE:
+      priv->device = g_value_get_object (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_device_gadget_class_init (ValentDeviceGadgetClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->get_property = valent_device_gadget_get_property;
+  object_class->set_property = valent_device_gadget_set_property;
+
   /**
    * ValentDeviceGadget:device:
    *
@@ -42,12 +90,21 @@ valent_device_gadget_default_init (ValentDeviceGadgetInterface *iface)
    *
    * Since: 1.0
    */
-  g_object_interface_install_property (iface,
-                                       g_param_spec_object ("device", NULL, NULL,
-                                                            G_TYPE_OBJECT,
-                                                            (G_PARAM_READWRITE |
-                                                             G_PARAM_CONSTRUCT_ONLY |
-                                                             G_PARAM_EXPLICIT_NOTIFY |
-                                                             G_PARAM_STATIC_STRINGS)));
+  properties [PROP_DEVICE] =
+    g_param_spec_object ("device", NULL, NULL,
+                         VALENT_TYPE_DEVICE,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+
+  gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
+}
+
+static void
+valent_device_gadget_init (ValentDeviceGadget *self)
+{
 }
 

--- a/src/libvalent/ui/valent-device-gadget.h
+++ b/src/libvalent/ui/valent-device-gadget.h
@@ -8,21 +8,21 @@
 #endif
 
 #include <gtk/gtk.h>
-#include <libvalent-core.h>
+#include <libvalent-device.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_DEVICE_GADGET (valent_device_gadget_get_type ())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_INTERFACE (ValentDeviceGadget, valent_device_gadget, VALENT, DEVICE_GADGET, GtkWidget)
+G_DECLARE_DERIVABLE_TYPE (ValentDeviceGadget, valent_device_gadget, VALENT, DEVICE_GADGET, GtkWidget)
 
-struct _ValentDeviceGadgetInterface
+struct _ValentDeviceGadgetClass
 {
-  GTypeInterface   g_iface;
+  GtkWidgetClass  parent_class;
 
   /*< private >*/
-  gpointer         padding[8];
+  gpointer        padding[8];
 };
 
 G_END_DECLS

--- a/src/main.c
+++ b/src/main.c
@@ -15,21 +15,21 @@ valent_plugin_init (void)
   PeasEngine *engine = peas_engine_get_default ();
   g_autofree char *xdg_plugin_dir = NULL;
 
+  /* The package plugin directory, typically `$LIBDIR/valent/plugins`. */
+  peas_engine_prepend_search_path (engine, VALENT_PLUGINSDIR, NULL);
+
   /* The user plugin directory as reported by XDG directories. If in a Flatpak,
    * this will be `~/.var/app/APPLICATION_ID/data/PACKAGE_NAME/plugins`. */
   xdg_plugin_dir = g_build_filename (g_get_user_data_dir (),
                                      PACKAGE_NAME, "plugins", NULL);
   peas_engine_prepend_search_path (engine, xdg_plugin_dir, NULL);
 
-  /* The package plugin directory, typically `$LIBDIR/valent/plugins`. */
-  peas_engine_prepend_search_path (engine, VALENT_PLUGINSDIR, NULL);
-
+  /* The real user plugin directory, regardless of XDG environment variables.
+   * This will always be `~/.local/share/PACKAGE_NAME/plugins`. */
   if (xdp_portal_running_under_flatpak ())
     {
       g_autofree char *real_plugin_dir = NULL;
 
-      /* The real user plugin directory, regardless XDG environment variables.
-       * This will always be `~/.local/share/PACKAGE_NAME/plugins`. */
       real_plugin_dir = g_build_filename (g_get_home_dir (), ".local", "share",
                                           PACKAGE_NAME, "plugins", NULL);
       peas_engine_prepend_search_path (engine, real_plugin_dir, NULL);

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,11 +12,11 @@ subdir('plugins')
 
 # Executable
 valent = executable('valent', 'main.c',
-              install: true,
-               c_args: valent_c_args + release_args,
-            link_args: valent_link_args,
-           link_whole: plugins_static,
-         dependencies: libvalent_dep,
-                  pie: true,
+        c_args: valent_c_args + release_args,
+     link_args: valent_link_args,
+    link_whole: plugins_static,
+  dependencies: libvalent_dep,
+       install: true,
+           pie: true,
 )
 

--- a/src/plugins/battery/valent-battery-gadget.c
+++ b/src/plugins/battery/valent-battery-gadget.c
@@ -18,26 +18,14 @@
 
 struct _ValentBatteryGadget
 {
-  GtkWidget     parent_instance;
+  ValentDeviceGadget  parent_instance;
 
-  ValentDevice *device;
-
-  GtkWidget    *button;
-  GtkWidget    *level_bar;
-  GtkWidget    *label;
+  GtkWidget          *button;
+  GtkWidget          *level_bar;
+  GtkWidget          *label;
 };
 
-static void valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface);
-
-G_DEFINE_TYPE_WITH_CODE (ValentBatteryGadget, valent_battery_gadget, GTK_TYPE_WIDGET,
-                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_GADGET, valent_device_gadget_iface_init))
-
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
+G_DEFINE_TYPE (ValentBatteryGadget, valent_battery_gadget, VALENT_TYPE_DEVICE_GADGET)
 
 
 static void
@@ -142,35 +130,28 @@ on_action_enabled_changed (GActionGroup        *action_group,
 }
 
 /*
- * ValentDeviceGadget
- */
-static void
-valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface)
-{
-}
-
-/*
  * GObject
  */
 static void
 valent_battery_gadget_constructed (GObject *object)
 {
   ValentBatteryGadget *self = VALENT_BATTERY_GADGET (object);
-  GActionGroup *action_group = G_ACTION_GROUP (self->device);
+  GActionGroup *action_group = NULL;
   gboolean enabled = FALSE;
 
-  g_signal_connect (action_group,
-                    "action-state-changed::battery.state",
-                    G_CALLBACK (on_action_state_changed),
-                    self);
-
-  g_signal_connect (action_group,
-                    "action-enabled-changed::battery.state",
-                    G_CALLBACK (on_action_enabled_changed),
-                    self);
+  g_object_get (object, "device", &action_group, NULL);
+  g_signal_connect_object (action_group,
+                           "action-state-changed::battery.state",
+                           G_CALLBACK (on_action_state_changed),
+                           self, 0);
+  g_signal_connect_object (action_group,
+                           "action-enabled-changed::battery.state",
+                           G_CALLBACK (on_action_enabled_changed),
+                           self, 0);
 
   enabled = g_action_group_get_action_enabled (action_group, "battery.state");
   on_action_enabled_changed (action_group, "battery.state", enabled, self);
+  g_clear_object (&action_group);
 
   G_OBJECT_CLASS (valent_battery_gadget_parent_class)->constructed (object);
 }
@@ -180,64 +161,18 @@ valent_battery_gadget_dispose (GObject *object)
 {
   ValentBatteryGadget *self = VALENT_BATTERY_GADGET (object);
 
-  g_signal_handlers_disconnect_by_data (self->device, self);
   g_clear_pointer (&self->button, gtk_widget_unparent);
 
   G_OBJECT_CLASS (valent_battery_gadget_parent_class)->dispose (object);
 }
 
 static void
-valent_battery_gadget_get_property (GObject    *object,
-                                    guint       prop_id,
-                                    GValue     *value,
-                                    GParamSpec *pspec)
-{
-  ValentBatteryGadget *self = VALENT_BATTERY_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_battery_gadget_set_property (GObject      *object,
-                                    guint         prop_id,
-                                    const GValue *value,
-                                    GParamSpec   *pspec)
-{
-  ValentBatteryGadget *self = VALENT_BATTERY_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_battery_gadget_class_init (ValentBatteryGadgetClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
-  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_battery_gadget_constructed;
   object_class->dispose = valent_battery_gadget_dispose;
-  object_class->get_property = valent_battery_gadget_get_property;
-  object_class->set_property = valent_battery_gadget_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
-
-  gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
 }
 
 static void

--- a/src/plugins/battery/valent-battery-gadget.h
+++ b/src/plugins/battery/valent-battery-gadget.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include <gtk/gtk.h>
+#include <libvalent-ui.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_BATTERY_GADGET (valent_battery_gadget_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentBatteryGadget, valent_battery_gadget, VALENT, BATTERY_GADGET, GtkWidget)
+G_DECLARE_FINAL_TYPE (ValentBatteryGadget, valent_battery_gadget, VALENT, BATTERY_GADGET, ValentDeviceGadget)
 
 G_END_DECLS

--- a/src/plugins/connectivity_report/valent-connectivity_report-gadget.h
+++ b/src/plugins/connectivity_report/valent-connectivity_report-gadget.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include <gtk/gtk.h>
+#include <libvalent-ui.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CONNECTIVITY_REPORT_GADGET (valent_connectivity_report_gadget_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentConnectivityReportGadget, valent_connectivity_report_gadget, VALENT, CONNECTIVITY_REPORT_GADGET, GtkWidget)
+G_DECLARE_FINAL_TYPE (ValentConnectivityReportGadget, valent_connectivity_report_gadget, VALENT, CONNECTIVITY_REPORT_GADGET, ValentDeviceGadget)
 
 G_END_DECLS

--- a/src/plugins/lock/valent-lock-gadget.c
+++ b/src/plugins/lock/valent-lock-gadget.c
@@ -16,34 +16,14 @@
 
 struct _ValentLockGadget
 {
-  GtkWidget     parent_instance;
-
-  ValentDevice *device;
+  ValentDeviceGadget  parent_instance;
 
   /* widgets */
-  GtkWidget    *button;
+  GtkWidget          *button;
 };
 
-static void valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface);
+G_DEFINE_TYPE (ValentLockGadget, valent_lock_gadget, VALENT_TYPE_DEVICE_GADGET)
 
-G_DEFINE_TYPE_WITH_CODE (ValentLockGadget, valent_lock_gadget, GTK_TYPE_WIDGET,
-                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_GADGET, valent_device_gadget_iface_init))
-
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
-
-
-/*
- * ValentDeviceGadget
- */
-static void
-valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface)
-{
-}
 
 /*
  * GObject
@@ -59,56 +39,11 @@ valent_lock_gadget_dispose (GObject *object)
 }
 
 static void
-valent_lock_gadget_get_property (GObject    *object,
-                                 guint       prop_id,
-                                 GValue     *value,
-                                 GParamSpec *pspec)
-{
-  ValentLockGadget *self = VALENT_LOCK_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_lock_gadget_set_property (GObject      *object,
-                                 guint         prop_id,
-                                 const GValue *value,
-                                 GParamSpec   *pspec)
-{
-  ValentLockGadget *self = VALENT_LOCK_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_lock_gadget_class_init (ValentLockGadgetClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
-  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->dispose = valent_lock_gadget_dispose;
-  object_class->get_property = valent_lock_gadget_get_property;
-  object_class->set_property = valent_lock_gadget_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
-
-  gtk_widget_class_set_layout_manager_type (widget_class, GTK_TYPE_BIN_LAYOUT);
 }
 
 static void

--- a/src/plugins/lock/valent-lock-gadget.h
+++ b/src/plugins/lock/valent-lock-gadget.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include <gtk/gtk.h>
+#include <libvalent-ui.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_LOCK_GADGET (valent_lock_gadget_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentLockGadget, valent_lock_gadget, VALENT, LOCK_GADGET, GtkWidget)
+G_DECLARE_FINAL_TYPE (ValentLockGadget, valent_lock_gadget, VALENT, LOCK_GADGET, ValentDeviceGadget)
 
 G_END_DECLS

--- a/tests/extra/ci-runner.sh
+++ b/tests/extra/ci-runner.sh
@@ -105,8 +105,8 @@ cx_suite_abidiff() {
             --no-added-syms \
             --headers-dir1 "${BASE_DIR}/usr/include" \
             --headers-dir2 "${HEAD_DIR}/usr/include" \
-            "${BASE_DIR}/usr/lib/libvalent.so" \
-            "${HEAD_DIR}/usr/lib/libvalent.so" > \
+            "${BASE_DIR}/usr/lib/libvalent-1.so" \
+            "${HEAD_DIR}/usr/lib/libvalent-1.so" > \
             "${BUILDDIR}/meson-logs/abidiff.log" || \
     (cat "${BUILDDIR}/meson-logs/abidiff.log" && exit 1);
 }

--- a/tests/fixtures/meson.build
+++ b/tests/fixtures/meson.build
@@ -74,7 +74,7 @@ endif
 
 
 # Library Definitions
-libvalent_test = static_library('valent-test-' + valent_api_version,
+libvalent_test = static_library('valent-test-@0@'.format(libvalent_api_version),
                                 libvalent_test_public_sources,
                                 libvalent_test_generated_sources,
                                 libvalent_test_generated_headers,

--- a/tests/fixtures/valent-mock-device-gadget.c
+++ b/tests/fixtures/valent-mock-device-gadget.c
@@ -5,8 +5,6 @@
 
 #include "config.h"
 
-#include <gtk/gtk.h>
-#include <libvalent-core.h>
 #include <libvalent-ui.h>
 
 #include "valent-mock-device-gadget.h"
@@ -14,82 +12,18 @@
 
 struct _ValentMockDeviceGadget
 {
-  GtkWidget     parent_instance;
-
-  ValentDevice *device;
+  ValentDeviceGadget  parent_instance;
 };
 
-static void valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface);
+G_DEFINE_TYPE (ValentMockDeviceGadget, valent_mock_device_gadget, VALENT_TYPE_DEVICE_GADGET)
 
-G_DEFINE_TYPE_WITH_CODE (ValentMockDeviceGadget, valent_mock_device_gadget, GTK_TYPE_WIDGET,
-                         G_IMPLEMENT_INTERFACE (VALENT_TYPE_DEVICE_GADGET, valent_device_gadget_iface_init))
-
-
-enum {
-  PROP_0,
-  PROP_DEVICE,
-  N_PROPERTIES
-};
-
-
-/*
- * ValentDeviceGadget
- */
-static void
-valent_device_gadget_iface_init (ValentDeviceGadgetInterface *iface)
-{
-}
 
 /*
  * GObject
  */
 static void
-valent_mock_device_gadget_get_property (GObject    *object,
-                                        guint       prop_id,
-                                        GValue     *value,
-                                        GParamSpec *pspec)
-{
-  ValentMockDeviceGadget *self = VALENT_MOCK_DEVICE_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      g_value_set_object (value, self->device);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_mock_device_gadget_set_property (GObject      *object,
-                                        guint         prop_id,
-                                        const GValue *value,
-                                        GParamSpec   *pspec)
-{
-  ValentMockDeviceGadget *self = VALENT_MOCK_DEVICE_GADGET (object);
-
-  switch (prop_id)
-    {
-    case PROP_DEVICE:
-      self->device = g_value_get_object (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_mock_device_gadget_class_init (ValentMockDeviceGadgetClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  object_class->get_property = valent_mock_device_gadget_get_property;
-  object_class->set_property = valent_mock_device_gadget_set_property;
-
-  g_object_class_override_property (object_class, PROP_DEVICE, "device");
 }
 
 static void

--- a/tests/fixtures/valent-mock-device-gadget.h
+++ b/tests/fixtures/valent-mock-device-gadget.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include <gtk/gtk.h>
+#include <libvalent-ui.h>
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_MOCK_DEVICE_GADGET (valent_mock_device_gadget_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentMockDeviceGadget, valent_mock_device_gadget, VALENT, MOCK_DEVICE_GADGET, GtkWidget)
+G_DECLARE_FINAL_TYPE (ValentMockDeviceGadget, valent_mock_device_gadget, VALENT, MOCK_DEVICE_GADGET, ValentDeviceGadget)
 
 G_END_DECLS


### PR DESCRIPTION
Since we depend on libportal anyways, move the singleton to the global utilities so it can be used by other sub-libraries and plugins.