### PR TITLE
fix(presenter): add missing window controls to presentation remote

### DIFF
--- a/src/plugins/presenter/valent-presenter-remote.ui
+++ b/src/plugins/presenter/valent-presenter-remote.ui
@@ -21,6 +21,11 @@
             <property name="margin-bottom">6</property>
             <child>
               <object class="GtkCenterBox">
+                <child type="start">
+                  <object class="GtkWindowControls">
+                    <property name="side">start</property>
+                  </object>
+                </child>
                 <child type="center">
                   <object class="AdwWindowTitle">
                   <property name="title"


### PR DESCRIPTION
The presentation remote uses a custom titlebar, which was missing the start-side window control area resulting in missing buttons for users with alternate button layouts.

fixes #374