### PR TITLE
build(deps): bump GLib to 2.76 and GTK to 4.10

### DIFF
--- a/build-aux/contrib/valent.spec
+++ b/build-aux/contrib/valent.spec
@@ -1,7 +1,7 @@
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
-%global glib2_version >= 2.72.0
-%global gtk4_version >= 4.8.0
+%global glib2_version >= 2.76.0
+%global gtk4_version >= 4.10.0
 %global json_glib_version >= 1.6.0
 %global libpeas_version >= 1.22.0
 %global libeds_version >= 3.34.0
@@ -115,7 +115,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_libexecdir}/installed-tests/libvalent-1/
 
 %changelog
-* Thu Mar 23 2023 Andy Holmes <andrew.g.r.holmes@gmail.com> - 1.0.0~alpha
+* Fri Jun 2 2023 Andy Holmes <andrew.g.r.holmes@gmail.com> - 1.0.0~alpha
 
 - Initial packaging
 

--- a/meson.build
+++ b/meson.build
@@ -90,9 +90,9 @@ project_c_args = [
   '-Wno-unused-parameter',
 
   # These should be kept in sync (eg. GTK 4.10 requires GLib 2.72)
-  '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_72',
-  '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_72',
-  '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_8',
+  '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_76',
+  '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_76',
+  '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_10',
 ]
 project_link_args = [
   '-Wl,-z,relro',
@@ -174,8 +174,8 @@ configure_file(
 #
 # Dependencies
 #
-gio_version = '>= 2.72.0'
-gtk_version = '>= 4.8.0'
+glib_version = '>= 2.76.0'
+gtk_version = '>= 4.10.0'
 gnutls_version = '>= 3.1.3'
 json_glib_version = '>= 1.6.0'
 libpeas_version = '>= 1.22.0'
@@ -185,8 +185,8 @@ libadwaita_version = '>= 1.2.0'
 libportal_version = ['>= 0.5', '<= 0.6']
 
 libm_dep = cc.find_library('m', required: true)
-gio_dep = dependency('gio-2.0', version: gio_version)
-gio_unix_dep = dependency('gio-unix-2.0', version: gio_version)
+gio_dep = dependency('gio-2.0', version: glib_version)
+gio_unix_dep = dependency('gio-unix-2.0', version: glib_version)
 gnutls_dep = dependency('gnutls', version: gnutls_version)
 json_glib_dep = dependency('json-glib-1.0', version: json_glib_version)
 libpeas_dep = dependency('libpeas-1.0', version: libpeas_version)

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-04-12 23:01-0700\n"
+"POT-Creation-Date: 2023-06-03 12:35-0700\n"
 "PO-Revision-Date: 2022-03-28 11:21-0700\n"
 "Last-Translator: Andy Holmes <andrew.g.r.holmes@gmail.com>\n"
 "Language-Team: English <andrew.g.r.holmes@gmail.com>\n"
@@ -27,7 +27,7 @@ msgid "Whether the device is paired"
 msgstr ""
 
 #: data/gsettings/ca.andyholmes.Valent.gschema.xml:10
-#: src/plugins/runcommand/valent-runcommand-editor.ui:44
+#: src/plugins/runcommand/valent-runcommand-editor.ui:39
 msgid "Name"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgstr ""
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:330 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
 msgid "Valent"
 msgstr ""
 
@@ -107,17 +107,17 @@ msgstr ""
 msgid "Andy Holmes"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:517
+#: src/libvalent/device/valent-device.c:512
 #, c-format
 msgid "Pairing request from %s"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:528
+#: src/libvalent/device/valent-device.c:523
 #: src/libvalent/ui/valent-device-page.ui:143
 msgid "Reject"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:534
+#: src/libvalent/device/valent-device.c:529
 #: src/libvalent/ui/valent-device-page.ui:156
 msgid "Accept"
 msgstr ""
@@ -128,8 +128,8 @@ msgid "Unavailable"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-page.ui:21
-#: src/libvalent/ui/valent-media-remote.ui:233
-#: src/libvalent/ui/valent-menu-list.c:523
+#: src/libvalent/ui/valent-media-remote.ui:239
+#: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr ""
@@ -190,8 +190,8 @@ msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
-#: src/libvalent/ui/valent-media-remote.ui:404
-#: src/libvalent/ui/valent-media-remote.ui:419
+#: src/libvalent/ui/valent-media-remote.ui:408
+#: src/libvalent/ui/valent-media-remote.ui:423
 msgid "Enable Repeat"
 msgstr ""
 
@@ -212,90 +212,90 @@ msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:314
 #: src/libvalent/ui/valent-media-remote.c:316
-#: src/libvalent/ui/valent-media-remote.ui:270
-#: src/libvalent/ui/valent-media-remote.ui:285
+#: src/libvalent/ui/valent-media-remote.ui:275
+#: src/libvalent/ui/valent-media-remote.ui:290
 msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:105
+#: src/libvalent/ui/valent-window.ui:113
 msgid "Media Remote"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:213
+#: src/libvalent/ui/valent-media-remote.ui:219
 #: src/plugins/telephony/valent-telephony-preferences.ui:15
 #: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "Volume"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:243
-#: src/libvalent/ui/valent-media-remote.ui:260
+#: src/libvalent/ui/valent-media-remote.ui:248
+#: src/libvalent/ui/valent-media-remote.ui:265
 msgid "Seek Back"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:295
-#: src/libvalent/ui/valent-media-remote.ui:312
+#: src/libvalent/ui/valent-media-remote.ui:300
+#: src/libvalent/ui/valent-media-remote.ui:317
 msgid "Seek Forward"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:322
-#: src/libvalent/ui/valent-media-remote.ui:337
+#: src/libvalent/ui/valent-media-remote.ui:327
+#: src/libvalent/ui/valent-media-remote.ui:342
 #: src/plugins/presenter/valent-presenter-remote.ui:151
 msgid "Next"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:347
-#: src/libvalent/ui/valent-media-remote.ui:361
+#: src/libvalent/ui/valent-media-remote.ui:351
+#: src/libvalent/ui/valent-media-remote.ui:365
 msgid "Options"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:428
-#: src/libvalent/ui/valent-media-remote.ui:443
+#: src/libvalent/ui/valent-media-remote.ui:432
+#: src/libvalent/ui/valent-media-remote.ui:447
 msgid "Shuffle"
 msgstr ""
 
-#: src/libvalent/ui/valent-menu-list.c:383
+#: src/libvalent/ui/valent-menu-list.c:529
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:373
+#: src/libvalent/ui/valent-preferences-window.c:375
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:380
+#: src/libvalent/ui/valent-preferences-window.c:382
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:387
+#: src/libvalent/ui/valent-preferences-window.c:389
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:394
+#: src/libvalent/ui/valent-preferences-window.c:396
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:401
+#: src/libvalent/ui/valent-preferences-window.c:403
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:408
+#: src/libvalent/ui/valent-preferences-window.c:410
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:415
+#: src/libvalent/ui/valent-preferences-window.c:417
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:422
+#: src/libvalent/ui/valent-preferences-window.c:424
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:63
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:429
+#: src/libvalent/ui/valent-preferences-window.c:431
 msgid "Session Manager"
 msgstr ""
 
@@ -416,37 +416,41 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.c:339
+#: src/libvalent/ui/valent-window.c:345
 msgid "translator-credits"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.c:344
+#: src/libvalent/ui/valent-window.c:350
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:44
+#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
 msgid "Refresh"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:71
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+msgid "Main Menu"
+msgstr ""
+
+#: src/libvalent/ui/valent-window.ui:79
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:87
 msgid "Searching for devices…"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:111
+#: src/libvalent/ui/valent-window.ui:119
 msgid "Preferences"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:115
+#: src/libvalent/ui/valent-window.ui:123
 #: src/plugins/sms/valent-sms-window.ui:350
 msgid "About Valent"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:121
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Quit"
 msgstr ""
 
@@ -641,7 +645,7 @@ msgstr ""
 msgid "Find a device by making it ring"
 msgstr ""
 
-#: src/plugins/findmyphone/valent-findmyphone-plugin.c:59
+#: src/plugins/findmyphone/valent-findmyphone-plugin.c:112
 msgid "Ring"
 msgstr ""
 
@@ -682,7 +686,7 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:516
+#: src/plugins/mousepad/valent-mousepad-plugin.c:579
 msgid "Remote Input"
 msgstr ""
 
@@ -738,20 +742,23 @@ msgstr ""
 msgid "Notification"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-dialog.ui:15
-#: src/plugins/presenter/valent-presenter-remote.c:91
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/share/valent-share-plugin.c:140
-#: src/plugins/share/valent-share-plugin.c:263
-#: src/plugins/share/valent-share-plugin.c:365
-#: src/plugins/share/valent-share-plugin.c:505
-#: src/plugins/share/valent-share-plugin.c:669
-#: src/plugins/share/valent-share-preferences.c:91
-msgid "Cancel"
+#: src/plugins/notification/valent-notification-dialog.ui:19
+#: src/plugins/runcommand/valent-runcommand-editor.ui:17
+#: src/plugins/share/valent-share-target-chooser.ui:22
+msgid "_Cancel"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-dialog.ui:20
-msgid "Send"
+#: src/plugins/notification/valent-notification-dialog.ui:26
+msgid "_Reply"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:150
+#: src/plugins/share/valent-share-text-dialog.ui:53
+msgid "Close"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:151
+msgid "Close the notification"
 msgstr ""
 
 #: src/plugins/notification/valent-notification-preferences.ui:10
@@ -807,12 +814,12 @@ msgstr ""
 msgid "Transfer Failed"
 msgstr ""
 
-#: src/plugins/photo/valent-photo-plugin.c:137
+#: src/plugins/photo/valent-photo-plugin.c:188
 msgid "Take Photo"
 msgstr ""
 
 #: src/plugins/ping/ping.plugin.desktop.in:7
-#: src/plugins/ping/valent-ping-plugin.c:95
+#: src/plugins/ping/valent-ping-plugin.c:142
 msgid "Ping"
 msgstr ""
 
@@ -832,18 +839,18 @@ msgstr ""
 msgid "Control presentations"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-plugin.c:215
 #: src/plugins/presenter/valent-presenter-remote.ui:8
 msgid "Presentation Remote"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:89
+#: src/plugins/presenter/valent-presenter-remote.c:91
 msgid "Select Presentation"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.c:92
 #: src/plugins/presenter/valent-presenter-remote.ui:86
-#: src/plugins/share/valent-share-preferences.c:90
+#: src/plugins/share/valent-share-preferences.c:94
 msgid "Open"
 msgstr ""
 
@@ -851,7 +858,7 @@ msgstr ""
 msgid "Presentations"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:108
+#: src/plugins/presenter/valent-presenter-remote.c:107
 msgid "All Files"
 msgstr ""
 
@@ -884,29 +891,40 @@ msgid "Execute commands remotely"
 msgstr ""
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:256
-msgid "Edit"
+#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+msgid "Edit Command"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:17
-#: src/plugins/share/valent-share-text-dialog.ui:54
-msgid "Save"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:24
+msgid "_Save"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:70
+#: src/plugins/runcommand/valent-runcommand-editor.ui:48
 msgid "Command Line"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-plugin.c:329
-msgid "Run Command"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:63
+msgid "Remove the command"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-preferences.c:266
+#: src/plugins/runcommand/valent-runcommand-editor.ui:69
 msgid "Remove"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-preferences.ui:34
-msgid "Add Command…"
+#: src/plugins/runcommand/valent-runcommand-plugin.c:317
+msgid "Run Command"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:14
+msgid "Add a command"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:24
+msgid "Local Commands"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:25
+msgid "Commands that can be executed by remote devices"
 msgstr ""
 
 #: src/plugins/sftp/sftp.plugin.desktop.in:7
@@ -926,7 +944,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:591
+#: src/plugins/sftp/valent-sftp-plugin.c:658
 msgid "Browse Files"
 msgstr ""
 
@@ -984,6 +1002,13 @@ msgid_plural "Received %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/plugins/share/valent-share-plugin.c:140
+#: src/plugins/share/valent-share-plugin.c:263
+#: src/plugins/share/valent-share-plugin.c:365
+#: src/plugins/share/valent-share-plugin.c:505
+msgid "Cancel"
+msgstr ""
+
 #: src/plugins/share/valent-share-plugin.c:158
 msgid "Open Folder"
 msgstr ""
@@ -1029,20 +1054,20 @@ msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:667
+#: src/plugins/share/valent-share-plugin.c:673
 #: src/plugins/share/valent-share-target-chooser.ui:8
 msgid "Share Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:668
+#: src/plugins/share/valent-share-plugin.c:674
 msgid "Share"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:912
+#: src/plugins/share/valent-share-plugin.c:1221
 msgid "Send Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-preferences.c:89
+#: src/plugins/share/valent-share-preferences.c:93
 msgid "Select download folder"
 msgstr ""
 
@@ -1052,10 +1077,6 @@ msgstr ""
 
 #: src/plugins/share/valent-share-preferences.ui:11
 msgid "Where received files are stored"
-msgstr ""
-
-#: src/plugins/share/valent-share-target-chooser.ui:22
-msgid "_Cancel"
 msgstr ""
 
 #: src/plugins/share/valent-share-target-chooser.ui:29
@@ -1074,13 +1095,14 @@ msgstr ""
 msgid "Always use this device"
 msgstr ""
 
+#: src/plugins/share/valent-share-text-dialog.c:98
+#: src/plugins/share/valent-share-text-dialog.ui:54
+msgid "Save"
+msgstr ""
+
 #: src/plugins/share/valent-share-text-dialog.ui:8
 #: src/plugins/share/valent-share-text-dialog.ui:15
 msgid "Shared Text"
-msgstr ""
-
-#: src/plugins/share/valent-share-text-dialog.ui:53
-msgid "Close"
 msgstr ""
 
 #: src/plugins/share/valent-share-text-dialog.ui:55
@@ -1129,7 +1151,7 @@ msgstr[1] ""
 
 #: src/plugins/sms/valent-sms-conversation.c:904
 #: src/plugins/sms/valent-sms-window.c:602
-#: src/plugins/sms/valent-sms-window.c:914
+#: src/plugins/sms/valent-sms-window.c:922
 msgid "New Conversation"
 msgstr ""
 
@@ -1148,7 +1170,7 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-plugin.c:442
+#: src/plugins/sms/valent-sms-plugin.c:505
 msgid "Messaging"
 msgstr ""
 
@@ -1162,7 +1184,7 @@ msgid "Send to %s"
 msgstr ""
 
 #: src/plugins/sms/valent-sms-window.c:629
-#: src/plugins/sms/valent-sms-window.c:936
+#: src/plugins/sms/valent-sms-window.c:944
 msgid "Search Messages"
 msgstr ""
 
@@ -1284,7 +1306,7 @@ msgstr ""
 msgid "Lower"
 msgstr ""
 
-#: src/plugins/xdp/valent-xdp-background.c:86
+#: src/plugins/xdp/valent-xdp-background.c:90
 msgid "Valent wants to run as a service"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-04-12 23:01-0700\n"
+"POT-Creation-Date: 2023-06-03 12:35-0700\n"
 "PO-Revision-Date: 2023-03-04 17:28+0100\n"
 "Last-Translator: Valérie Roux <vxlerieuwu@unixgirl.xyz>\n"
 "Language-Team: French <vxlerieuwu@unixgirl.xyz>\n"
@@ -29,7 +29,7 @@ msgid "Whether the device is paired"
 msgstr "Si l'appareil est lié"
 
 #: data/gsettings/ca.andyholmes.Valent.gschema.xml:10
-#: src/plugins/runcommand/valent-runcommand-editor.ui:44
+#: src/plugins/runcommand/valent-runcommand-editor.ui:39
 msgid "Name"
 msgstr "Nom"
 
@@ -48,7 +48,7 @@ msgstr "Si l'extension est activée ou non"
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:330 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
 msgid "Valent"
 msgstr "Valent"
 
@@ -115,17 +115,17 @@ msgstr "Liez et connectez vos appareils"
 msgid "Andy Holmes"
 msgstr "Andy Holmes"
 
-#: src/libvalent/device/valent-device.c:517
+#: src/libvalent/device/valent-device.c:512
 #, c-format
 msgid "Pairing request from %s"
 msgstr "Demande de liaison de %s"
 
-#: src/libvalent/device/valent-device.c:528
+#: src/libvalent/device/valent-device.c:523
 #: src/libvalent/ui/valent-device-page.ui:143
 msgid "Reject"
 msgstr "Refuser"
 
-#: src/libvalent/device/valent-device.c:534
+#: src/libvalent/device/valent-device.c:529
 #: src/libvalent/ui/valent-device-page.ui:156
 msgid "Accept"
 msgstr "Accepter"
@@ -136,8 +136,8 @@ msgid "Unavailable"
 msgstr "Indisponible"
 
 #: src/libvalent/ui/valent-device-page.ui:21
-#: src/libvalent/ui/valent-media-remote.ui:233
-#: src/libvalent/ui/valent-menu-list.c:523
+#: src/libvalent/ui/valent-media-remote.ui:239
+#: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr "Précédent"
@@ -201,8 +201,8 @@ msgstr "Pas d'extensions"
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
-#: src/libvalent/ui/valent-media-remote.ui:404
-#: src/libvalent/ui/valent-media-remote.ui:419
+#: src/libvalent/ui/valent-media-remote.ui:408
+#: src/libvalent/ui/valent-media-remote.ui:423
 #, fuzzy
 msgid "Enable Repeat"
 msgstr "Répéter"
@@ -226,91 +226,91 @@ msgstr "Pause"
 
 #: src/libvalent/ui/valent-media-remote.c:314
 #: src/libvalent/ui/valent-media-remote.c:316
-#: src/libvalent/ui/valent-media-remote.ui:270
-#: src/libvalent/ui/valent-media-remote.ui:285
+#: src/libvalent/ui/valent-media-remote.ui:275
+#: src/libvalent/ui/valent-media-remote.ui:290
 msgid "Play"
 msgstr "Jouer"
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:105
+#: src/libvalent/ui/valent-window.ui:113
 msgid "Media Remote"
 msgstr "Télécommande média"
 
-#: src/libvalent/ui/valent-media-remote.ui:213
+#: src/libvalent/ui/valent-media-remote.ui:219
 #: src/plugins/telephony/valent-telephony-preferences.ui:15
 #: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "Volume"
 msgstr "Volume"
 
-#: src/libvalent/ui/valent-media-remote.ui:243
-#: src/libvalent/ui/valent-media-remote.ui:260
+#: src/libvalent/ui/valent-media-remote.ui:248
+#: src/libvalent/ui/valent-media-remote.ui:265
 msgid "Seek Back"
 msgstr "Reculer d'un pas"
 
-#: src/libvalent/ui/valent-media-remote.ui:295
-#: src/libvalent/ui/valent-media-remote.ui:312
+#: src/libvalent/ui/valent-media-remote.ui:300
+#: src/libvalent/ui/valent-media-remote.ui:317
 msgid "Seek Forward"
 msgstr "Avancer d'un pas"
 
-#: src/libvalent/ui/valent-media-remote.ui:322
-#: src/libvalent/ui/valent-media-remote.ui:337
+#: src/libvalent/ui/valent-media-remote.ui:327
+#: src/libvalent/ui/valent-media-remote.ui:342
 #: src/plugins/presenter/valent-presenter-remote.ui:151
 msgid "Next"
 msgstr "Suivant"
 
-#: src/libvalent/ui/valent-media-remote.ui:347
-#: src/libvalent/ui/valent-media-remote.ui:361
+#: src/libvalent/ui/valent-media-remote.ui:351
+#: src/libvalent/ui/valent-media-remote.ui:365
 #, fuzzy
 msgid "Options"
 msgstr "Applications"
 
-#: src/libvalent/ui/valent-media-remote.ui:428
-#: src/libvalent/ui/valent-media-remote.ui:443
+#: src/libvalent/ui/valent-media-remote.ui:432
+#: src/libvalent/ui/valent-media-remote.ui:447
 msgid "Shuffle"
 msgstr "Aléatoire"
 
-#: src/libvalent/ui/valent-menu-list.c:383
+#: src/libvalent/ui/valent-menu-list.c:529
 msgid "No Actions"
 msgstr "Aucune action"
 
-#: src/libvalent/ui/valent-preferences-window.c:373
+#: src/libvalent/ui/valent-preferences-window.c:375
 msgid "Global"
 msgstr "Global"
 
-#: src/libvalent/ui/valent-preferences-window.c:380
+#: src/libvalent/ui/valent-preferences-window.c:382
 msgid "Device Connections"
 msgstr "Connexions"
 
-#: src/libvalent/ui/valent-preferences-window.c:387
+#: src/libvalent/ui/valent-preferences-window.c:389
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr "Presse-papiers"
 
-#: src/libvalent/ui/valent-preferences-window.c:394
+#: src/libvalent/ui/valent-preferences-window.c:396
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr "Contacts"
 
-#: src/libvalent/ui/valent-preferences-window.c:401
+#: src/libvalent/ui/valent-preferences-window.c:403
 msgid "Mouse and Keyboard"
 msgstr "Souris et clavier"
 
-#: src/libvalent/ui/valent-preferences-window.c:408
+#: src/libvalent/ui/valent-preferences-window.c:410
 msgid "Media Players"
 msgstr "Lecteurs média"
 
-#: src/libvalent/ui/valent-preferences-window.c:415
+#: src/libvalent/ui/valent-preferences-window.c:417
 msgid "Volume Control"
 msgstr "Contrôle du volume"
 
-#: src/libvalent/ui/valent-preferences-window.c:422
+#: src/libvalent/ui/valent-preferences-window.c:424
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:63
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/libvalent/ui/valent-preferences-window.c:429
+#: src/libvalent/ui/valent-preferences-window.c:431
 msgid "Session Manager"
 msgstr "Gestion de session"
 
@@ -431,37 +431,42 @@ msgstr "Non associé"
 msgid "Connected"
 msgstr "Connecté"
 
-#: src/libvalent/ui/valent-window.c:339
+#: src/libvalent/ui/valent-window.c:345
 msgid "translator-credits"
 msgstr "Valérie Roux <vxlerieuwu@unixgirl.xyz>"
 
-#: src/libvalent/ui/valent-window.c:344
+#: src/libvalent/ui/valent-window.c:350
 msgid "Sponsors"
 msgstr "Sponsors"
 
-#: src/libvalent/ui/valent-window.ui:44
+#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: src/libvalent/ui/valent-window.ui:71
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#, fuzzy
+msgid "Main Menu"
+msgstr "Nom de l'appareil"
+
+#: src/libvalent/ui/valent-window.ui:79
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr "Appareils"
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:87
 msgid "Searching for devices…"
 msgstr "Recherche d'appareils"
 
-#: src/libvalent/ui/valent-window.ui:111
+#: src/libvalent/ui/valent-window.ui:119
 msgid "Preferences"
 msgstr "Paramètres"
 
-#: src/libvalent/ui/valent-window.ui:115
+#: src/libvalent/ui/valent-window.ui:123
 #: src/plugins/sms/valent-sms-window.ui:350
 msgid "About Valent"
 msgstr "À propos de Valent"
 
-#: src/libvalent/ui/valent-window.ui:121
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Quit"
 msgstr "Quitter"
 
@@ -671,7 +676,7 @@ msgstr "Trouver mon téléphone"
 msgid "Find a device by making it ring"
 msgstr "Trouver un appareil en le faisant sonner"
 
-#: src/plugins/findmyphone/valent-findmyphone-plugin.c:59
+#: src/plugins/findmyphone/valent-findmyphone-plugin.c:112
 msgid "Ring"
 msgstr "Sonner"
 
@@ -712,7 +717,7 @@ msgstr "Tapis de souris"
 msgid "Control the mouse and keyboard"
 msgstr "Contrôler la souris et le clavier"
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:516
+#: src/plugins/mousepad/valent-mousepad-plugin.c:579
 msgid "Remote Input"
 msgstr "Entrée distante"
 
@@ -768,21 +773,25 @@ msgstr "Synchroniser les notifications"
 msgid "Notification"
 msgstr "Notification"
 
-#: src/plugins/notification/valent-notification-dialog.ui:15
-#: src/plugins/presenter/valent-presenter-remote.c:91
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/share/valent-share-plugin.c:140
-#: src/plugins/share/valent-share-plugin.c:263
-#: src/plugins/share/valent-share-plugin.c:365
-#: src/plugins/share/valent-share-plugin.c:505
-#: src/plugins/share/valent-share-plugin.c:669
-#: src/plugins/share/valent-share-preferences.c:91
-msgid "Cancel"
+#: src/plugins/notification/valent-notification-dialog.ui:19
+#: src/plugins/runcommand/valent-runcommand-editor.ui:17
+#: src/plugins/share/valent-share-target-chooser.ui:22
+msgid "_Cancel"
 msgstr "Annuler"
 
-#: src/plugins/notification/valent-notification-dialog.ui:20
-msgid "Send"
-msgstr "Envoyer"
+#: src/plugins/notification/valent-notification-dialog.ui:26
+msgid "_Reply"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:150
+#: src/plugins/share/valent-share-text-dialog.ui:53
+msgid "Close"
+msgstr "Fermer"
+
+#: src/plugins/notification/valent-notification-dialog.ui:151
+#, fuzzy
+msgid "Close the notification"
+msgstr "Notifications d'appel et de SMS"
 
 #: src/plugins/notification/valent-notification-preferences.ui:10
 #, fuzzy
@@ -842,12 +851,12 @@ msgstr "Échec de récéption de “%s” depuis %s"
 msgid "Transfer Failed"
 msgstr "Échec du transfert"
 
-#: src/plugins/photo/valent-photo-plugin.c:137
+#: src/plugins/photo/valent-photo-plugin.c:188
 msgid "Take Photo"
 msgstr "Prendre une photo"
 
 #: src/plugins/ping/ping.plugin.desktop.in:7
-#: src/plugins/ping/valent-ping-plugin.c:95
+#: src/plugins/ping/valent-ping-plugin.c:142
 msgid "Ping"
 msgstr "Ping"
 
@@ -867,18 +876,18 @@ msgstr "Présentations"
 msgid "Control presentations"
 msgstr "Contrôle des présentations"
 
-#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-plugin.c:215
 #: src/plugins/presenter/valent-presenter-remote.ui:8
 msgid "Presentation Remote"
 msgstr "Télécommande des présentations"
 
-#: src/plugins/presenter/valent-presenter-remote.c:89
+#: src/plugins/presenter/valent-presenter-remote.c:91
 msgid "Select Presentation"
 msgstr "Sélectionner la présentation"
 
-#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.c:92
 #: src/plugins/presenter/valent-presenter-remote.ui:86
-#: src/plugins/share/valent-share-preferences.c:90
+#: src/plugins/share/valent-share-preferences.c:94
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -886,7 +895,7 @@ msgstr "Ouvrir"
 msgid "Presentations"
 msgstr "Présentations"
 
-#: src/plugins/presenter/valent-presenter-remote.c:108
+#: src/plugins/presenter/valent-presenter-remote.c:107
 msgid "All Files"
 msgstr "Tous les fichiers"
 
@@ -919,30 +928,47 @@ msgid "Execute commands remotely"
 msgstr "Exécuter des commandes à distance"
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:256
-msgid "Edit"
-msgstr "Modifier"
+#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#, fuzzy
+msgid "Edit Command"
+msgstr "Commandes"
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:17
-#: src/plugins/share/valent-share-text-dialog.ui:54
-msgid "Save"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:24
+#, fuzzy
+msgid "_Save"
 msgstr "Enregistrer"
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:70
+#: src/plugins/runcommand/valent-runcommand-editor.ui:48
 msgid "Command Line"
 msgstr "Ligne de commande"
 
-#: src/plugins/runcommand/valent-runcommand-plugin.c:329
-msgid "Run Command"
-msgstr "Exécuter la commande"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:63
+msgid "Remove the command"
+msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-preferences.c:266
+#: src/plugins/runcommand/valent-runcommand-editor.ui:69
 msgid "Remove"
 msgstr "Supprimer"
 
-#: src/plugins/runcommand/valent-runcommand-preferences.ui:34
-msgid "Add Command…"
+#: src/plugins/runcommand/valent-runcommand-plugin.c:317
+msgid "Run Command"
+msgstr "Exécuter la commande"
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:14
+#, fuzzy
+msgid "Add a command"
 msgstr "Ajouter une commande..."
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:24
+#, fuzzy
+msgid "Local Commands"
+msgstr "Commandes"
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:25
+#, fuzzy
+msgid "Commands that can be executed by remote devices"
+msgstr ""
+"Définir les commandes qui peuvent être exécutées par l'appareil distant."
 
 #: src/plugins/sftp/sftp.plugin.desktop.in:7
 #, fuzzy
@@ -963,7 +989,7 @@ msgstr "Accueil"
 msgid "Permission denied"
 msgstr "Permission non accordée"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:591
+#: src/plugins/sftp/valent-sftp-plugin.c:658
 msgid "Browse Files"
 msgstr "Parcourir les fichiers"
 
@@ -1028,6 +1054,13 @@ msgid_plural "Received %2$d files from %1$s"
 msgstr[0] "Fichier reçu de %1$s"
 msgstr[1] "%2$d fichiers reçu de %1$s"
 
+#: src/plugins/share/valent-share-plugin.c:140
+#: src/plugins/share/valent-share-plugin.c:263
+#: src/plugins/share/valent-share-plugin.c:365
+#: src/plugins/share/valent-share-plugin.c:505
+msgid "Cancel"
+msgstr "Annuler"
+
 #: src/plugins/share/valent-share-plugin.c:158
 msgid "Open Folder"
 msgstr "Ouvrir le dossier"
@@ -1073,20 +1106,20 @@ msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] "Un fichier envoyé vers %1$s"
 msgstr[1] "%2$d fichiers envoyés vers %1$s"
 
-#: src/plugins/share/valent-share-plugin.c:667
+#: src/plugins/share/valent-share-plugin.c:673
 #: src/plugins/share/valent-share-target-chooser.ui:8
 msgid "Share Files"
 msgstr "Partager des fichiers"
 
-#: src/plugins/share/valent-share-plugin.c:668
+#: src/plugins/share/valent-share-plugin.c:674
 msgid "Share"
 msgstr "Partager"
 
-#: src/plugins/share/valent-share-plugin.c:912
+#: src/plugins/share/valent-share-plugin.c:1221
 msgid "Send Files"
 msgstr "Envoyer des fichiers"
 
-#: src/plugins/share/valent-share-preferences.c:89
+#: src/plugins/share/valent-share-preferences.c:93
 msgid "Select download folder"
 msgstr "Sélectionner le dossier de téléchargement"
 
@@ -1097,10 +1130,6 @@ msgstr "Dossier de téléchargement"
 #: src/plugins/share/valent-share-preferences.ui:11
 msgid "Where received files are stored"
 msgstr "Où les fichiers entrants sont stockés"
-
-#: src/plugins/share/valent-share-target-chooser.ui:22
-msgid "_Cancel"
-msgstr "Annuler"
 
 #: src/plugins/share/valent-share-target-chooser.ui:29
 msgid "_Share"
@@ -1118,14 +1147,15 @@ msgstr "Recherche..."
 msgid "Always use this device"
 msgstr "Toujours utiliser cet appareil"
 
+#: src/plugins/share/valent-share-text-dialog.c:98
+#: src/plugins/share/valent-share-text-dialog.ui:54
+msgid "Save"
+msgstr "Enregistrer"
+
 #: src/plugins/share/valent-share-text-dialog.ui:8
 #: src/plugins/share/valent-share-text-dialog.ui:15
 msgid "Shared Text"
 msgstr "Texte partagé"
-
-#: src/plugins/share/valent-share-text-dialog.ui:53
-msgid "Close"
-msgstr "Fermer"
 
 #: src/plugins/share/valent-share-text-dialog.ui:55
 msgid "Copy"
@@ -1173,7 +1203,7 @@ msgstr[1] "%d mins"
 
 #: src/plugins/sms/valent-sms-conversation.c:904
 #: src/plugins/sms/valent-sms-window.c:602
-#: src/plugins/sms/valent-sms-window.c:914
+#: src/plugins/sms/valent-sms-window.c:922
 msgid "New Conversation"
 msgstr "Nouvelle conversation"
 
@@ -1192,7 +1222,7 @@ msgstr "Envoyer le message"
 msgid "Type a message"
 msgstr "Entrez un message"
 
-#: src/plugins/sms/valent-sms-plugin.c:442
+#: src/plugins/sms/valent-sms-plugin.c:505
 msgid "Messaging"
 msgstr "Messagerie"
 
@@ -1206,7 +1236,7 @@ msgid "Send to %s"
 msgstr "Envoyer à %s"
 
 #: src/plugins/sms/valent-sms-window.c:629
-#: src/plugins/sms/valent-sms-window.c:936
+#: src/plugins/sms/valent-sms-window.c:944
 msgid "Search Messages"
 msgstr "Chercher un message"
 
@@ -1330,7 +1360,7 @@ msgstr "Rien"
 msgid "Lower"
 msgstr "Baisser"
 
-#: src/plugins/xdp/valent-xdp-background.c:86
+#: src/plugins/xdp/valent-xdp-background.c:90
 msgid "Valent wants to run as a service"
 msgstr "Valent veut s'exécuter en tant que service"
 
@@ -1341,6 +1371,12 @@ msgstr "Portails"
 #: src/plugins/xdp/xdp.plugin.desktop.in:8
 msgid "Integration with desktop portals"
 msgstr "Intégration avec les portails de bureau"
+
+#~ msgid "Send"
+#~ msgstr "Envoyer"
+
+#~ msgid "Edit"
+#~ msgstr "Modifier"
 
 #~ msgid "Device"
 #~ msgstr "Appareil"
@@ -1444,10 +1480,6 @@ msgstr "Intégration avec les portails de bureau"
 
 #~ msgid "I Understand"
 #~ msgstr "Je comprends"
-
-#~ msgid "Define commands that can be executed by the remote device."
-#~ msgstr ""
-#~ "Définir les commandes qui peuvent être exécutées par l'appareil distant."
 
 #~ msgid "Restrictions"
 #~ msgstr "Restrictions"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-04-12 23:01-0700\n"
+"POT-Creation-Date: 2023-06-03 12:35-0700\n"
 "PO-Revision-Date: 2022-09-12 19:59+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -26,7 +26,7 @@ msgid "Whether the device is paired"
 msgstr "Of het apparaat is gekoppeld."
 
 #: data/gsettings/ca.andyholmes.Valent.gschema.xml:10
-#: src/plugins/runcommand/valent-runcommand-editor.ui:44
+#: src/plugins/runcommand/valent-runcommand-editor.ui:39
 msgid "Name"
 msgstr "Naam"
 
@@ -45,7 +45,7 @@ msgstr "Of de plug-in is ingeschakeld."
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:330 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
 msgid "Valent"
 msgstr "Valent"
 
@@ -110,17 +110,17 @@ msgstr "Maak verbinding met uw apparaten"
 msgid "Andy Holmes"
 msgstr "Andy Holmes"
 
-#: src/libvalent/device/valent-device.c:517
+#: src/libvalent/device/valent-device.c:512
 #, c-format
 msgid "Pairing request from %s"
 msgstr "Koppelverzoek van %s"
 
-#: src/libvalent/device/valent-device.c:528
+#: src/libvalent/device/valent-device.c:523
 #: src/libvalent/ui/valent-device-page.ui:143
 msgid "Reject"
 msgstr "Afwijzen"
 
-#: src/libvalent/device/valent-device.c:534
+#: src/libvalent/device/valent-device.c:529
 #: src/libvalent/ui/valent-device-page.ui:156
 msgid "Accept"
 msgstr "Goedkeuren"
@@ -131,8 +131,8 @@ msgid "Unavailable"
 msgstr "Niet beschikbaar"
 
 #: src/libvalent/ui/valent-device-page.ui:21
-#: src/libvalent/ui/valent-media-remote.ui:233
-#: src/libvalent/ui/valent-menu-list.c:523
+#: src/libvalent/ui/valent-media-remote.ui:239
+#: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr "Vorige"
@@ -196,8 +196,8 @@ msgstr "Er zijn geen plug-ins."
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
-#: src/libvalent/ui/valent-media-remote.ui:404
-#: src/libvalent/ui/valent-media-remote.ui:419
+#: src/libvalent/ui/valent-media-remote.ui:408
+#: src/libvalent/ui/valent-media-remote.ui:423
 msgid "Enable Repeat"
 msgstr ""
 
@@ -219,92 +219,92 @@ msgstr "Media onderbreken"
 
 #: src/libvalent/ui/valent-media-remote.c:314
 #: src/libvalent/ui/valent-media-remote.c:316
-#: src/libvalent/ui/valent-media-remote.ui:270
-#: src/libvalent/ui/valent-media-remote.ui:285
+#: src/libvalent/ui/valent-media-remote.ui:275
+#: src/libvalent/ui/valent-media-remote.ui:290
 msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:105
+#: src/libvalent/ui/valent-window.ui:113
 msgid "Media Remote"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:213
+#: src/libvalent/ui/valent-media-remote.ui:219
 #: src/plugins/telephony/valent-telephony-preferences.ui:15
 #: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "Volume"
 msgstr "Volume"
 
-#: src/libvalent/ui/valent-media-remote.ui:243
-#: src/libvalent/ui/valent-media-remote.ui:260
+#: src/libvalent/ui/valent-media-remote.ui:248
+#: src/libvalent/ui/valent-media-remote.ui:265
 #, fuzzy
 msgid "Seek Back"
 msgstr "Terug"
 
-#: src/libvalent/ui/valent-media-remote.ui:295
-#: src/libvalent/ui/valent-media-remote.ui:312
+#: src/libvalent/ui/valent-media-remote.ui:300
+#: src/libvalent/ui/valent-media-remote.ui:317
 msgid "Seek Forward"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:322
-#: src/libvalent/ui/valent-media-remote.ui:337
+#: src/libvalent/ui/valent-media-remote.ui:327
+#: src/libvalent/ui/valent-media-remote.ui:342
 #: src/plugins/presenter/valent-presenter-remote.ui:151
 msgid "Next"
 msgstr "Volgende"
 
-#: src/libvalent/ui/valent-media-remote.ui:347
-#: src/libvalent/ui/valent-media-remote.ui:361
+#: src/libvalent/ui/valent-media-remote.ui:351
+#: src/libvalent/ui/valent-media-remote.ui:365
 #, fuzzy
 msgid "Options"
 msgstr "Toepassingen"
 
-#: src/libvalent/ui/valent-media-remote.ui:428
-#: src/libvalent/ui/valent-media-remote.ui:443
+#: src/libvalent/ui/valent-media-remote.ui:432
+#: src/libvalent/ui/valent-media-remote.ui:447
 msgid "Shuffle"
 msgstr ""
 
-#: src/libvalent/ui/valent-menu-list.c:383
+#: src/libvalent/ui/valent-menu-list.c:529
 msgid "No Actions"
 msgstr "Er zijn geen acties."
 
-#: src/libvalent/ui/valent-preferences-window.c:373
+#: src/libvalent/ui/valent-preferences-window.c:375
 msgid "Global"
 msgstr "Algemeen"
 
-#: src/libvalent/ui/valent-preferences-window.c:380
+#: src/libvalent/ui/valent-preferences-window.c:382
 msgid "Device Connections"
 msgstr "Verbonden apparaten"
 
-#: src/libvalent/ui/valent-preferences-window.c:387
+#: src/libvalent/ui/valent-preferences-window.c:389
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr "Klembord"
 
-#: src/libvalent/ui/valent-preferences-window.c:394
+#: src/libvalent/ui/valent-preferences-window.c:396
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr "Contactpersonen"
 
-#: src/libvalent/ui/valent-preferences-window.c:401
+#: src/libvalent/ui/valent-preferences-window.c:403
 msgid "Mouse and Keyboard"
 msgstr "Muis en toetsenbord"
 
-#: src/libvalent/ui/valent-preferences-window.c:408
+#: src/libvalent/ui/valent-preferences-window.c:410
 msgid "Media Players"
 msgstr "Mediaspelers"
 
-#: src/libvalent/ui/valent-preferences-window.c:415
+#: src/libvalent/ui/valent-preferences-window.c:417
 msgid "Volume Control"
 msgstr "Volumeregeling"
 
-#: src/libvalent/ui/valent-preferences-window.c:422
+#: src/libvalent/ui/valent-preferences-window.c:424
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:63
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/libvalent/ui/valent-preferences-window.c:429
+#: src/libvalent/ui/valent-preferences-window.c:431
 msgid "Session Manager"
 msgstr "Sessiebeheer"
 
@@ -425,37 +425,42 @@ msgstr "Niet gekoppeld"
 msgid "Connected"
 msgstr "Verbonden"
 
-#: src/libvalent/ui/valent-window.c:339
+#: src/libvalent/ui/valent-window.c:345
 msgid "translator-credits"
 msgstr "Heimen Stoffels <vistausss@fastmail.com>"
 
-#: src/libvalent/ui/valent-window.c:344
+#: src/libvalent/ui/valent-window.c:350
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:44
+#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
 msgid "Refresh"
 msgstr "Herladen"
 
-#: src/libvalent/ui/valent-window.ui:71
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#, fuzzy
+msgid "Main Menu"
+msgstr "Apparaatnaam"
+
+#: src/libvalent/ui/valent-window.ui:79
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr "Apparaten"
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:87
 msgid "Searching for devices…"
 msgstr "Bezig met zoeken naar apparaten…"
 
-#: src/libvalent/ui/valent-window.ui:111
+#: src/libvalent/ui/valent-window.ui:119
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/libvalent/ui/valent-window.ui:115
+#: src/libvalent/ui/valent-window.ui:123
 #: src/plugins/sms/valent-sms-window.ui:350
 msgid "About Valent"
 msgstr "Over Valent"
 
-#: src/libvalent/ui/valent-window.ui:121
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -665,7 +670,7 @@ msgstr "Telefoon zoeken"
 msgid "Find a device by making it ring"
 msgstr "Zoek een apparaat door het te bellen"
 
-#: src/plugins/findmyphone/valent-findmyphone-plugin.c:59
+#: src/plugins/findmyphone/valent-findmyphone-plugin.c:112
 msgid "Ring"
 msgstr "Bellen"
 
@@ -706,7 +711,7 @@ msgstr "Touchpad"
 msgid "Control the mouse and keyboard"
 msgstr "Bedien de muis en het toetsenbord"
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:516
+#: src/plugins/mousepad/valent-mousepad-plugin.c:579
 msgid "Remote Input"
 msgstr "Externe invoer"
 
@@ -762,21 +767,25 @@ msgstr "Meldingen synchroniseren"
 msgid "Notification"
 msgstr "Melding"
 
-#: src/plugins/notification/valent-notification-dialog.ui:15
-#: src/plugins/presenter/valent-presenter-remote.c:91
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/share/valent-share-plugin.c:140
-#: src/plugins/share/valent-share-plugin.c:263
-#: src/plugins/share/valent-share-plugin.c:365
-#: src/plugins/share/valent-share-plugin.c:505
-#: src/plugins/share/valent-share-plugin.c:669
-#: src/plugins/share/valent-share-preferences.c:91
-msgid "Cancel"
-msgstr "Annuleren"
+#: src/plugins/notification/valent-notification-dialog.ui:19
+#: src/plugins/runcommand/valent-runcommand-editor.ui:17
+#: src/plugins/share/valent-share-target-chooser.ui:22
+msgid "_Cancel"
+msgstr "_Annuleren"
 
-#: src/plugins/notification/valent-notification-dialog.ui:20
-msgid "Send"
-msgstr "Versturen"
+#: src/plugins/notification/valent-notification-dialog.ui:26
+msgid "_Reply"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:150
+#: src/plugins/share/valent-share-text-dialog.ui:53
+msgid "Close"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:151
+#, fuzzy
+msgid "Close the notification"
+msgstr "Oproep- en sms-meldingen"
 
 #: src/plugins/notification/valent-notification-preferences.ui:10
 #, fuzzy
@@ -836,12 +845,12 @@ msgstr "‘%s’ kan niet worden opgehaald van %s"
 msgid "Transfer Failed"
 msgstr "Overdracht mislukt"
 
-#: src/plugins/photo/valent-photo-plugin.c:137
+#: src/plugins/photo/valent-photo-plugin.c:188
 msgid "Take Photo"
 msgstr "Foto maken"
 
 #: src/plugins/ping/ping.plugin.desktop.in:7
-#: src/plugins/ping/valent-ping-plugin.c:95
+#: src/plugins/ping/valent-ping-plugin.c:142
 msgid "Ping"
 msgstr "Rinkelen"
 
@@ -861,18 +870,18 @@ msgstr "Afstandsbediening"
 msgid "Control presentations"
 msgstr "Bedien presentaties"
 
-#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-plugin.c:215
 #: src/plugins/presenter/valent-presenter-remote.ui:8
 msgid "Presentation Remote"
 msgstr "Presentatie-afstandsbediening"
 
-#: src/plugins/presenter/valent-presenter-remote.c:89
+#: src/plugins/presenter/valent-presenter-remote.c:91
 msgid "Select Presentation"
 msgstr "Kies een presentatie"
 
-#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.c:92
 #: src/plugins/presenter/valent-presenter-remote.ui:86
-#: src/plugins/share/valent-share-preferences.c:90
+#: src/plugins/share/valent-share-preferences.c:94
 msgid "Open"
 msgstr "Openen"
 
@@ -880,7 +889,7 @@ msgstr "Openen"
 msgid "Presentations"
 msgstr "Presentaties"
 
-#: src/plugins/presenter/valent-presenter-remote.c:108
+#: src/plugins/presenter/valent-presenter-remote.c:107
 msgid "All Files"
 msgstr "Alle bestanden"
 
@@ -913,30 +922,48 @@ msgid "Execute commands remotely"
 msgstr "Voer externe opdrachten uit"
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:256
-msgid "Edit"
-msgstr "Bewerken"
+#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#, fuzzy
+msgid "Edit Command"
+msgstr "Opdrachten"
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:17
-#: src/plugins/share/valent-share-text-dialog.ui:54
-msgid "Save"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:24
+#, fuzzy
+msgid "_Save"
 msgstr "Opslaan"
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:70
+#: src/plugins/runcommand/valent-runcommand-editor.ui:48
 msgid "Command Line"
 msgstr "Opdrachtregel"
 
-#: src/plugins/runcommand/valent-runcommand-plugin.c:329
-msgid "Run Command"
-msgstr "Opdracht uitvoeren"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:63
+#, fuzzy
+msgid "Remove the command"
+msgstr "Kies een opdracht"
 
-#: src/plugins/runcommand/valent-runcommand-preferences.c:266
+#: src/plugins/runcommand/valent-runcommand-editor.ui:69
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: src/plugins/runcommand/valent-runcommand-preferences.ui:34
-msgid "Add Command…"
+#: src/plugins/runcommand/valent-runcommand-plugin.c:317
+msgid "Run Command"
+msgstr "Opdracht uitvoeren"
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:14
+#, fuzzy
+msgid "Add a command"
 msgstr "Opdracht toevoegen…"
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:24
+#, fuzzy
+msgid "Local Commands"
+msgstr "Opdrachten"
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:25
+#, fuzzy
+msgid "Commands that can be executed by remote devices"
+msgstr ""
+"Voeg opdrachten toe die op het externe apparaat kunnen worden uitgevoerd."
 
 #: src/plugins/sftp/sftp.plugin.desktop.in:7
 #, fuzzy
@@ -957,7 +984,7 @@ msgstr "Persoonlijke map"
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:591
+#: src/plugins/sftp/valent-sftp-plugin.c:658
 msgid "Browse Files"
 msgstr "Bestanden verkennen"
 
@@ -1022,6 +1049,13 @@ msgid_plural "Received %2$d files from %1$s"
 msgstr[0] "Eén bestand ontvangen van %1$s"
 msgstr[1] "%2$d bestanden ontvangen van %1$s"
 
+#: src/plugins/share/valent-share-plugin.c:140
+#: src/plugins/share/valent-share-plugin.c:263
+#: src/plugins/share/valent-share-plugin.c:365
+#: src/plugins/share/valent-share-plugin.c:505
+msgid "Cancel"
+msgstr "Annuleren"
+
 #: src/plugins/share/valent-share-plugin.c:158
 msgid "Open Folder"
 msgstr "Map openen"
@@ -1067,20 +1101,20 @@ msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] "Eén bestand verstuurd naar %1$s"
 msgstr[1] "%2$d bestanden verstuurd naar %1$s"
 
-#: src/plugins/share/valent-share-plugin.c:667
+#: src/plugins/share/valent-share-plugin.c:673
 #: src/plugins/share/valent-share-target-chooser.ui:8
 msgid "Share Files"
 msgstr "Bestanden delen"
 
-#: src/plugins/share/valent-share-plugin.c:668
+#: src/plugins/share/valent-share-plugin.c:674
 msgid "Share"
 msgstr "Delen"
 
-#: src/plugins/share/valent-share-plugin.c:912
+#: src/plugins/share/valent-share-plugin.c:1221
 msgid "Send Files"
 msgstr "Bestanden versturen"
 
-#: src/plugins/share/valent-share-preferences.c:89
+#: src/plugins/share/valent-share-preferences.c:93
 msgid "Select download folder"
 msgstr "Kies een downloadmap"
 
@@ -1091,10 +1125,6 @@ msgstr "Downloadmap"
 #: src/plugins/share/valent-share-preferences.ui:11
 msgid "Where received files are stored"
 msgstr "Waar ontvangen bestanden dienen te worden opgeslagen"
-
-#: src/plugins/share/valent-share-target-chooser.ui:22
-msgid "_Cancel"
-msgstr "_Annuleren"
 
 #: src/plugins/share/valent-share-target-chooser.ui:29
 #, fuzzy
@@ -1114,15 +1144,16 @@ msgstr "Bezig met zoeken naar apparaten…"
 msgid "Always use this device"
 msgstr ""
 
+#: src/plugins/share/valent-share-text-dialog.c:98
+#: src/plugins/share/valent-share-text-dialog.ui:54
+msgid "Save"
+msgstr "Opslaan"
+
 #: src/plugins/share/valent-share-text-dialog.ui:8
 #: src/plugins/share/valent-share-text-dialog.ui:15
 #, fuzzy
 msgid "Shared Text"
 msgstr "Deelstatus"
-
-#: src/plugins/share/valent-share-text-dialog.ui:53
-msgid "Close"
-msgstr ""
 
 #: src/plugins/share/valent-share-text-dialog.ui:55
 msgid "Copy"
@@ -1170,7 +1201,7 @@ msgstr[1] "%d min."
 
 #: src/plugins/sms/valent-sms-conversation.c:904
 #: src/plugins/sms/valent-sms-window.c:602
-#: src/plugins/sms/valent-sms-window.c:914
+#: src/plugins/sms/valent-sms-window.c:922
 msgid "New Conversation"
 msgstr "Nieuw gesprek"
 
@@ -1189,7 +1220,7 @@ msgstr "Bericht versturen"
 msgid "Type a message"
 msgstr "Voer een bericht in…"
 
-#: src/plugins/sms/valent-sms-plugin.c:442
+#: src/plugins/sms/valent-sms-plugin.c:505
 msgid "Messaging"
 msgstr "Berichten"
 
@@ -1203,7 +1234,7 @@ msgid "Send to %s"
 msgstr "Versturen naar %s"
 
 #: src/plugins/sms/valent-sms-window.c:629
-#: src/plugins/sms/valent-sms-window.c:936
+#: src/plugins/sms/valent-sms-window.c:944
 msgid "Search Messages"
 msgstr "Berichten doorzoeken"
 
@@ -1328,7 +1359,7 @@ msgstr "Niets doen"
 msgid "Lower"
 msgstr "Verlagen"
 
-#: src/plugins/xdp/valent-xdp-background.c:86
+#: src/plugins/xdp/valent-xdp-background.c:90
 msgid "Valent wants to run as a service"
 msgstr "Valent wil worden uitgevoerd als achtergronddienst"
 
@@ -1339,6 +1370,12 @@ msgstr "Portalen"
 #: src/plugins/xdp/xdp.plugin.desktop.in:8
 msgid "Integration with desktop portals"
 msgstr "Integratie met bureaubladportalen"
+
+#~ msgid "Send"
+#~ msgstr "Versturen"
+
+#~ msgid "Edit"
+#~ msgstr "Bewerken"
 
 #~ msgid "Device"
 #~ msgstr "Apparaat"
@@ -1443,10 +1480,6 @@ msgstr "Integratie met bureaubladportalen"
 #~ msgid "I Understand"
 #~ msgstr "Ik begrijp het"
 
-#~ msgid "Define commands that can be executed by the remote device."
-#~ msgstr ""
-#~ "Voeg opdrachten toe die op het externe apparaat kunnen worden uitgevoerd."
-
 #~ msgid "Restrictions"
 #~ msgstr "Beperkingen"
 
@@ -1504,9 +1537,6 @@ msgstr "Integratie met bureaubladportalen"
 #~ msgstr ""
 #~ "De apparaatnaam wordt gebruikt om dit apparaat op het netwerk te "
 #~ "herkennen."
-
-#~ msgid "Select Command"
-#~ msgstr "Kies een opdracht"
 
 #~ msgid "Select"
 #~ msgstr "Kiezen"

--- a/po/valent.pot
+++ b/po/valent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-04-12 23:01-0700\n"
+"POT-Creation-Date: 2023-06-03 12:35-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Whether the device is paired"
 msgstr ""
 
 #: data/gsettings/ca.andyholmes.Valent.gschema.xml:10
-#: src/plugins/runcommand/valent-runcommand-editor.ui:44
+#: src/plugins/runcommand/valent-runcommand-editor.ui:39
 msgid "Name"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgstr ""
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:330 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
 msgid "Valent"
 msgstr ""
 
@@ -107,17 +107,17 @@ msgstr ""
 msgid "Andy Holmes"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:517
+#: src/libvalent/device/valent-device.c:512
 #, c-format
 msgid "Pairing request from %s"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:528
+#: src/libvalent/device/valent-device.c:523
 #: src/libvalent/ui/valent-device-page.ui:143
 msgid "Reject"
 msgstr ""
 
-#: src/libvalent/device/valent-device.c:534
+#: src/libvalent/device/valent-device.c:529
 #: src/libvalent/ui/valent-device-page.ui:156
 msgid "Accept"
 msgstr ""
@@ -128,8 +128,8 @@ msgid "Unavailable"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-page.ui:21
-#: src/libvalent/ui/valent-media-remote.ui:233
-#: src/libvalent/ui/valent-menu-list.c:523
+#: src/libvalent/ui/valent-media-remote.ui:239
+#: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr ""
@@ -190,8 +190,8 @@ msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
-#: src/libvalent/ui/valent-media-remote.ui:404
-#: src/libvalent/ui/valent-media-remote.ui:419
+#: src/libvalent/ui/valent-media-remote.ui:408
+#: src/libvalent/ui/valent-media-remote.ui:423
 msgid "Enable Repeat"
 msgstr ""
 
@@ -212,90 +212,90 @@ msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:314
 #: src/libvalent/ui/valent-media-remote.c:316
-#: src/libvalent/ui/valent-media-remote.ui:270
-#: src/libvalent/ui/valent-media-remote.ui:285
+#: src/libvalent/ui/valent-media-remote.ui:275
+#: src/libvalent/ui/valent-media-remote.ui:290
 msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:105
+#: src/libvalent/ui/valent-window.ui:113
 msgid "Media Remote"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:213
+#: src/libvalent/ui/valent-media-remote.ui:219
 #: src/plugins/telephony/valent-telephony-preferences.ui:15
 #: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "Volume"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:243
-#: src/libvalent/ui/valent-media-remote.ui:260
+#: src/libvalent/ui/valent-media-remote.ui:248
+#: src/libvalent/ui/valent-media-remote.ui:265
 msgid "Seek Back"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:295
-#: src/libvalent/ui/valent-media-remote.ui:312
+#: src/libvalent/ui/valent-media-remote.ui:300
+#: src/libvalent/ui/valent-media-remote.ui:317
 msgid "Seek Forward"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:322
-#: src/libvalent/ui/valent-media-remote.ui:337
+#: src/libvalent/ui/valent-media-remote.ui:327
+#: src/libvalent/ui/valent-media-remote.ui:342
 #: src/plugins/presenter/valent-presenter-remote.ui:151
 msgid "Next"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:347
-#: src/libvalent/ui/valent-media-remote.ui:361
+#: src/libvalent/ui/valent-media-remote.ui:351
+#: src/libvalent/ui/valent-media-remote.ui:365
 msgid "Options"
 msgstr ""
 
-#: src/libvalent/ui/valent-media-remote.ui:428
-#: src/libvalent/ui/valent-media-remote.ui:443
+#: src/libvalent/ui/valent-media-remote.ui:432
+#: src/libvalent/ui/valent-media-remote.ui:447
 msgid "Shuffle"
 msgstr ""
 
-#: src/libvalent/ui/valent-menu-list.c:383
+#: src/libvalent/ui/valent-menu-list.c:529
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:373
+#: src/libvalent/ui/valent-preferences-window.c:375
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:380
+#: src/libvalent/ui/valent-preferences-window.c:382
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:387
+#: src/libvalent/ui/valent-preferences-window.c:389
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:394
+#: src/libvalent/ui/valent-preferences-window.c:396
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:401
+#: src/libvalent/ui/valent-preferences-window.c:403
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:408
+#: src/libvalent/ui/valent-preferences-window.c:410
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:415
+#: src/libvalent/ui/valent-preferences-window.c:417
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:422
+#: src/libvalent/ui/valent-preferences-window.c:424
 #: src/plugins/notification/notification.plugin.desktop.in:7
 #: src/plugins/notification/valent-notification-preferences.ui:63
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:429
+#: src/libvalent/ui/valent-preferences-window.c:431
 msgid "Session Manager"
 msgstr ""
 
@@ -416,37 +416,41 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.c:339
+#: src/libvalent/ui/valent-window.c:345
 msgid "translator-credits"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.c:344
+#: src/libvalent/ui/valent-window.c:350
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:44
+#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
 msgid "Refresh"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:71
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+msgid "Main Menu"
+msgstr ""
+
+#: src/libvalent/ui/valent-window.ui:79
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:87
 msgid "Searching for devices…"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:111
+#: src/libvalent/ui/valent-window.ui:119
 msgid "Preferences"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:115
+#: src/libvalent/ui/valent-window.ui:123
 #: src/plugins/sms/valent-sms-window.ui:350
 msgid "About Valent"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:121
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Quit"
 msgstr ""
 
@@ -641,7 +645,7 @@ msgstr ""
 msgid "Find a device by making it ring"
 msgstr ""
 
-#: src/plugins/findmyphone/valent-findmyphone-plugin.c:59
+#: src/plugins/findmyphone/valent-findmyphone-plugin.c:112
 msgid "Ring"
 msgstr ""
 
@@ -682,7 +686,7 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:516
+#: src/plugins/mousepad/valent-mousepad-plugin.c:579
 msgid "Remote Input"
 msgstr ""
 
@@ -738,20 +742,23 @@ msgstr ""
 msgid "Notification"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-dialog.ui:15
-#: src/plugins/presenter/valent-presenter-remote.c:91
-#: src/plugins/runcommand/valent-runcommand-editor.ui:12
-#: src/plugins/share/valent-share-plugin.c:140
-#: src/plugins/share/valent-share-plugin.c:263
-#: src/plugins/share/valent-share-plugin.c:365
-#: src/plugins/share/valent-share-plugin.c:505
-#: src/plugins/share/valent-share-plugin.c:669
-#: src/plugins/share/valent-share-preferences.c:91
-msgid "Cancel"
+#: src/plugins/notification/valent-notification-dialog.ui:19
+#: src/plugins/runcommand/valent-runcommand-editor.ui:17
+#: src/plugins/share/valent-share-target-chooser.ui:22
+msgid "_Cancel"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-dialog.ui:20
-msgid "Send"
+#: src/plugins/notification/valent-notification-dialog.ui:26
+msgid "_Reply"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:150
+#: src/plugins/share/valent-share-text-dialog.ui:53
+msgid "Close"
+msgstr ""
+
+#: src/plugins/notification/valent-notification-dialog.ui:151
+msgid "Close the notification"
 msgstr ""
 
 #: src/plugins/notification/valent-notification-preferences.ui:10
@@ -807,12 +814,12 @@ msgstr ""
 msgid "Transfer Failed"
 msgstr ""
 
-#: src/plugins/photo/valent-photo-plugin.c:137
+#: src/plugins/photo/valent-photo-plugin.c:188
 msgid "Take Photo"
 msgstr ""
 
 #: src/plugins/ping/ping.plugin.desktop.in:7
-#: src/plugins/ping/valent-ping-plugin.c:95
+#: src/plugins/ping/valent-ping-plugin.c:142
 msgid "Ping"
 msgstr ""
 
@@ -832,18 +839,18 @@ msgstr ""
 msgid "Control presentations"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-plugin.c:164
+#: src/plugins/presenter/valent-presenter-plugin.c:215
 #: src/plugins/presenter/valent-presenter-remote.ui:8
 msgid "Presentation Remote"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:89
+#: src/plugins/presenter/valent-presenter-remote.c:91
 msgid "Select Presentation"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:90
+#: src/plugins/presenter/valent-presenter-remote.c:92
 #: src/plugins/presenter/valent-presenter-remote.ui:86
-#: src/plugins/share/valent-share-preferences.c:90
+#: src/plugins/share/valent-share-preferences.c:94
 msgid "Open"
 msgstr ""
 
@@ -851,7 +858,7 @@ msgstr ""
 msgid "Presentations"
 msgstr ""
 
-#: src/plugins/presenter/valent-presenter-remote.c:108
+#: src/plugins/presenter/valent-presenter-remote.c:107
 msgid "All Files"
 msgstr ""
 
@@ -884,29 +891,40 @@ msgid "Execute commands remotely"
 msgstr ""
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:256
-msgid "Edit"
+#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+msgid "Edit Command"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:17
-#: src/plugins/share/valent-share-text-dialog.ui:54
-msgid "Save"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:24
+msgid "_Save"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-editor.ui:70
+#: src/plugins/runcommand/valent-runcommand-editor.ui:48
 msgid "Command Line"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-plugin.c:329
-msgid "Run Command"
+#: src/plugins/runcommand/valent-runcommand-editor.ui:63
+msgid "Remove the command"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-preferences.c:266
+#: src/plugins/runcommand/valent-runcommand-editor.ui:69
 msgid "Remove"
 msgstr ""
 
-#: src/plugins/runcommand/valent-runcommand-preferences.ui:34
-msgid "Add Command…"
+#: src/plugins/runcommand/valent-runcommand-plugin.c:317
+msgid "Run Command"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:14
+msgid "Add a command"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:24
+msgid "Local Commands"
+msgstr ""
+
+#: src/plugins/runcommand/valent-runcommand-preferences.ui:25
+msgid "Commands that can be executed by remote devices"
 msgstr ""
 
 #: src/plugins/sftp/sftp.plugin.desktop.in:7
@@ -926,7 +944,7 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:591
+#: src/plugins/sftp/valent-sftp-plugin.c:658
 msgid "Browse Files"
 msgstr ""
 
@@ -984,6 +1002,13 @@ msgid_plural "Received %2$d files from %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/plugins/share/valent-share-plugin.c:140
+#: src/plugins/share/valent-share-plugin.c:263
+#: src/plugins/share/valent-share-plugin.c:365
+#: src/plugins/share/valent-share-plugin.c:505
+msgid "Cancel"
+msgstr ""
+
 #: src/plugins/share/valent-share-plugin.c:158
 msgid "Open Folder"
 msgstr ""
@@ -1029,20 +1054,20 @@ msgid_plural "Sent %2$d files to %1$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/plugins/share/valent-share-plugin.c:667
+#: src/plugins/share/valent-share-plugin.c:673
 #: src/plugins/share/valent-share-target-chooser.ui:8
 msgid "Share Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:668
+#: src/plugins/share/valent-share-plugin.c:674
 msgid "Share"
 msgstr ""
 
-#: src/plugins/share/valent-share-plugin.c:912
+#: src/plugins/share/valent-share-plugin.c:1221
 msgid "Send Files"
 msgstr ""
 
-#: src/plugins/share/valent-share-preferences.c:89
+#: src/plugins/share/valent-share-preferences.c:93
 msgid "Select download folder"
 msgstr ""
 
@@ -1052,10 +1077,6 @@ msgstr ""
 
 #: src/plugins/share/valent-share-preferences.ui:11
 msgid "Where received files are stored"
-msgstr ""
-
-#: src/plugins/share/valent-share-target-chooser.ui:22
-msgid "_Cancel"
 msgstr ""
 
 #: src/plugins/share/valent-share-target-chooser.ui:29
@@ -1074,13 +1095,14 @@ msgstr ""
 msgid "Always use this device"
 msgstr ""
 
+#: src/plugins/share/valent-share-text-dialog.c:98
+#: src/plugins/share/valent-share-text-dialog.ui:54
+msgid "Save"
+msgstr ""
+
 #: src/plugins/share/valent-share-text-dialog.ui:8
 #: src/plugins/share/valent-share-text-dialog.ui:15
 msgid "Shared Text"
-msgstr ""
-
-#: src/plugins/share/valent-share-text-dialog.ui:53
-msgid "Close"
 msgstr ""
 
 #: src/plugins/share/valent-share-text-dialog.ui:55
@@ -1129,7 +1151,7 @@ msgstr[1] ""
 
 #: src/plugins/sms/valent-sms-conversation.c:904
 #: src/plugins/sms/valent-sms-window.c:602
-#: src/plugins/sms/valent-sms-window.c:914
+#: src/plugins/sms/valent-sms-window.c:922
 msgid "New Conversation"
 msgstr ""
 
@@ -1148,7 +1170,7 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
-#: src/plugins/sms/valent-sms-plugin.c:442
+#: src/plugins/sms/valent-sms-plugin.c:505
 msgid "Messaging"
 msgstr ""
 
@@ -1162,7 +1184,7 @@ msgid "Send to %s"
 msgstr ""
 
 #: src/plugins/sms/valent-sms-window.c:629
-#: src/plugins/sms/valent-sms-window.c:936
+#: src/plugins/sms/valent-sms-window.c:944
 msgid "Search Messages"
 msgstr ""
 
@@ -1284,7 +1306,7 @@ msgstr ""
 msgid "Lower"
 msgstr ""
 
-#: src/plugins/xdp/valent-xdp-background.c:86
+#: src/plugins/xdp/valent-xdp-background.c:90
 msgid "Valent wants to run as a service"
 msgstr ""
 

--- a/src/libvalent/core/valent-macros.h
+++ b/src/libvalent/core/valent-macros.h
@@ -35,33 +35,6 @@ G_BEGIN_DECLS
  */
 #define VALENT_STRV_INIT(...) ((const char * const[]) { __VA_ARGS__, NULL})
 
-/**
- * valent_set_string: (skip)
- * @ptr: a pointer to a string
- * @str: the string to set
- *
- * Set a string.
- *
- * Returns: %TRUE if changed, or %FALSE otherwise
- */
-static inline gboolean
-valent_set_string (char       **ptr,
-                   const char  *str)
-{
-  char *copy;
-
-  g_assert (ptr != NULL);
-
-  if (*ptr == str || (*ptr && str && strcmp (*ptr, str) == 0))
-    return FALSE;
-
-  copy = g_strdup (str);
-  g_free (*ptr);
-  *ptr = copy;
-
-  return TRUE;
-}
-
 G_END_DECLS
 
 #endif /* __GI_SCANNER__ */

--- a/src/libvalent/device/valent-channel-service.c
+++ b/src/libvalent/device/valent-channel-service.c
@@ -641,7 +641,7 @@ valent_channel_service_set_name (ValentChannelService *service,
   g_return_if_fail (VALENT_IS_CHANNEL_SERVICE (service));
   g_return_if_fail (name != NULL && *name != '\0');
 
-  if (valent_set_string (&priv->name, name))
+  if (g_set_str (&priv->name, name))
     g_object_notify_by_pspec (G_OBJECT (service), properties [PROP_NAME]);
 
   valent_object_lock (VALENT_OBJECT (service));

--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -1053,7 +1053,7 @@ valent_device_manager_set_name (ValentDeviceManager *manager,
   g_return_if_fail (VALENT_IS_DEVICE_MANAGER (manager));
   g_return_if_fail (name != NULL && *name != '\0');
 
-  if (valent_set_string (&manager->name, name))
+  if (g_set_str (&manager->name, name))
     g_object_notify_by_pspec (G_OBJECT (manager), properties [PROP_NAME]);
 }
 

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -632,14 +632,14 @@ valent_device_handle_identity (ValentDevice *device,
   if (!valent_packet_get_string (packet, "deviceName", &device_name))
     device_name = "Unnamed";
 
-  if (valent_set_string (&device->name, device_name))
+  if (g_set_str (&device->name, device_name))
     g_object_notify_by_pspec (G_OBJECT (device), properties [PROP_NAME]);
 
   /* Device Type */
   if (!valent_packet_get_string (packet, "deviceType", &device_type))
     device_type = DEVICE_TYPE_DESKTOP;
 
-  if (valent_set_string (&device->type, device_type))
+  if (g_set_str (&device->type, device_type))
     {
       const char *device_icon = "computer-symbolic";
 
@@ -654,7 +654,7 @@ valent_device_handle_identity (ValentDevice *device,
       else if (g_str_equal (device_type, DEVICE_TYPE_TV))
         device_icon = "tv-symbolic";
 
-      if (valent_set_string (&device->icon_name, device_icon))
+      if (g_set_str (&device->icon_name, device_icon))
         g_object_notify_by_pspec (G_OBJECT (device), properties [PROP_ICON_NAME]);
     }
 

--- a/src/libvalent/device/valent-packet.h
+++ b/src/libvalent/device/valent-packet.h
@@ -92,89 +92,89 @@ valent_packet_is_valid (JsonNode *packet)
 
 /* Packet Helpers */
 VALENT_AVAILABLE_IN_1_0
-JsonNode    * valent_packet_new              (const char     *type);
+JsonNode   * valent_packet_new              (const char     *type);
 VALENT_AVAILABLE_IN_1_0
-void          valent_packet_init             (JsonBuilder   **builder,
-                                              const char     *type);
+void         valent_packet_init             (JsonBuilder   **builder,
+                                             const char     *type);
 VALENT_AVAILABLE_IN_1_0
-JsonNode    * valent_packet_end              (JsonBuilder   **builder);
+JsonNode   * valent_packet_end              (JsonBuilder   **builder);
 VALENT_AVAILABLE_IN_1_0
-int64_t       valent_packet_get_id           (JsonNode       *packet);
+int64_t      valent_packet_get_id           (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-const char  * valent_packet_get_type         (JsonNode       *packet);
+const char * valent_packet_get_type         (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-JsonObject  * valent_packet_get_body         (JsonNode       *packet);
+JsonObject * valent_packet_get_body         (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_has_payload      (JsonNode       *packet);
+gboolean     valent_packet_has_payload      (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-JsonObject  * valent_packet_get_payload_full (JsonNode       *packet,
-                                              goffset        *size,
-                                              GError        **error);
+JsonObject * valent_packet_get_payload_full (JsonNode       *packet,
+                                             goffset        *size,
+                                             GError        **error);
 VALENT_AVAILABLE_IN_1_0
-void          valent_packet_set_payload_full (JsonNode       *packet,
-                                              JsonObject     *info,
-                                              goffset         size);
+void         valent_packet_set_payload_full (JsonNode       *packet,
+                                             JsonObject     *info,
+                                             goffset         size);
 VALENT_AVAILABLE_IN_1_0
-JsonObject  * valent_packet_get_payload_info (JsonNode       *packet);
+JsonObject * valent_packet_get_payload_info (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-void          valent_packet_set_payload_info (JsonNode       *packet,
-                                              JsonObject     *info);
+void         valent_packet_set_payload_info (JsonNode       *packet,
+                                             JsonObject     *info);
 VALENT_AVAILABLE_IN_1_0
-goffset       valent_packet_get_payload_size (JsonNode       *packet);
+goffset      valent_packet_get_payload_size (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-void          valent_packet_set_payload_size (JsonNode       *packet,
-                                              goffset         size);
+void         valent_packet_set_payload_size (JsonNode       *packet,
+                                             goffset         size);
 
 /* Field Helpers */
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_check_field      (JsonNode       *packet,
-                                              const char     *field);
+gboolean     valent_packet_check_field      (JsonNode       *packet,
+                                             const char     *field);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_boolean      (JsonNode       *packet,
-                                              const char     *field,
-                                              gboolean       *value);
+gboolean     valent_packet_get_boolean      (JsonNode       *packet,
+                                             const char     *field,
+                                             gboolean       *value);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_double       (JsonNode       *packet,
-                                              const char     *field,
-                                              double         *value);
+gboolean     valent_packet_get_double       (JsonNode       *packet,
+                                             const char     *field,
+                                             double         *value);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_int          (JsonNode       *packet,
-                                              const char     *field,
-                                              int64_t        *value);
+gboolean     valent_packet_get_int          (JsonNode       *packet,
+                                             const char     *field,
+                                             int64_t        *value);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_string       (JsonNode       *packet,
-                                              const char     *field,
-                                              const char    **value);
+gboolean     valent_packet_get_string       (JsonNode       *packet,
+                                             const char     *field,
+                                             const char    **value);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_array        (JsonNode       *packet,
-                                              const char     *field,
-                                              JsonArray     **value);
+gboolean     valent_packet_get_array        (JsonNode       *packet,
+                                             const char     *field,
+                                             JsonArray     **value);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_get_object       (JsonNode       *packet,
-                                              const char     *field,
-                                              JsonObject    **value);
+gboolean     valent_packet_get_object       (JsonNode       *packet,
+                                             const char     *field,
+                                             JsonObject    **value);
 VALENT_AVAILABLE_IN_1_0
-GStrv         valent_packet_dup_strv         (JsonNode       *packet,
-                                              const char     *field);
+GStrv        valent_packet_dup_strv         (JsonNode       *packet,
+                                             const char     *field);
 
 /* I/O Helpers */
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_validate         (JsonNode       *packet,
-                                              GError        **error);
+gboolean     valent_packet_validate         (JsonNode       *packet,
+                                             GError        **error);
 VALENT_AVAILABLE_IN_1_0
-JsonNode    * valent_packet_from_stream      (GInputStream   *stream,
-                                              gssize          max_len,
-                                              GCancellable   *cancellable,
-                                              GError        **error);
+JsonNode   * valent_packet_from_stream      (GInputStream   *stream,
+                                             gssize          max_len,
+                                             GCancellable   *cancellable,
+                                             GError        **error);
 VALENT_AVAILABLE_IN_1_0
-gboolean      valent_packet_to_stream        (GOutputStream  *stream,
-                                              JsonNode       *packet,
-                                              GCancellable   *cancellable,
-                                              GError        **error);
+gboolean     valent_packet_to_stream        (GOutputStream  *stream,
+                                             JsonNode       *packet,
+                                             GCancellable   *cancellable,
+                                             GError        **error);
 VALENT_AVAILABLE_IN_1_0
-char        * valent_packet_serialize        (JsonNode       *packet);
+char       * valent_packet_serialize        (JsonNode       *packet);
 VALENT_AVAILABLE_IN_1_0
-JsonNode    * valent_packet_deserialize      (const char     *json,
-                                              GError        **error);
+JsonNode   * valent_packet_deserialize      (const char     *json,
+                                             GError        **error);
 
 G_END_DECLS

--- a/src/libvalent/notifications/valent-notification.c
+++ b/src/libvalent/notifications/valent-notification.c
@@ -464,7 +464,7 @@ valent_notification_set_application (ValentNotification *notification,
 {
   g_return_if_fail (VALENT_IS_NOTIFICATION (notification));
 
-  if (valent_set_string (&notification->application, application))
+  if (g_set_str (&notification->application, application))
     g_object_notify_by_pspec (G_OBJECT (notification), properties [PROP_APPLICATION]);
 }
 
@@ -501,7 +501,7 @@ valent_notification_set_body (ValentNotification *notification,
 {
   g_return_if_fail (VALENT_IS_NOTIFICATION (notification));
 
-  if (valent_set_string (&notification->body, body))
+  if (g_set_str (&notification->body, body))
     g_object_notify_by_pspec (G_OBJECT (notification), properties [PROP_BODY]);
 }
 
@@ -580,7 +580,7 @@ valent_notification_set_id (ValentNotification *notification,
   g_return_if_fail (VALENT_IS_NOTIFICATION (notification));
   g_return_if_fail (id != NULL && *id != '\0');
 
-  if (valent_set_string (&notification->id, id))
+  if (g_set_str (&notification->id, id))
     g_object_notify_by_pspec (G_OBJECT (notification), properties [PROP_ID]);
 }
 
@@ -698,7 +698,7 @@ valent_notification_set_title (ValentNotification *notification,
   g_return_if_fail (VALENT_IS_NOTIFICATION (notification));
   g_return_if_fail (title != NULL);
 
-  if (valent_set_string (&notification->title, title))
+  if (g_set_str (&notification->title, title))
     g_object_notify_by_pspec (G_OBJECT (notification), properties [PROP_TITLE]);
 }
 
@@ -790,7 +790,7 @@ valent_notification_set_action_and_target (ValentNotification *notification,
   g_return_if_fail (VALENT_IS_NOTIFICATION (notification));
   g_return_if_fail (action != NULL && g_action_name_is_valid (action));
 
-  valent_set_string (&notification->default_action, action);
+  g_set_str (&notification->default_action, action);
   g_clear_pointer (&notification->default_action_target, g_variant_unref);
 
   if (target)

--- a/src/plugins/mpris/valent-mpris-device.c
+++ b/src/plugins/mpris/valent-mpris-device.c
@@ -720,6 +720,6 @@ valent_mpris_device_update_name (ValentMprisDevice *player,
   g_return_if_fail (VALENT_IS_MPRIS_DEVICE (player));
   g_return_if_fail (name != NULL);
 
-  if (valent_set_string (&player->name, name))
+  if (g_set_str (&player->name, name))
     g_object_notify (G_OBJECT (player), "name");
 }

--- a/src/plugins/mpris/valent-mpris-impl.c
+++ b/src/plugins/mpris/valent-mpris-impl.c
@@ -827,7 +827,7 @@ valent_mpris_impl_export_full (ValentMPRISImpl     *impl,
   g_task_set_source_tag (task, valent_mpris_impl_export_full);
 
   /* Set the new bus name */
-  valent_set_string (&impl->bus_name, bus_name);
+  g_set_str (&impl->bus_name, bus_name);
 
   /* Set up a dedicated connection */
   address = g_dbus_address_get_for_bus_sync (G_BUS_TYPE_SESSION,

--- a/src/plugins/notification/valent-notification-dialog.c
+++ b/src/plugins/notification/valent-notification-dialog.c
@@ -14,26 +14,28 @@
 
 struct _ValentNotificationDialog
 {
-  GtkDialog           parent_instance;
+  GtkWindow           parent_instance;
 
+  ValentDevice       *device;
   ValentNotification *notification;
   char               *reply_id;
-  gboolean            state;
 
   /* template */
   GtkButton          *cancel_button;
-  GtkButton          *send_button;
+  GtkButton          *reply_button;
   GtkImage           *icon_image;
   GtkLabel           *title_label;
   GtkLabel           *body_label;
+  GtkLabel           *time_label;
   GtkWidget          *reply_frame;
   GtkTextView        *reply_entry;
 };
 
-G_DEFINE_FINAL_TYPE (ValentNotificationDialog, valent_notification_dialog, GTK_TYPE_DIALOG)
+G_DEFINE_FINAL_TYPE (ValentNotificationDialog, valent_notification_dialog, GTK_TYPE_WINDOW)
 
 enum {
   PROP_0,
+  PROP_DEVICE,
   PROP_NOTIFICATION,
   PROP_REPLY_ID,
   N_PROPERTIES
@@ -43,55 +45,137 @@ static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
 static void
-valent_notification_dialog_check (ValentNotificationDialog *self)
+valent_notification_dialog_sync (ValentNotificationDialog *self)
 {
-  gboolean state = FALSE;
+  gboolean repliable = FALSE;
+  gboolean enabled = FALSE;
 
-  if (self->state)
+  g_assert (VALENT_IS_NOTIFICATION_DIALOG (self));
+
+  /* Check if the notification is repliable */
+  repliable = (self->reply_id != NULL && *self->reply_id != '\0');
+  gtk_widget_set_visible (GTK_WIDGET (self->reply_button), repliable);
+  gtk_widget_set_visible (GTK_WIDGET (self->reply_frame), repliable);
+
+  /* If it's repliable, check if the device action is enabled */
+  if (repliable && self->device != NULL)
+    enabled = g_action_group_get_action_enabled (G_ACTION_GROUP (self->device),
+                                                 "notification.reply");
+
+  gtk_widget_set_sensitive (GTK_WIDGET (self->reply_entry), enabled);
+
+  /* If it's enabled, check if a reply is ready to be sent */
+  if (enabled)
     {
       GtkTextBuffer *buffer;
 
       buffer = gtk_text_view_get_buffer (self->reply_entry);
-      state = gtk_text_buffer_get_char_count (buffer) > 0;
+      enabled = gtk_text_buffer_get_char_count (buffer) > 0;
     }
 
-  gtk_dialog_set_response_sensitive (GTK_DIALOG (self), GTK_RESPONSE_OK, state);
+  gtk_widget_action_set_enabled (GTK_WIDGET (self),
+                                 "notification.reply",
+                                 enabled);
 }
+
 static void
 valent_notification_dialog_set_notification (ValentNotificationDialog *self,
                                              ValentNotification       *notification)
 {
+  GIcon *icon;
+  const char *title;
+  const char *body;
+  gint64 timestamp;
+
   g_assert (VALENT_IS_NOTIFICATION_DIALOG (self));
   g_assert (notification == NULL || VALENT_IS_NOTIFICATION (notification));
 
-  if (g_set_object (&self->notification, notification))
+  if (!g_set_object (&self->notification, notification))
+    return;
+
+  if ((icon = valent_notification_get_icon (self->notification)) != NULL)
+    gtk_image_set_from_gicon (self->icon_image, icon);
+
+  if ((title = valent_notification_get_title (self->notification)) != NULL)
+    gtk_label_set_label (self->title_label, title);
+
+  if ((body = valent_notification_get_body (self->notification)) != NULL)
     {
-      GIcon *icon;
-      const char *title;
-      const char *body;
+      g_autofree char *label = NULL;
 
-      icon = valent_notification_get_icon (self->notification);
-
-      if (icon != NULL)
-        gtk_image_set_from_gicon (self->icon_image, icon);
-
-      title = valent_notification_get_title (self->notification);
-
-      if (title != NULL)
-        gtk_label_set_label (self->title_label, title);
-
-      body = valent_notification_get_body (self->notification);
-
-      if (body != NULL)
-        {
-          g_autofree char *label = NULL;
-
-          label = valent_string_to_markup (body);
-          gtk_label_set_label (self->body_label, label);
-        }
+      label = valent_string_to_markup (body);
+      gtk_label_set_label (self->body_label, label);
     }
 
-  valent_notification_dialog_check (self);
+      // FIXME: better time string
+  if ((timestamp = valent_notification_get_time (self->notification)) != 0)
+    {
+      g_autoptr (GDateTime) date = NULL;
+      g_autofree char *label = NULL;
+
+      date = g_date_time_new_from_unix_local (timestamp / 1000);
+      label = g_date_time_format (date, "%c");
+      gtk_label_set_label (self->time_label, label);
+    }
+
+  valent_notification_dialog_sync (self);
+}
+
+/*
+ * GAction
+ */
+static void
+dialog_cancel_action (GtkWidget  *widget,
+                      const char *action_name,
+                      GVariant   *parameter)
+{
+  ValentNotificationDialog *self = VALENT_NOTIFICATION_DIALOG (widget);
+
+  g_assert (VALENT_IS_NOTIFICATION_DIALOG (self));
+
+  gtk_window_destroy (GTK_WINDOW (self));
+}
+
+static void
+notification_close_action (GtkWidget  *widget,
+                           const char *action_name,
+                           GVariant   *parameter)
+{
+  ValentNotificationDialog *self = VALENT_NOTIFICATION_DIALOG (widget);
+  const char *id = NULL;
+
+  g_assert (VALENT_IS_NOTIFICATION_DIALOG (self));
+
+  id = valent_notification_get_id (self->notification);
+  g_action_group_activate_action (G_ACTION_GROUP (self->device),
+                                  "notification.close",
+                                  g_variant_new_string (id));
+}
+
+static void
+notification_reply_action (GtkWidget  *widget,
+                           const char *action_name,
+                           GVariant   *parameter)
+{
+  ValentNotificationDialog *self = VALENT_NOTIFICATION_DIALOG (widget);
+  g_autofree char *message = NULL;
+  GVariant *reply = NULL;
+  GtkTextBuffer *buffer;
+
+  if (!g_action_group_get_action_enabled (G_ACTION_GROUP (self->device),
+                                          "notification.reply"))
+    return;
+
+  buffer = gtk_text_view_get_buffer (self->reply_entry);
+  g_object_get (buffer, "text", &message, NULL);
+  g_return_if_fail (message != NULL && *message != '\0');
+
+  reply = g_variant_new ("(ssv)", self->reply_id, message,
+                         valent_notification_serialize (self->notification));
+  g_action_group_activate_action (G_ACTION_GROUP (self->device),
+                                  "notification.reply",
+                                  reply);
+  gtk_window_destroy (GTK_WINDOW (self));
 }
 
 /*
@@ -105,6 +189,38 @@ valent_notification_dialog_dispose (GObject *object)
   gtk_widget_dispose_template (widget, VALENT_TYPE_NOTIFICATION_DIALOG);
 
   G_OBJECT_CLASS (valent_notification_dialog_parent_class)->dispose (object);
+}
+
+static void
+valent_notification_dialog_constructed (GObject *object)
+{
+  ValentNotificationDialog *self = VALENT_NOTIFICATION_DIALOG (object);
+
+  if (self->device != NULL)
+    {
+      gtk_widget_insert_action_group (GTK_WIDGET (self),
+                                      "device",
+                                      G_ACTION_GROUP (self->device));
+      g_signal_connect_object (self->device,
+                               "action-added::notification.reply",
+                               G_CALLBACK (valent_notification_dialog_sync),
+                               self,
+                               G_CONNECT_SWAPPED);
+      g_signal_connect_object (self->device,
+                               "action-removed::notification.reply",
+                               G_CALLBACK (valent_notification_dialog_sync),
+                               self,
+                               G_CONNECT_SWAPPED);
+      g_signal_connect_object (self->device,
+                               "action-enabled-changed::notification.reply",
+                               G_CALLBACK (valent_notification_dialog_sync),
+                               self,
+                               G_CONNECT_SWAPPED);
+    }
+
+  valent_notification_dialog_sync (self);
+
+  G_OBJECT_CLASS (valent_notification_dialog_parent_class)->constructed (object);
 }
 
 static void
@@ -128,6 +244,10 @@ valent_notification_dialog_get_property (GObject    *object,
 
   switch (prop_id)
     {
+    case PROP_DEVICE:
+      g_value_set_object (value, self->device);
+      break;
+
     case PROP_NOTIFICATION:
       g_value_set_object (value, self->notification);
       break;
@@ -151,6 +271,10 @@ valent_notification_dialog_set_property (GObject      *object,
 
   switch (prop_id)
     {
+    case PROP_DEVICE:
+      self->device = g_value_get_object (value);
+      break;
+
     case PROP_NOTIFICATION:
       valent_notification_dialog_set_notification (self, g_value_get_object (value));
       break;
@@ -171,25 +295,45 @@ valent_notification_dialog_class_init (ValentNotificationDialogClass *klass)
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->dispose = valent_notification_dialog_dispose;
+  object_class->constructed = valent_notification_dialog_constructed;
   object_class->finalize = valent_notification_dialog_finalize;
   object_class->get_property = valent_notification_dialog_get_property;
   object_class->set_property = valent_notification_dialog_set_property;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/notification/valent-notification-dialog.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, cancel_button);
-  gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, send_button);
+  gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, reply_button);
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, icon_image);
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, title_label);
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, body_label);
+  gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, time_label);
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, reply_frame);
   gtk_widget_class_bind_template_child (widget_class, ValentNotificationDialog, reply_entry);
+
+  gtk_widget_class_install_action (widget_class, "dialog.cancel", NULL, dialog_cancel_action);
+
+  gtk_widget_class_install_action (widget_class, "notification.close", NULL, notification_close_action);
+  gtk_widget_class_install_action (widget_class, "notification.reply", NULL, notification_reply_action);
+
+  /**
+   * ValentNotificationDialog:device:
+   *
+   * The device that owns the notification.
+   */
+  properties [PROP_DEVICE] =
+    g_param_spec_object ("device", NULL, NULL,
+                         VALENT_TYPE_DEVICE,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
 
   /**
    * ValentNotificationDialog:notification:
    *
    * The notification the dialog represents.
    */
-  properties[PROP_NOTIFICATION] =
+  properties [PROP_NOTIFICATION] =
     g_param_spec_object ("notification", NULL, NULL,
                          VALENT_TYPE_NOTIFICATION,
                          (G_PARAM_READWRITE |
@@ -202,7 +346,7 @@ valent_notification_dialog_class_init (ValentNotificationDialogClass *klass)
    *
    * The notification reply ID.
    */
-  properties[PROP_REPLY_ID] =
+  properties [PROP_REPLY_ID] =
     g_param_spec_string ("reply-id", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
@@ -218,36 +362,18 @@ valent_notification_dialog_init (ValentNotificationDialog *self)
 {
   gtk_widget_init_template (GTK_WIDGET (self));
 
-  g_signal_connect_swapped (gtk_text_view_get_buffer (self->reply_entry),
-                            "notify::text",
-                            G_CALLBACK (valent_notification_dialog_check),
-                            self);
-}
-
-/**
- * valent_notification_dialog_new:
- * @notification: a #ValentNotification
- *
- * Create a new #ValentNotificationDialog.
- *
- * Returns: (transfer full) (nullable): a #GtkDialog
- */
-GtkDialog *
-valent_notification_dialog_new (ValentNotification *notification)
-{
-  g_return_val_if_fail (VALENT_IS_NOTIFICATION (notification), NULL);
-
-  return g_object_new (VALENT_TYPE_NOTIFICATION_DIALOG,
-                       "notification",   notification,
-                       "use-header-bar", TRUE,
-                       NULL);
+  g_signal_connect_object (gtk_text_view_get_buffer (self->reply_entry),
+                           "notify::text",
+                           G_CALLBACK (valent_notification_dialog_sync),
+                           self,
+                           G_CONNECT_SWAPPED);
 }
 
 /**
  * valent_notification_dialog_get_notification:
  * @dialog: a #ValentNotificationDialog
  *
- * Get the #ValentNotification @dialog represents.
+ * Get the notification.
  *
  * Returns: (transfer none): a #ValentNotification
  */
@@ -260,10 +386,10 @@ valent_notification_dialog_get_notification (ValentNotificationDialog *dialog)
 }
 
 /**
- * valent_notification_dialog_get_reply_id:
+ * valent_notification_dialog_get_reply_id: (get-property reply-id)
  * @dialog: a #ValentNotificationDialog
  *
- * Get the notification reply ID for @dialog.
+ * Get the notification reply ID.
  *
  * Returns: (transfer none): the reply ID
  */
@@ -276,11 +402,11 @@ valent_notification_dialog_get_reply_id (ValentNotificationDialog *dialog)
 }
 
 /**
- * valent_notification_dialog_set_reply_id:
+ * valent_notification_dialog_set_reply_id: (set-property reply-id)
  * @dialog: a #ValentNotificationDialog
  * @reply_id: (nullable): a notification reply ID
  *
- * Set the notification reply ID for @dialog.
+ * Set the notification reply ID.
  *
  * If @reply_id is %NULL or empty, the notification can not be replied to.
  */
@@ -293,57 +419,7 @@ valent_notification_dialog_set_reply_id (ValentNotificationDialog *dialog,
   if (!g_set_str (&dialog->reply_id, reply_id))
     return;
 
-  if (reply_id == NULL || *reply_id == '\0')
-    {
-      gtk_widget_set_visible (GTK_WIDGET (dialog->reply_frame), FALSE);
-      gtk_widget_set_visible (GTK_WIDGET (dialog->send_button), FALSE);
-    }
-  else
-    {
-      gtk_widget_set_visible (GTK_WIDGET (dialog->reply_frame), TRUE);
-      gtk_widget_set_visible (GTK_WIDGET (dialog->send_button), TRUE);
-    }
-
+  valent_notification_dialog_sync (dialog);
   g_object_notify_by_pspec (G_OBJECT (dialog), properties [PROP_REPLY_ID]);
-}
-
-/**
- * valent_notification_dialog_get_reply:
- * @dialog: a #ValentNotificationDialog
- *
- * Get the message @dialog
- *
- * Returns: (transfer full): the command text
- */
-char *
-valent_notification_dialog_get_reply (ValentNotificationDialog *dialog)
-{
-  GtkTextBuffer *buffer;
-  GtkTextIter start, end;
-
-  g_return_val_if_fail (VALENT_IS_NOTIFICATION_DIALOG (dialog), NULL);
-
-  buffer = gtk_text_view_get_buffer (dialog->reply_entry);
-  gtk_text_buffer_get_bounds (buffer, &start, &end);
-
-  return gtk_text_buffer_get_text (buffer, &start, &end, FALSE);
-}
-
-/**
- * valent_notification_dialog_update_state:
- * @dialog: a #ValentNotificationDialog
- * @state: the #ValentDevice state
- *
- * Sets whether the associated #ValentDevice is available (i.e. connected and
- * paired).
- */
-void
-valent_notification_dialog_update_state (ValentNotificationDialog *dialog,
-                                         gboolean                  state)
-{
-  g_return_if_fail (VALENT_IS_NOTIFICATION_DIALOG (dialog));
-
-  dialog->state = state;
-  valent_notification_dialog_check (dialog);
 }
 

--- a/src/plugins/notification/valent-notification-dialog.c
+++ b/src/plugins/notification/valent-notification-dialog.c
@@ -290,7 +290,7 @@ valent_notification_dialog_set_reply_id (ValentNotificationDialog *dialog,
 {
   g_return_if_fail (VALENT_IS_NOTIFICATION_DIALOG (dialog));
 
-  if (!valent_set_string (&dialog->reply_id, reply_id))
+  if (!g_set_str (&dialog->reply_id, reply_id))
     return;
 
   if (reply_id == NULL || *reply_id == '\0')

--- a/src/plugins/notification/valent-notification-dialog.h
+++ b/src/plugins/notification/valent-notification-dialog.h
@@ -9,16 +9,11 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_NOTIFICATION_DIALOG (valent_notification_dialog_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentNotificationDialog, valent_notification_dialog, VALENT, NOTIFICATION_DIALOG, GtkDialog)
+G_DECLARE_FINAL_TYPE (ValentNotificationDialog, valent_notification_dialog, VALENT, NOTIFICATION_DIALOG, GtkWindow)
 
-GtkDialog          * valent_notification_dialog_new              (ValentNotification       *notification);
 ValentNotification * valent_notification_dialog_get_notification (ValentNotificationDialog *dialog);
-char               * valent_notification_dialog_get_reply        (ValentNotificationDialog *dialog);
 const char         * valent_notification_dialog_get_reply_id     (ValentNotificationDialog *dialog);
 void                 valent_notification_dialog_set_reply_id     (ValentNotificationDialog *dialog,
                                                                   const char               *reply_id);
-void                 valent_notification_dialog_update_state     (ValentNotificationDialog *dialog,
-                                                                  gboolean                  state);
-
 
 G_END_DECLS

--- a/src/plugins/notification/valent-notification-dialog.ui
+++ b/src/plugins/notification/valent-notification-dialog.ui
@@ -4,140 +4,222 @@
 <!-- SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com> -->
 
 <interface domain="valent">
-  <template class="ValentNotificationDialog" parent="GtkDialog">
-    <property name="default-width">320</property>
+  <template class="ValentNotificationDialog" parent="GtkWindow">
+    <property name="default-width">360</property>
     <property name="default-height">294</property>
-    <property name="width-request">320</property>
+    <property name="width-request">360</property>
     <property name="height-request">294</property>
     <property name="title" translatable="yes">Notification</property>
-    <child type="action">
-      <object class="GtkButton" id="cancel_button">
-        <property name="label" translatable="yes">Cancel</property>
+    <property name="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="show-title-buttons">0</property>
+        <child type="start">
+          <object class="GtkButton" id="cancel_button">
+            <property name="action-name">dialog.cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
+            <property name="use-underline">1</property>
+         </object>
+        </child>
+        <child type="end">
+          <object class="GtkButton" id="reply_button">
+            <property name="action-name">notification.reply</property>
+            <property name="label" translatable="yes">_Reply</property>
+            <property name="use-underline">1</property>
+            <accessibility>
+              <property name="description">Reply to the notification</property>
+            </accessibility>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+         </object>
+        </child>
       </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="send_button">
-        <property name="label" translatable="yes">Send</property>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">cancel_button</action-widget>
-      <action-widget response="ok" default="true">send_button</action-widget>
-    </action-widgets>
-    <child internal-child="content_area">
-      <object class="GtkBox">
-        <property name="margin-top">12</property>
-        <property name="margin-bottom">12</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
+    </property>
+    <property name="child">
+      <object class="AdwClamp">
         <child>
-          <object class="GtkFrame">
-            <property name="valign">start</property>
-            <property name="vexpand">0</property>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+
+            <!-- Mock Notification -->
             <child>
-              <object class="GtkBox">
-                <property name="orientation">vertical</property>
+              <object class="GtkFrame">
+                <property name="accessible-role">presentation</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="valign">start</property>
+                <style>
+                  <class name="osd"/>
+                </style>
                 <child>
-                  <object class="GtkGrid">
-                    <property name="column-spacing">12</property>
-                    <property name="row-spacing">6</property>
-                    <property name="margin-top">12</property>
-                    <property name="margin-bottom">12</property>
-                    <property name="margin-start">12</property>
-                    <property name="margin-end">12</property>
+                  <object class="GtkGrid" id="notification_grid">
+                    <property name="accessible-role">group</property>
+                    <accessibility>
+                      <relation name="labelled-by">title_label</relation>
+                      <relation name="described-by">body_label</relation>
+                    </accessibility>
+                    <style>
+                      <class name="notification"/>
+                    </style>
                     <child>
-                      <object class="GtkImage" id="icon_image">
-                        <property name="halign">start</property>
-                        <property name="valign">start</property>
-                        <property name="icon-name">phonelink-symbolic</property>
-                        <property name="pixel-size">32</property>
+                      <object class="GtkGrid" id="notification_content">
+                        <property name="accessible-role">presentation</property>
+                        <property name="column-spacing">6</property>
+                        <property name="row-spacing">6</property>
+                        <property name="margin-top">18</property>
+                        <property name="margin-bottom">18</property>
+                        <property name="margin-start">18</property>
+                        <property name="margin-end">18</property>
                         <layout>
                           <property name="column">0</property>
                           <property name="row">0</property>
-                          <property name="row-span">2</property>
                         </layout>
+                        <child>
+                          <object class="GtkImage" id="icon_image">
+                            <property name="margin-end">6</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                            <property name="icon-name">dialog-information-symbolic</property>
+                            <property name="pixel-size">32</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="title_label">
+                            <property name="halign">start</property>
+                            <property name="label">No Title</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="time_label">
+                            <property name="halign">start</property>
+                            <property name="hexpand">1</property>
+                            <property name="valign">end</property>
+                            <layout>
+                              <property name="column">2</property>
+                              <property name="row">0</property>
+                            </layout>
+                            <style>
+                              <class name="caption"/>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="body_label">
+                            <property name="hexpand">1</property>
+                            <property name="use-markup">1</property>
+                            <property name="wrap">1</property>
+                            <property name="wrap-mode">word-char</property>
+                            <property name="xalign">0</property>
+                            <property name="yalign">0</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">1</property>
+                              <property name="column-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="title_label">
-                        <property name="halign">start</property>
-                        <property name="hexpand">1</property>
-                        <property name="label">No Title</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
+                      <object class="GtkButton" id="close_button">
+                        <property name="action-name">notification.close</property>
+                        <property name="child">
+                          <object class="GtkImage">
+                            <property name="icon-name">window-close-symbolic</property>
+                            <property name="pixel-size">16</property>
+                          </object>
+                        </property>
+                        <property name="valign">start</property>
+                        <property name="visible">0</property>
+                        <accessibility>
+                          <property name="label" translatable="yes">Close</property>
+                          <property name="description" translatable="yes">Close the notification</property>
+                        </accessibility>
                         <layout>
                           <property name="column">1</property>
                           <property name="row">0</property>
                         </layout>
+                        <style>
+                          <class name="circular"/>
+                        </style>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="body_label">
+                      <object class="GtkBox" id="notification_buttons">
+                        <property name="accessible-role">group</property>
                         <property name="hexpand">1</property>
-                        <property name="use-markup">1</property>
-                        <property name="wrap">1</property>
-                        <property name="wrap-mode">word-char</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0</property>
+                        <property name="homogeneous">1</property>
                         <layout>
-                          <property name="column">1</property>
+                          <property name="column">0</property>
+                          <property name="column-span">2</property>
                           <property name="row">1</property>
                         </layout>
+                        <style>
+                          <class name="linked"/>
+                          <class name="notification-buttons"/>
+                        </style>
+                        <child>
+                          <object class="GtkButton" id="button1">
+                            <property name="visible">0</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button2">
+                            <property name="visible">0</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button3">
+                            <property name="visible">0</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkBox" id="notification_buttons">
-                    <property name="hexpand">1</property>
-                    <property name="homogeneous">1</property>
-                    <property name="visible">0</property>
-                    <child>
-                      <object class="GtkButton" id="button1">
-                        <property name="visible">0</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button2">
-                        <property name="visible">0</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button3">
-                        <property name="visible">0</property>
-                      </object>
-                    </child>
-                    <style>
-                      <class name="linked"/>
-                      <class name="notification-buttons"/>
-                    </style>
                   </object>
                 </child>
               </object>
             </child>
-            <style>
-              <class name="notification"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFrame" id="reply_frame">
-            <property name="visible">0</property>
+
+            <!-- Reply Entry -->
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar-policy">never</property>
+              <object class="GtkBox">
+                <style>
+                  <class name="message-area"/>
+                </style>
                 <child>
-                  <object class="GtkTextView" id="reply_entry">
-                    <property name="hexpand">1</property>
-                    <property name="vexpand">1</property>
-                    <property name="top-margin">6</property>
-                    <property name="bottom-margin">6</property>
-                    <property name="left-margin">6</property>
-                    <property name="right-margin">6</property>
-                    <property name="wrap-mode">word-char</property>
+                  <object class="GtkFrame" id="reply_frame">
+                    <property name="visible">0</property>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="hscrollbar-policy">never</property>
+                        <child>
+                          <object class="GtkTextView" id="reply_entry">
+                            <property name="hexpand">1</property>
+                            <property name="vexpand">1</property>
+                            <property name="top-margin">6</property>
+                            <property name="bottom-margin">6</property>
+                            <property name="left-margin">6</property>
+                            <property name="right-margin">6</property>
+                            <property name="wrap-mode">word-char</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -145,6 +227,9 @@
           </object>
         </child>
       </object>
-    </child>
+    </property>
+    <style>
+      <class name="messagedialog"/>
+    </style>
   </template>
 </interface>

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -814,40 +814,6 @@ notification_close_action (GSimpleAction *action,
 }
 
 static void
-on_notification_reply (ValentNotificationDialog *dialog,
-                       int                       response_id,
-                       ValentNotificationPlugin *self)
-{
-  ValentNotification *notification = NULL;
-  g_autofree char *reply = NULL;
-  const char *reply_id;
-
-  g_assert (VALENT_IS_NOTIFICATION_DIALOG (dialog));
-  g_assert (VALENT_IS_NOTIFICATION_PLUGIN (self));
-
-  notification = valent_notification_dialog_get_notification (dialog);
-  reply = valent_notification_dialog_get_reply (dialog);
-  reply_id = valent_notification_dialog_get_reply_id (dialog);
-
-  if (response_id == GTK_RESPONSE_OK && *reply != '\0')
-    {
-      g_autoptr (JsonBuilder) builder = NULL;
-      g_autoptr (JsonNode) packet = NULL;
-
-      valent_packet_init (&builder, "kdeconnect.notification.reply");
-      json_builder_set_member_name (builder, "requestReplyId");
-      json_builder_add_string_value (builder, reply_id);
-      json_builder_set_member_name (builder, "message");
-      json_builder_add_string_value (builder, reply);
-      packet = valent_packet_end (&builder);
-
-      valent_device_plugin_queue_packet (VALENT_DEVICE_PLUGIN (self), packet);
-    }
-
-  g_hash_table_remove (self->dialogs, notification);
-}
-
-static void
 notification_reply_action (GSimpleAction *action,
                            GVariant      *parameter,
                            gpointer       user_data)
@@ -885,27 +851,16 @@ notification_reply_action (GSimpleAction *action,
       if ((dialog = g_hash_table_lookup (self->dialogs, notification)) == NULL)
         {
           ValentDevice *device;
-          ValentDeviceState state;
-          gboolean available;
-
-          dialog = g_object_new (VALENT_TYPE_NOTIFICATION_DIALOG,
-                                 "notification",   notification,
-                                 "reply-id",       reply_id,
-                                 "use-header-bar", TRUE,
-                                 NULL);
-          g_signal_connect (dialog,
-                            "response",
-                            G_CALLBACK (on_notification_reply),
-                            self);
-          g_hash_table_insert (self->dialogs,
-                               g_object_ref (notification),
-                               g_object_ref (dialog));
 
           device = valent_extension_get_object (VALENT_EXTENSION (self));
-          state = valent_device_get_state (device);
-          available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
-                      (state & VALENT_DEVICE_STATE_PAIRED) != 0;
-          valent_notification_dialog_update_state (dialog, available);
+          dialog = g_object_new (VALENT_TYPE_NOTIFICATION_DIALOG,
+                                 "device",       device,
+                                 "notification", notification,
+                                 "reply-id",     reply_id,
+                                 NULL);
+          g_hash_table_insert (self->dialogs,
+                               g_object_ref (notification),
+                               g_object_ref_sink (dialog));
         }
 
       gtk_window_present (GTK_WINDOW (dialog));
@@ -979,8 +934,6 @@ valent_notification_plugin_update_state (ValentDevicePlugin *plugin,
                                          ValentDeviceState   state)
 {
   ValentNotificationPlugin *self = VALENT_NOTIFICATION_PLUGIN (plugin);
-  GHashTableIter iter;
-  ValentNotificationDialog *dialog;
   gboolean available;
 
   g_assert (VALENT_IS_NOTIFICATION_PLUGIN (self));
@@ -997,12 +950,6 @@ valent_notification_plugin_update_state (ValentDevicePlugin *plugin,
       valent_notification_plugin_request_notifications (self);
       VALENT_NOTE ("TODO: send active notifications");
     }
-
-  /* Update Reply Dialogs */
-  g_hash_table_iter_init (&iter, self->dialogs);
-
-  while (g_hash_table_iter_next (&iter, NULL, (void **)&dialog))
-    valent_notification_dialog_update_state (dialog, available);
 }
 
 static void

--- a/src/plugins/runcommand/valent-runcommand-editor.c
+++ b/src/plugins/runcommand/valent-runcommand-editor.c
@@ -193,7 +193,7 @@ valent_runcommand_editor_set_uuid (ValentRuncommandEditor *editor,
   if (uuid == NULL)
     uuid = "";
 
-  valent_set_string (&editor->uuid, uuid);
+  g_set_str (&editor->uuid, uuid);
 }
 
 /**

--- a/src/plugins/runcommand/valent-runcommand-editor.h
+++ b/src/plugins/runcommand/valent-runcommand-editor.h
@@ -9,17 +9,13 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_RUNCOMMAND_EDITOR (valent_runcommand_editor_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentRuncommandEditor, valent_runcommand_editor, VALENT, RUNCOMMAND_EDITOR, GtkDialog)
+G_DECLARE_FINAL_TYPE (ValentRuncommandEditor, valent_runcommand_editor, VALENT, RUNCOMMAND_EDITOR, GtkWindow)
 
-const char * valent_runcommand_editor_get_command (ValentRuncommandEditor *editor);
+GVariant   * valent_runcommand_editor_get_command (ValentRuncommandEditor *editor);
 void         valent_runcommand_editor_set_command (ValentRuncommandEditor *editor,
-                                                   const char             *command);
-const char * valent_runcommand_editor_get_name    (ValentRuncommandEditor *editor);
-void         valent_runcommand_editor_set_name    (ValentRuncommandEditor *editor,
-                                                   const char             *name);
+                                                   GVariant               *command);
 const char * valent_runcommand_editor_get_uuid    (ValentRuncommandEditor *editor);
 void         valent_runcommand_editor_set_uuid    (ValentRuncommandEditor *editor,
                                                    const char             *uuid);
-void         valent_runcommand_editor_clear       (ValentRuncommandEditor *editor);
 
 G_END_DECLS

--- a/src/plugins/runcommand/valent-runcommand-editor.ui
+++ b/src/plugins/runcommand/valent-runcommand-editor.ui
@@ -4,95 +4,81 @@
 <!-- SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com> -->
 
 <interface domain="valent">
-  <template class="ValentRuncommandEditor" parent="GtkDialog">
-    <property name="title" translatable="yes">Edit</property>
-    <property name="hide-on-close">1</property>
-    <child type="action">
-      <object class="GtkButton" id="cancel_button">
-        <property name="label" translatable="yes">Cancel</property>
+  <template class="ValentRuncommandEditor" parent="GtkWindow">
+    <property name="title" translatable="yes">Edit Command</property>
+    <property name="width-request">360</property>
+    <property name="height-request">294</property>
+    <property name="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="show-title-buttons">0</property>
+        <child type="start">
+          <object class="GtkButton">
+            <property name="action-name">editor.cancel</property>
+            <property name="label" translatable="yes">_Cancel</property>
+            <property name="use-underline">1</property>
+         </object>
+        </child>
+        <child type="end">
+          <object class="GtkButton" id="save_button">
+            <property name="action-name">editor.save</property>
+            <property name="label" translatable="yes">_Save</property>
+            <property name="use-underline">1</property>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+         </object>
+        </child>
       </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="save_button">
-        <property name="label" translatable="yes">Save</property>
-        <property name="sensitive">0</property>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">cancel_button</action-widget>
-      <action-widget response="accept" default="true">save_button</action-widget>
-    </action-widgets>
-    <child internal-child="content_area">
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
+    </property>
+    <property name="child">
+      <object class="AdwPreferencesPage">
         <child>
-          <object class="GtkGrid">
-            <property name="valign">start</property>
-            <property name="margin-start">12</property>
-            <property name="margin-end">12</property>
-            <property name="margin-top">8</property>
-            <property name="margin-bottom">8</property>
-            <property name="hexpand">1</property>
+          <object class="AdwPreferencesGroup">
+            <child>
+              <object class="AdwEntryRow" id="name_entry">
+                <property name="title" translatable="yes">Name</property>
+                <signal name="changed"
+                        handler="on_entry_changed"
+                        object="ValentRuncommandEditor"
+                        swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="AdwEntryRow" id="argv_entry">
+                <property name="title" translatable="yes">Command Line</property>
+                <signal name="changed"
+                        handler="on_entry_changed"
+                        object="ValentRuncommandEditor"
+                        swapped="no"/>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="remove_group">
+            <property name="valign">end</property>
             <property name="vexpand">1</property>
-            <property name="row-spacing">6</property>
-            <property name="column-spacing">12</property>
             <child>
-              <object class="GtkLabel">
-                <property name="halign">end</property>
-                <property name="xalign">1</property>
-                <property name="label" translatable="yes">Name</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">0</property>
-                </layout>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="name_entry">
-                <property name="activates-default">1</property>
-                <property name="valign">center</property>
-                <property name="hexpand">1</property>
-                <signal name="changed" handler="on_entry_changed" object="ValentRuncommandEditor" swapped="no"/>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">0</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">end</property>
-                <property name="xalign">1</property>
-                <property name="label" translatable="yes">Command Line</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">1</property>
-                </layout>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="command_entry">
-                <property name="activates-default">1</property>
-                <property name="valign">center</property>
-                <property name="hexpand">1</property>
-                <signal name="changed" handler="on_entry_changed" object="ValentRuncommandEditor" swapped="no"/>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">1</property>
-                </layout>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Remove the command</property>
+                <property name="activatable">0</property>
+                <property name="selectable">0</property>
+                <child type="suffix">
+                  <object class="GtkButton">
+                    <property name="action-name">editor.remove</property>
+                    <property name="label" translatable="yes">Remove</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="destructive-action"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
           </object>
         </child>
       </object>
-    </child>
+    </property>
   </template>
 </interface>
 

--- a/src/plugins/runcommand/valent-runcommand-preferences.c
+++ b/src/plugins/runcommand/valent-runcommand-preferences.c
@@ -20,266 +20,25 @@ struct _ValentRuncommandPreferences
 {
   ValentDevicePreferencesGroup  parent_instance;
 
-  GtkWindow                    *command_dialog;
+  GtkWindow                    *editor;
 
   /* template */
+  AdwExpanderRow               *command_list_row;
   GtkListBox                   *command_list;
-  GtkWidget                    *command_add;
 };
 
 G_DEFINE_FINAL_TYPE (ValentRuncommandPreferences, valent_runcommand_preferences, VALENT_TYPE_DEVICE_PREFERENCES_GROUP)
 
 
-static void edit_command      (ValentRuncommandPreferences *self,
-                               const char                  *uuid,
-                               const char                  *name,
-                               const char                  *command);
-static void remove_command    (ValentRuncommandPreferences *self,
-                               const char                  *uuid);
-static void populate_commands (ValentRuncommandPreferences *self);
-static void save_command      (ValentRuncommandPreferences *self,
-                               const char                  *uuid,
-                               const char                  *name,
-                               const char                  *command);
-
-
-/*
- * GSettings functions
- */
-static void
-edit_command_response (GtkDialog                   *dialog,
-                       int                          response_id,
-                       ValentRuncommandPreferences *self)
-{
-  ValentRuncommandEditor *editor = VALENT_RUNCOMMAND_EDITOR (dialog);
-
-  g_assert (VALENT_IS_RUNCOMMAND_EDITOR (editor));
-
-  if (response_id == GTK_RESPONSE_ACCEPT)
-    {
-      const char *command;
-      const char *name;
-      const char *uuid;
-
-      command = valent_runcommand_editor_get_command (editor);
-      name = valent_runcommand_editor_get_name (editor);
-      uuid = valent_runcommand_editor_get_uuid (editor);
-      save_command (self, uuid, name, command);
-    }
-
-  valent_runcommand_editor_clear (editor);
-  gtk_window_close (GTK_WINDOW (dialog));
-}
-
-static void
-edit_command (ValentRuncommandPreferences *self,
-              const char                  *uuid,
-              const char                  *name,
-              const char                  *command)
-{
-  ValentRuncommandEditor *editor;
-
-  if (self->command_dialog == NULL)
-    {
-      GtkRoot *window;
-
-      window = gtk_widget_get_root (GTK_WIDGET (self));
-      self->command_dialog = g_object_new (VALENT_TYPE_RUNCOMMAND_EDITOR,
-                                           "use-header-bar", TRUE,
-                                           "modal",          (window != NULL),
-                                           "transient-for",  window,
-                                           NULL);
-
-      g_signal_connect (self->command_dialog,
-                        "response",
-                        G_CALLBACK (edit_command_response),
-                        self);
-      g_object_add_weak_pointer (G_OBJECT (self->command_dialog),
-                                 (gpointer) &self->command_dialog);
-    }
-
-
-  editor = VALENT_RUNCOMMAND_EDITOR (self->command_dialog);
-  valent_runcommand_editor_set_uuid (editor, uuid);
-  valent_runcommand_editor_set_name (editor, name);
-  valent_runcommand_editor_set_command (editor, command);
-
-  gtk_window_present_with_time (self->command_dialog, GDK_CURRENT_TIME);
-}
-
-static void
-remove_command (ValentRuncommandPreferences *self,
-                const char                  *uuid)
-{
-  ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
-  GSettings *settings;
-  g_autoptr (GVariant) commands = NULL;
-  GVariantDict dict;
-  GVariant *value;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  settings = valent_device_preferences_group_get_settings (group);
-  commands = g_settings_get_value (settings, "commands");
-
-  g_variant_dict_init (&dict, commands);
-  g_variant_dict_remove (&dict, uuid);
-  value = g_variant_dict_end (&dict);
-
-  g_settings_set_value (settings, "commands", value);
-}
-
-static void
-save_command (ValentRuncommandPreferences *self,
-              const char                  *uuid,
-              const char                  *name,
-              const char                  *command)
-{
-  ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
-  GSettings *settings;
-  g_autoptr (GVariant) commands = NULL;
-  GVariantDict dict;
-  GVariant *item;
-  GVariant *value;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  settings = valent_device_preferences_group_get_settings (group);
-  commands = g_settings_get_value (settings, "commands");
-
-  item = g_variant_new_parsed ("{'name': <%s>, 'command': <%s>}",
-                               name,
-                               command);
-
-  g_variant_dict_init (&dict, commands);
-  g_variant_dict_insert_value (&dict, uuid, item);
-  value = g_variant_dict_end (&dict);
-
-  g_settings_set_value (settings, "commands", value);
-}
-
-static void
-on_commands_changed (GSettings                   *settings,
-                     const char                  *key,
-                     ValentRuncommandPreferences *self)
-{
-  g_assert (G_IS_SETTINGS (settings));
-  g_assert (key != NULL);
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  populate_commands (self);
-}
-
-/*
- * UI Callbacks
- */
-static void
-on_add_command (GtkListBox                  *box,
-                GtkListBoxRow               *row,
-                ValentRuncommandPreferences *self)
-{
-  g_autofree char *uuid = NULL;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  uuid = g_uuid_string_random ();
-  edit_command (self, uuid, "", "");
-}
-
-static void
-on_edit_command (GtkButton                   *button,
-                 ValentRuncommandPreferences *self)
-{
-  GtkWidget *row;
-  const char *name;
-  const char *command;
-  const char *uuid;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  row = gtk_widget_get_ancestor (GTK_WIDGET (button), GTK_TYPE_LIST_BOX_ROW);
-  uuid = gtk_widget_get_name (row);
-  name = adw_preferences_row_get_title (ADW_PREFERENCES_ROW (row));
-  command = adw_action_row_get_subtitle (ADW_ACTION_ROW (row));
-
-  edit_command (self, uuid, name, command);
-}
-
-static void
-on_remove_command (GtkButton                   *button,
-                   ValentRuncommandPreferences *self)
-{
-  GtkWidget *row;
-  const char *uuid;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  row = gtk_widget_get_ancestor (GTK_WIDGET (button), GTK_TYPE_LIST_BOX_ROW);
-  uuid = gtk_widget_get_name (GTK_WIDGET (row));
-  remove_command (self, uuid);
-}
-
 /*
  * Rows
  */
 static void
-add_command_row (ValentRuncommandPreferences *self,
-                 const char                  *uuid,
-                 const char                  *name,
-                 const char                  *command)
-{
-  GtkWidget *row;
-  GtkWidget *edit;
-  GtkWidget *delete;
-  GtkWidget *buttons;
-
-  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
-
-  /* Row */
-  row = g_object_new (ADW_TYPE_ACTION_ROW,
-                      "name",        uuid,
-                      "title",       name,
-                      "subtitle",    command,
-                      "activatable", FALSE,
-                      NULL);
-
-  /* Buttons */
-  buttons = g_object_new (GTK_TYPE_BOX,
-                          "orientation", GTK_ORIENTATION_HORIZONTAL,
-                          "spacing",     6,
-                          "valign",      GTK_ALIGN_CENTER,
-                          NULL);
-  adw_action_row_add_suffix (ADW_ACTION_ROW (row), buttons);
-
-  edit = g_object_new (GTK_TYPE_BUTTON,
-                       "icon-name",    "document-edit-symbolic",
-                       "tooltip-text", _("Edit"),
-                       NULL);
-  gtk_box_insert_child_after (GTK_BOX (buttons), edit, NULL);
-  g_signal_connect (G_OBJECT (edit),
-                    "clicked",
-                    G_CALLBACK (on_edit_command),
-                    self);
-
-  delete = g_object_new (GTK_TYPE_BUTTON,
-                         "icon-name",    "edit-delete-symbolic",
-                         "tooltip-text", _("Remove"),
-                         NULL);
-  gtk_box_insert_child_after (GTK_BOX (buttons), delete, edit);
-  g_signal_connect (G_OBJECT (delete),
-                    "clicked",
-                    G_CALLBACK (on_remove_command),
-                    self);
-
-  gtk_list_box_insert (self->command_list, row, -1);
-}
-
-static void
-populate_commands (ValentRuncommandPreferences *self)
+valent_runcommand_preferences_populate (ValentRuncommandPreferences *self)
 {
   ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
-  GtkWidget *child;
   GSettings *settings;
+  GtkWidget *child;
   g_autoptr (GVariant) commands = NULL;
   GVariantIter iter;
   char *uuid;
@@ -287,8 +46,13 @@ populate_commands (ValentRuncommandPreferences *self)
 
   g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
 
-  while ((child = gtk_widget_get_first_child (GTK_WIDGET (self->command_list))))
-    gtk_list_box_remove (self->command_list, child);
+  for (child = gtk_widget_get_first_child (GTK_WIDGET (self->command_list));
+       child != NULL;)
+    {
+      GtkWidget *current_child = child;
+      child = gtk_widget_get_next_sibling (current_child);
+      gtk_list_box_remove (self->command_list, current_child);
+    }
 
   settings = valent_device_preferences_group_get_settings (group);
   commands = g_settings_get_value (settings, "commands");
@@ -302,7 +66,35 @@ populate_commands (ValentRuncommandPreferences *self)
 
       if (g_variant_lookup (item, "name", "&s", &name) &&
           g_variant_lookup (item, "command", "&s", &command))
-        add_command_row (self, uuid, name, command);
+        {
+          GtkWidget *row;
+          GtkWidget *icon;
+
+          row = g_object_new (ADW_TYPE_ACTION_ROW,
+                              "name",          uuid,
+                              "title",         name,
+                              "subtitle",      command,
+                              "activatable",   TRUE,
+                              "action-target", g_variant_new_string (uuid),
+                              "action-name",   "runcommand.edit",
+                              NULL);
+
+          icon = g_object_new (GTK_TYPE_IMAGE,
+                               "icon-name",    "document-edit-symbolic",
+                               "tooltip-text", _("Edit Command"),
+                               NULL);
+          gtk_widget_add_css_class (icon, "dim-label");
+          adw_action_row_add_suffix (ADW_ACTION_ROW (row), icon);
+
+          /* a11y: an activatable widget would change the label and description,
+           * but a button is unnecessary and the label should be unchanged. */
+          gtk_accessible_update_relation (GTK_ACCESSIBLE (row),
+                                          GTK_ACCESSIBLE_RELATION_DESCRIBED_BY,
+                                            icon, NULL,
+                                          -1);
+
+          gtk_list_box_append (self->command_list, row);
+        }
 
       g_clear_pointer (&uuid, g_free);
       g_clear_pointer (&item, g_variant_unref);
@@ -323,6 +115,161 @@ sort_commands (GtkListBoxRow *row1,
   return g_utf8_collate (title1, title2);
 }
 
+static inline GtkListBox *
+_adw_expander_row_get_list (AdwExpanderRow *row)
+{
+  GtkWidget *box;
+  GtkWidget *child;
+
+  /* First child is a GtkBox */
+  box = gtk_widget_get_first_child (GTK_WIDGET (row));
+
+  /* The GtkBox contains the primary AdwActionRow and a GtkRevealer */
+  for (child = gtk_widget_get_first_child (box);
+       child != NULL;
+       child = gtk_widget_get_next_sibling (child))
+    {
+      if (GTK_IS_REVEALER (child))
+        break;
+    }
+
+  /* The GtkRevealer's child is the GtkListBox */
+  if (GTK_IS_REVEALER (child))
+    return GTK_LIST_BOX (gtk_revealer_get_child (GTK_REVEALER (child)));
+
+  return NULL;
+}
+
+/*
+ * GAction
+ */
+static void
+on_command_changed (ValentRuncommandEditor      *editor,
+                    GParamSpec                  *pspec,
+                    ValentRuncommandPreferences *self)
+{
+  const char *uuid;
+  GVariant *command;
+
+  g_assert (VALENT_IS_RUNCOMMAND_EDITOR (editor));
+  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
+
+  uuid = valent_runcommand_editor_get_uuid (editor);
+  command = valent_runcommand_editor_get_command (editor);
+
+  if (command != NULL)
+    gtk_widget_activate_action (GTK_WIDGET (self), "runcommand.save", "s", uuid);
+  else
+    gtk_widget_activate_action (GTK_WIDGET (self), "runcommand.remove", "s", uuid);
+
+  gtk_window_destroy (GTK_WINDOW (editor));
+}
+
+static void
+runcommand_add_action (GtkWidget  *widget,
+                       const char *action_name,
+                       GVariant   *parameter)
+{
+  g_autofree char *uuid = NULL;
+
+  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (widget));
+
+  uuid = g_uuid_string_random ();
+  gtk_widget_activate_action (widget, "runcommand.edit", "s", uuid);
+}
+
+static void
+runcommand_edit_action (GtkWidget  *widget,
+                        const char *action_name,
+                        GVariant   *parameter)
+{
+  ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (widget);
+  ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
+  const char *uuid = NULL;
+  GSettings *settings;
+  GtkRoot *window;
+  g_autoptr (GVariant) commands = NULL;
+  g_autoptr (GVariant) command = NULL;
+
+  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
+
+  uuid = g_variant_get_string (parameter, NULL);
+  settings = valent_device_preferences_group_get_settings (group);
+  commands = g_settings_get_value (settings, "commands");
+  g_variant_lookup (commands, uuid, "@a{sv}", &command);
+
+  window = gtk_widget_get_root (GTK_WIDGET (self));
+  self->editor = g_object_new (VALENT_TYPE_RUNCOMMAND_EDITOR,
+                               "uuid",          uuid,
+                               "command",       command,
+                               "modal",         (window != NULL),
+                               "transient-for", window,
+                               NULL);
+  g_object_add_weak_pointer (G_OBJECT (self->editor),
+                             (gpointer) &self->editor);
+  g_signal_connect_object (self->editor,
+                           "notify::command",
+                           G_CALLBACK (on_command_changed),
+                           self, 0);
+
+  gtk_window_present_with_time (self->editor, GDK_CURRENT_TIME);
+}
+
+static void
+runcommand_save_action (GtkWidget  *widget,
+                        const char *action_name,
+                        GVariant   *parameter)
+{
+  ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (widget);
+  ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
+  GSettings *settings;
+  g_autoptr (GVariant) commands = NULL;
+  GVariant *command;
+  const char *uuid;
+  GVariantDict dict;
+  GVariant *value;
+
+  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
+
+  settings = valent_device_preferences_group_get_settings (group);
+  commands = g_settings_get_value (settings, "commands");
+
+  uuid = valent_runcommand_editor_get_uuid (VALENT_RUNCOMMAND_EDITOR (self->editor));
+  command = valent_runcommand_editor_get_command (VALENT_RUNCOMMAND_EDITOR (self->editor));
+
+  g_variant_dict_init (&dict, commands);
+  g_variant_dict_insert_value (&dict, uuid, command);
+  value = g_variant_dict_end (&dict);
+
+  g_settings_set_value (settings, "commands", value);
+}
+
+static void
+runcommand_remove_action (GtkWidget  *widget,
+                          const char *action_name,
+                          GVariant   *parameter)
+{
+  ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (widget);
+  ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
+  GSettings *settings;
+  g_autoptr (GVariant) commands = NULL;
+  GVariantDict dict;
+  GVariant *value;
+  const char *uuid = NULL;
+
+  g_assert (VALENT_IS_RUNCOMMAND_PREFERENCES (self));
+
+  uuid = g_variant_get_string (parameter, NULL);
+  settings = valent_device_preferences_group_get_settings (group);
+  commands = g_settings_get_value (settings, "commands");
+
+  g_variant_dict_init (&dict, commands);
+  g_variant_dict_remove (&dict, uuid);
+  value = g_variant_dict_end (&dict);
+
+  g_settings_set_value (settings, "commands", value);
+}
+
 /*
  * GObject
  */
@@ -333,15 +280,16 @@ valent_runcommand_preferences_constructed (GObject *object)
   ValentDevicePreferencesGroup *group = VALENT_DEVICE_PREFERENCES_GROUP (self);
   GSettings *settings;
 
+  gtk_list_box_set_sort_func (self->command_list, sort_commands, self, NULL);
+
+  /* Setup GSettings */
   settings = valent_device_preferences_group_get_settings (group);
   g_signal_connect_object (settings,
                            "changed::commands",
-                           G_CALLBACK (on_commands_changed),
-                           self, 0);
-
-  /* Populate list */
-  gtk_list_box_set_sort_func (self->command_list, sort_commands, self, NULL);
-  populate_commands (self);
+                           G_CALLBACK (valent_runcommand_preferences_populate),
+                           self,
+                           G_CONNECT_SWAPPED);
+  valent_runcommand_preferences_populate (self);
 
   G_OBJECT_CLASS (valent_runcommand_preferences_parent_class)->constructed (object);
 }
@@ -361,7 +309,7 @@ valent_runcommand_preferences_finalize (GObject *object)
 {
   ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (object);
 
-  g_clear_pointer (&self->command_dialog, gtk_window_destroy);
+  g_clear_pointer (&self->editor, gtk_window_destroy);
 
   G_OBJECT_CLASS (valent_runcommand_preferences_parent_class)->finalize (object);
 }
@@ -377,14 +325,19 @@ valent_runcommand_preferences_class_init (ValentRuncommandPreferencesClass *klas
   object_class->finalize = valent_runcommand_preferences_finalize;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/runcommand/valent-runcommand-preferences.ui");
-  gtk_widget_class_bind_template_child (widget_class, ValentRuncommandPreferences, command_list);
-  gtk_widget_class_bind_template_child (widget_class, ValentRuncommandPreferences, command_add);
-  gtk_widget_class_bind_template_callback (widget_class, on_add_command);
+  gtk_widget_class_bind_template_child (widget_class, ValentRuncommandPreferences, command_list_row);
+
+  gtk_widget_class_install_action (widget_class, "runcommand.add", NULL, runcommand_add_action);
+  gtk_widget_class_install_action (widget_class, "runcommand.edit", "s", runcommand_edit_action);
+  gtk_widget_class_install_action (widget_class, "runcommand.remove", "s", runcommand_remove_action);
+  gtk_widget_class_install_action (widget_class, "runcommand.save", "s", runcommand_save_action);
 }
 
 static void
 valent_runcommand_preferences_init (ValentRuncommandPreferences *self)
 {
   gtk_widget_init_template (GTK_WIDGET (self));
+
+  self->command_list = _adw_expander_row_get_list (self->command_list_row);
 }
 

--- a/src/plugins/runcommand/valent-runcommand-preferences.ui
+++ b/src/plugins/runcommand/valent-runcommand-preferences.ui
@@ -5,46 +5,24 @@
 
 <interface domain="valent">
   <template class="ValentRuncommandPreferences" parent="ValentDevicePreferencesGroup">
+    <child type="header-suffix">
+      <object class="GtkButton">
+        <property name="action-name">runcommand.add</property>
+        <property name="icon-name">list-add-symbolic</property>
+        <property name="valign">end</property>
+        <accessibility>
+          <property name="label" translatable="yes">Add a command</property>
+        </accessibility>
+        <style>
+          <class name="accent"/>
+          <class name="circular"/>
+        </style>
+      </object>
+    </child>
     <child>
-      <object class="GtkFrame">
-        <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkListBox" id="command_list">
-                <property name="show-separators">1</property>
-                <property name="selection-mode">none</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkListBox">
-                <property name="activate-on-single-click">1</property>
-                <property name="show-separators">1</property>
-                <property name="selection-mode">none</property>
-                <signal name="row-activated" handler="on_add_command" object="ValentRuncommandPreferences" swapped="no"/>
-                <child>
-                  <object class="GtkListBoxRow" id="command_add">
-                    <property name="activatable">1</property>
-                    <property name="selectable">0</property>
-                    <accessibility>
-                      <relation name="labelled-by">command_add_label</relation>
-                    </accessibility>
-                    <child>
-                      <object class="GtkLabel" id="command_add_label">
-                        <property name="label" translatable="yes">Add Command…</property>
-                        <property name="halign">center</property>
-                        <property name="hexpand">1</property>
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">12</property>
-                        <property name="valign">center</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
+      <object class="AdwExpanderRow" id="command_list_row">
+        <property name="title" translatable="yes">Local Commands</property>
+        <property name="subtitle" translatable="yes">Commands that can be executed by remote devices</property>
       </object>
     </child>
   </template>

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -199,7 +199,7 @@ sftp_session_find (ValentSftpPlugin *self)
             self->session = g_new0 (ValentSftpSession, 1);
 
           g_set_object (&self->session->mount, iter->data);
-          valent_set_string (&self->session->uri, uri);
+          g_set_str (&self->session->uri, uri);
 
           return TRUE;
         }

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -52,7 +52,7 @@ valent_share_plugin_create_download_file (ValentSharePlugin *self,
       const char *user_download = NULL;
 
       user_download = valent_get_user_directory (G_USER_DIRECTORY_DOWNLOAD);
-      valent_set_string (&download_folder, user_download);
+      g_set_str (&download_folder, user_download);
     }
 
   if (g_mkdir_with_parents (download_folder, 0700) == -1)

--- a/src/plugins/share/valent-share-preferences.c
+++ b/src/plugins/share/valent-share-preferences.c
@@ -132,7 +132,7 @@ valent_share_preferences_constructed (GObject *object)
       const char *user_download = NULL;
 
       user_download = valent_get_user_directory (G_USER_DIRECTORY_DOWNLOAD);
-      valent_set_string (&download_folder, user_download);
+      g_set_str (&download_folder, user_download);
       g_settings_set_string (settings, "download-folder", download_folder);
     }
 

--- a/src/plugins/share/valent-share-text-dialog.c
+++ b/src/plugins/share/valent-share-text-dialog.c
@@ -254,7 +254,7 @@ valent_share_text_dialog_set_text (ValentShareTextDialog *dialog,
 {
   g_assert (VALENT_IS_SHARE_TEXT_DIALOG (dialog));
 
-  if (valent_set_string (&dialog->text, text))
+  if (g_set_str (&dialog->text, text))
     {
       g_autofree char *markup = NULL;
 

--- a/src/plugins/sms/valent-message.c
+++ b/src/plugins/sms/valent-message.c
@@ -471,10 +471,10 @@ valent_message_update (ValentMessage *message,
       g_object_notify_by_pspec (G_OBJECT (message), properties [PROP_READ]);
     }
 
-  if (valent_set_string (&message->sender, update->sender))
+  if (g_set_str (&message->sender, update->sender))
     g_object_notify_by_pspec (G_OBJECT (message), properties [PROP_SENDER]);
 
-  if (valent_set_string (&message->text, update->text))
+  if (g_set_str (&message->text, update->text))
     g_object_notify_by_pspec (G_OBJECT (message), properties [PROP_TEXT]);
 
   g_object_thaw_notify (G_OBJECT (message));

--- a/src/plugins/sms/valent-sms-conversation-row.c
+++ b/src/plugins/sms/valent-sms-conversation-row.c
@@ -50,7 +50,8 @@ valent_sms_conversation_row_activate_link (GtkLabel   *label,
                                            gpointer    user_data)
 {
   GtkWidget *widget = GTK_WIDGET (label);
-  GtkWidget *toplevel = GTK_WIDGET (gtk_widget_get_root (widget));
+  GtkWindow *toplevel = GTK_WINDOW (gtk_widget_get_root (widget));
+  g_autoptr (GtkUriLauncher) launcher = NULL;
   g_autofree char *url = NULL;
 
   /* Only handle links that need to be amended with a scheme */
@@ -61,7 +62,8 @@ valent_sms_conversation_row_activate_link (GtkLabel   *label,
     return FALSE;
 
   url = g_strdup_printf ("https://%s", uri);
-  gtk_show_uri (GTK_WINDOW (toplevel), url, GDK_CURRENT_TIME);
+  launcher = gtk_uri_launcher_new (url);
+  gtk_uri_launcher_launch (launcher, toplevel, NULL, NULL, NULL);
 
   return TRUE;
 }

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -89,7 +89,7 @@ on_stream_changed (ValentMixerStream        *stream,
    * update the state and send the whole list */
   description = valent_mixer_stream_get_description (stream);
 
-  if (valent_set_string (&state->description, description))
+  if (g_set_str (&state->description, description))
     {
       valent_systemvolume_plugin_send_sinklist (self);
       return;

--- a/tests/libvalent/core/test-application-plugin.c
+++ b/tests/libvalent/core/test-application-plugin.c
@@ -24,7 +24,7 @@ application_fixture_set_up (ApplicationPluginFixture *fixture,
 
   VALENT_TEST_CHECK ("Plugin can be constructed");
   fixture->application = g_application_new ("ca.andyholmes.Valent.Tests",
-                                            G_APPLICATION_FLAGS_NONE);
+                                            G_APPLICATION_DEFAULT_FLAGS);
   fixture->extension = peas_engine_create_extension (engine,
                                                      plugin_info,
                                                      VALENT_TYPE_APPLICATION_PLUGIN,

--- a/tests/plugins/share/test-share-target.c
+++ b/tests/plugins/share/test-share-target.c
@@ -24,7 +24,7 @@ application_fixture_set_up (ApplicationPluginFixture *fixture,
   plugin_info = peas_engine_get_plugin_info (engine, "share");
 
   fixture->application = g_application_new ("ca.andyholmes.Valent.Tests",
-                                            G_APPLICATION_FLAGS_NONE);
+                                            G_APPLICATION_DEFAULT_FLAGS);
   fixture->manager = valent_device_manager_get_default ();
   fixture->extension = peas_engine_create_extension (engine,
                                                      plugin_info,


### PR DESCRIPTION
Bump GLib to 2.76 and GTK to 4.10, which allows `g_set_str()`
and dropping `valent_set_string()`, along with `GBindingGroup`
and `GSignalGroup` which will be employed later.

Make the other necessary changes to avoid silencing any
deprecation warnings.