### PR TITLE
fix(libvalent): don't include build-time headers in public headers

### DIFF
--- a/src/libvalent/clipboard/libvalent-clipboard.h
+++ b/src/libvalent/clipboard/libvalent-clipboard.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-clipboard.h"

--- a/src/libvalent/clipboard/valent-clipboard-adapter.h
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/clipboard/valent-clipboard.h
+++ b/src/libvalent/clipboard/valent-clipboard.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-component.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/contacts/libvalent-contacts.h
+++ b/src/libvalent/contacts/libvalent-contacts.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-contacts.h"

--- a/src/libvalent/contacts/valent-contact-store.h
+++ b/src/libvalent/contacts/valent-contact-store.h
@@ -7,8 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
+#include "../core/valent-component.h"
 #include "valent-eds.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/contacts/valent-contacts-adapter.h
+++ b/src/libvalent/contacts/valent-contacts-adapter.h
@@ -7,8 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
+#include "../core/valent-component.h"
 #include "valent-contact-store.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/contacts/valent-contacts.h
+++ b/src/libvalent/contacts/valent-contacts.h
@@ -7,8 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
+#include "../core/valent-component.h"
 #include "valent-contact-store.h"
 
 

--- a/src/libvalent/device/libvalent-device.h
+++ b/src/libvalent/device/libvalent-device.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-channel.h"

--- a/src/libvalent/device/meson.build
+++ b/src/libvalent/device/meson.build
@@ -48,7 +48,7 @@ libvalent_device_public_sources = [
 # Enumerations
 libvalent_device_enums = gnome.mkenums_simple('valent-device-enums',
           body_prefix: '#include "config.h"',
-        header_prefix: '#include <libvalent-core.h>',
+        header_prefix: '#include "../core/valent-version.h"',
             decorator: '_VALENT_EXTERN',
               sources: libvalent_device_enum_headers,
        install_header: true,

--- a/src/libvalent/device/valent-channel-service.h
+++ b/src/libvalent/device/valent-channel-service.h
@@ -7,8 +7,6 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
 #include "valent-channel.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/device/valent-channel.h
+++ b/src/libvalent/device/valent-channel.h
@@ -9,7 +9,9 @@
 
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-data.h"
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/device/valent-device-impl.h
+++ b/src/libvalent/device/valent-device-impl.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <gio/gio.h>
-
 #include "valent-device.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/device/valent-device-manager.h
+++ b/src/libvalent/device/valent-device-manager.h
@@ -7,8 +7,6 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
 #include "valent-device.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/device/valent-device-plugin.h
+++ b/src/libvalent/device/valent-device-plugin.h
@@ -9,7 +9,6 @@
 
 #include <json-glib/json-glib.h>
 #include <libpeas/peas.h>
-#include <libvalent-core.h>
 
 #include "valent-device.h"
 

--- a/src/libvalent/device/valent-device-transfer.h
+++ b/src/libvalent/device/valent-device-transfer.h
@@ -7,10 +7,9 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
 #include <json-glib/json-glib.h>
-#include <libvalent-core.h>
 
+#include "../core/valent-transfer.h"
 #include "valent-device.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/device/valent-device.h
+++ b/src/libvalent/device/valent-device.h
@@ -8,7 +8,6 @@
 #endif
 
 #include <json-glib/json-glib.h>
-#include <libvalent-core.h>
 
 #include "valent-channel.h"
 

--- a/src/libvalent/device/valent-packet.c
+++ b/src/libvalent/device/valent-packet.c
@@ -8,6 +8,7 @@
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
 
+#include "valent-global.h"
 #include "valent-packet.h"
 
 

--- a/src/libvalent/device/valent-packet.h
+++ b/src/libvalent/device/valent-packet.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <json-glib/json-glib.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/input/libvalent-input.h
+++ b/src/libvalent/input/libvalent-input.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-input.h"

--- a/src/libvalent/input/valent-input-adapter.h
+++ b/src/libvalent/input/valent-input-adapter.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/input/valent-input.h
+++ b/src/libvalent/input/valent-input.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-component.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/media/libvalent-media.h
+++ b/src/libvalent/media/libvalent-media.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-media.h"

--- a/src/libvalent/media/meson.build
+++ b/src/libvalent/media/meson.build
@@ -37,7 +37,7 @@ libvalent_media_public_sources = [
 # Enumerations
 libvalent_media_enums = gnome.mkenums_simple('valent-media-enums',
      body_prefix: '#include "config.h"',
-   header_prefix: '#include <libvalent-core.h>',
+   header_prefix: '#include "../core/valent-version.h"',
        decorator: '_VALENT_EXTERN',
          sources: libvalent_media_enum_headers,
   install_header: true,

--- a/src/libvalent/media/valent-media-adapter.h
+++ b/src/libvalent/media/valent-media-adapter.h
@@ -7,8 +7,6 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <gio/gio.h>
-
 #include "valent-media-player.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -6,6 +6,7 @@
 #include "config.h"
 
 #include <gio/gio.h>
+#include <libvalent-core.h>
 
 #include "valent-media-enums.h"
 #include "valent-media-player.h"

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/media/valent-media.h
+++ b/src/libvalent/media/valent-media.h
@@ -8,8 +8,8 @@
 #endif
 
 #include <gio/gio.h>
-#include <libvalent-core.h>
 
+#include "../core/valent-component.h"
 #include "valent-media-player.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/mixer/libvalent-mixer.h
+++ b/src/libvalent/mixer/libvalent-mixer.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-mixer.h"

--- a/src/libvalent/mixer/meson.build
+++ b/src/libvalent/mixer/meson.build
@@ -37,7 +37,7 @@ libvalent_mixer_public_sources = [
 # Enumerations
 libvalent_mixer_enums = gnome.mkenums_simple('valent-mixer-enums',
      body_prefix: '#include "config.h"',
-   header_prefix: '#include <libvalent-core.h>',
+   header_prefix: '#include "../core/valent-version.h"',
        decorator: '_VALENT_EXTERN',
          sources: libvalent_mixer_enum_headers,
   install_header: true,

--- a/src/libvalent/mixer/valent-mixer-adapter.c
+++ b/src/libvalent/mixer/valent-mixer-adapter.c
@@ -6,6 +6,7 @@
 #include "config.h"
 
 #include <libpeas/peas.h>
+#include <libvalent-core.h>
 
 #include "valent-mixer.h"
 #include "valent-mixer-adapter.h"

--- a/src/libvalent/mixer/valent-mixer-adapter.h
+++ b/src/libvalent/mixer/valent-mixer-adapter.h
@@ -7,10 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
 #include "valent-mixer-stream.h"
-
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/mixer/valent-mixer-stream.c
+++ b/src/libvalent/mixer/valent-mixer-stream.c
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <libvalent-core.h>
+
 #include "valent-mixer-enums.h"
 #include "valent-mixer-stream.h"
 

--- a/src/libvalent/mixer/valent-mixer-stream.h
+++ b/src/libvalent/mixer/valent-mixer-stream.h
@@ -7,8 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/mixer/valent-mixer.h
+++ b/src/libvalent/mixer/valent-mixer.h
@@ -7,8 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
+#include "../core/valent-component.h"
 #include "valent-mixer-stream.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/notifications/libvalent-notifications.h
+++ b/src/libvalent/notifications/libvalent-notifications.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-notification.h"

--- a/src/libvalent/notifications/valent-notification.c
+++ b/src/libvalent/notifications/valent-notification.c
@@ -6,6 +6,7 @@
 #include "config.h"
 
 #include <gio/gio.h>
+#include <libvalent-core.h>
 
 #include "valent-notification.h"
 

--- a/src/libvalent/notifications/valent-notification.h
+++ b/src/libvalent/notifications/valent-notification.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/notifications/valent-notifications-adapter.h
+++ b/src/libvalent/notifications/valent-notifications-adapter.h
@@ -7,8 +7,6 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
-
 #include "valent-notification.h"
 
 G_BEGIN_DECLS

--- a/src/libvalent/notifications/valent-notifications.h
+++ b/src/libvalent/notifications/valent-notifications.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-component.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/session/libvalent-session.h
+++ b/src/libvalent/session/libvalent-session.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <libvalent-core.h>
-
 G_BEGIN_DECLS
 
 #include "valent-session.h"

--- a/src/libvalent/session/valent-session-adapter.h
+++ b/src/libvalent/session/valent-session-adapter.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/session/valent-session.h
+++ b/src/libvalent/session/valent-session.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-component.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-application-plugin.c
+++ b/src/libvalent/ui/valent-application-plugin.c
@@ -7,6 +7,7 @@
 
 #include <gio/gio.h>
 #include <libpeas/peas.h>
+#include <libvalent-core.h>
 #include <libvalent-device.h>
 
 #include "valent-application-plugin.h"

--- a/src/libvalent/ui/valent-application-plugin.h
+++ b/src/libvalent/ui/valent-application-plugin.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-device.h>
+#include "../device/valent-device-manager.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-application.h
+++ b/src/libvalent/ui/valent-application.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <gtk/gtk.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-device-gadget.h
+++ b/src/libvalent/ui/valent-device-gadget.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <gtk/gtk.h>
-#include <libvalent-device.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-device-page.h
+++ b/src/libvalent/ui/valent-device-page.h
@@ -4,7 +4,8 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-device-preferences-page.h
+++ b/src/libvalent/ui/valent-device-preferences-page.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <adwaita.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-device-preferences-window.h
+++ b/src/libvalent/ui/valent-device-preferences-window.h
@@ -4,7 +4,8 @@
 #pragma once
 
 #include <adwaita.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-preferences-page.h
+++ b/src/libvalent/ui/valent-preferences-page.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <adwaita.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-preferences-window.h
+++ b/src/libvalent/ui/valent-preferences-window.h
@@ -4,7 +4,8 @@
 #pragma once
 
 #include <adwaita.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-ui-utils.h
+++ b/src/libvalent/ui/valent-ui-utils.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include <libvalent-core.h>
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/libvalent/ui/valent-window.h
+++ b/src/libvalent/ui/valent-window.h
@@ -4,7 +4,8 @@
 #pragma once
 
 #include <adwaita.h>
-#include <libvalent-core.h>
+
+#include "../core/valent-object.h"
 
 G_BEGIN_DECLS
 

--- a/src/plugins/sms/valent-contact-row.h
+++ b/src/plugins/sms/valent-contact-row.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <libvalent-contacts.h>
+#include <valent.h>
 
 G_BEGIN_DECLS
 

--- a/src/plugins/sms/valent-message-row.h
+++ b/src/plugins/sms/valent-message-row.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <libvalent-contacts.h>
+#include <valent.h>
 
 #include "valent-message.h"
 

--- a/src/plugins/sms/valent-sms-conversation-row.h
+++ b/src/plugins/sms/valent-sms-conversation-row.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <libvalent-contacts.h>
+#include <valent.h>
 
 #include "valent-message.h"
 

--- a/src/plugins/sms/valent-sms-conversation.h
+++ b/src/plugins/sms/valent-sms-conversation.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
-#include <libvalent-contacts.h>
+#include <valent.h>
 
 #include "valent-message.h"
 #include "valent-sms-store.h"


### PR DESCRIPTION
For now the old libvalent sub-headers are still around as a build-time convenience, but they're never installed so ensure they not referenced from any public headers.