### PR TITLE
refactor(runcommand): build command list manually

### DIFF
--- a/src/libvalent/device/valent-device.h
+++ b/src/libvalent/device/valent-device.h
@@ -56,7 +56,7 @@ GMenuModel        * valent_device_get_menu           (ValentDevice         *devi
 VALENT_AVAILABLE_IN_1_0
 const char        * valent_device_get_name           (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-GPtrArray         * valent_device_get_plugins        (ValentDevice         *device);
+GStrv               valent_device_get_plugins        (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
 ValentDeviceState   valent_device_get_state          (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0

--- a/tests/fixtures/valent-test-fixture.c
+++ b/tests/fixtures/valent-test-fixture.c
@@ -58,9 +58,10 @@ void
 valent_test_fixture_init (ValentTestFixture *fixture,
                           gconstpointer      user_data)
 {
+  PeasEngine *engine = valent_get_plugin_engine ();
   g_autofree ValentChannel **channels = NULL;
   g_autoptr (JsonParser) parser = NULL;
-  g_autoptr (GPtrArray) plugins = NULL;
+  g_auto (GStrv) plugins = NULL;
   JsonNode *identity;
 
   fixture->loop = g_main_loop_new (NULL, FALSE);
@@ -83,16 +84,17 @@ valent_test_fixture_init (ValentTestFixture *fixture,
   /* Init settings */
   plugins = valent_device_get_plugins (fixture->device);
 
-  for (unsigned int i = 0; i < plugins->len; i++)
+  for (unsigned int i = 0; plugins[i]; i++)
     {
-      PeasPluginInfo *plugin_info = g_ptr_array_index (plugins, i);
-      const char *module_name = peas_plugin_info_get_module_name (plugin_info);
+      PeasPluginInfo *plugin_info;
+      const char *module_name = plugins[i];
       const char *device_id;
 
       if (strcmp (module_name, "mock") == 0 ||
           strcmp (module_name, "packetless") == 0)
         continue;
 
+      plugin_info = peas_engine_get_plugin_info (engine, module_name);
       device_id = valent_device_get_id (fixture->device);
       fixture->settings = valent_device_plugin_create_settings (plugin_info,
                                                                 device_id);


### PR DESCRIPTION
Instead of using json-glib's convenience function for serializing GVariant to JSON, build the command list manually so the dictionary can be used to store other settings without leaking it to remote devices.