### PR TITLE
fix: remove duplicated "Purism::form_factor" tag from metainfo

### DIFF
--- a/data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in
+++ b/data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in
@@ -76,7 +76,6 @@
   </requires>
 
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>


### PR DESCRIPTION
Sometime recently `appstreamcli` started considering the duplicate custom key recommended by Purism.

Remove the `workstation` key to appease `appstreamcli validate`, since we're really only trying to convery support for mobile.