### PR TITLE
fix: call `gtk_widget_dispose_template()` as necessary

### DIFF
--- a/src/libvalent/ui/valent-device-page.c
+++ b/src/libvalent/ui/valent-device-page.c
@@ -255,6 +255,8 @@ valent_device_page_dispose (GObject *object)
   g_clear_pointer (&self->plugins, g_hash_table_unref);
   g_clear_pointer (&self->preferences, gtk_window_destroy);
 
+  gtk_widget_dispose_template (GTK_WIDGET (object), VALENT_TYPE_DEVICE_PAGE);
+
   G_OBJECT_CLASS (valent_device_page_parent_class)->dispose (object);
 }
 

--- a/src/libvalent/ui/valent-device-preferences-window.c
+++ b/src/libvalent/ui/valent-device-preferences-window.c
@@ -296,6 +296,9 @@ valent_device_preferences_window_dispose (GObject *object)
   g_clear_object (&self->device);
   g_clear_pointer (&self->plugins, g_hash_table_unref);
 
+  gtk_widget_dispose_template (GTK_WIDGET (object),
+                               VALENT_TYPE_DEVICE_PREFERENCES_WINDOW);
+
   G_OBJECT_CLASS (valent_device_preferences_window_parent_class)->dispose (object);
 }
 

--- a/src/libvalent/ui/valent-preferences-window.c
+++ b/src/libvalent/ui/valent-preferences-window.c
@@ -429,6 +429,9 @@ valent_preferences_window_dispose (GObject *object)
   g_signal_handlers_disconnect_by_data (valent_get_plugin_engine (), self);
   g_clear_object (&self->settings);
 
+  gtk_widget_dispose_template (GTK_WIDGET (object),
+                               VALENT_TYPE_PREFERENCES_WINDOW);
+
   G_OBJECT_CLASS (valent_preferences_window_parent_class)->dispose (object);
 }
 

--- a/src/libvalent/ui/valent-window.c
+++ b/src/libvalent/ui/valent-window.c
@@ -392,6 +392,8 @@ valent_window_dispose (GObject *object)
   g_clear_pointer (&self->preferences, gtk_window_destroy);
   g_clear_handle_id (&self->refresh_id, g_source_remove);
 
+  gtk_widget_dispose_template (GTK_WIDGET (object), VALENT_TYPE_WINDOW);
+
   G_OBJECT_CLASS (valent_window_parent_class)->dispose (object);
 }
 

--- a/src/plugins/battery/valent-battery-preferences.c
+++ b/src/plugins/battery/valent-battery-preferences.c
@@ -64,12 +64,23 @@ valent_battery_preferences_constructed (GObject *object)
 }
 
 static void
+valent_battery_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_BATTERY_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_battery_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_battery_preferences_class_init (ValentBatteryPreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_battery_preferences_constructed;
+  object_class->dispose = valent_battery_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/battery/valent-battery-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentBatteryPreferences, share_state);

--- a/src/plugins/clipboard/valent-clipboard-preferences.c
+++ b/src/plugins/clipboard/valent-clipboard-preferences.c
@@ -50,12 +50,23 @@ valent_clipboard_preferences_constructed (GObject *object)
 }
 
 static void
+valent_clipboard_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_CLIPBOARD_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_clipboard_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_clipboard_preferences_class_init (ValentClipboardPreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_clipboard_preferences_constructed;
+  object_class->dispose = valent_clipboard_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/clipboard/valent-clipboard-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentClipboardPreferences, sync_pull);

--- a/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
@@ -53,12 +53,23 @@ valent_connectivity_report_preferences_constructed (GObject *object)
 }
 
 static void
+valent_connectivity_report_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_CONNECTIVITY_REPORT_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_connectivity_report_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_connectivity_report_preferences_class_init (ValentConnectivityReportPreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_connectivity_report_preferences_constructed;
+  object_class->dispose = valent_connectivity_report_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/connectivity_report/valent-connectivity_report-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentConnectivityReportPreferences, share_state_row);

--- a/src/plugins/contacts/valent-contacts-preferences.c
+++ b/src/plugins/contacts/valent-contacts-preferences.c
@@ -205,6 +205,16 @@ valent_contacts_preferences_constructed (GObject *object)
 }
 
 static void
+valent_contacts_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_CONTACTS_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_contacts_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_contacts_preferences_finalize (GObject *object)
 {
   ValentContactsPreferences *self = VALENT_CONTACTS_PREFERENCES (object);
@@ -221,6 +231,7 @@ valent_contacts_preferences_class_init (ValentContactsPreferencesClass *klass)
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_contacts_preferences_constructed;
+  object_class->dispose = valent_contacts_preferences_dispose;
   object_class->finalize = valent_contacts_preferences_finalize;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/contacts/valent-contacts-preferences.ui");

--- a/src/plugins/mousepad/valent-mousepad-remote.c
+++ b/src/plugins/mousepad/valent-mousepad-remote.c
@@ -520,6 +520,8 @@ valent_mousepad_remote_dispose (GObject *object)
 
   valent_mousepad_remote_reset (self);
 
+  gtk_widget_dispose_template (GTK_WIDGET (object), VALENT_TYPE_MOUSEPAD_REMOTE);
+
   G_OBJECT_CLASS (valent_mousepad_remote_parent_class)->dispose (object);
 }
 

--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -526,6 +526,8 @@ valent_mpris_remote_dispose (GObject *object)
       g_clear_object (&self->player);
     }
 
+  gtk_widget_dispose_template (GTK_WIDGET (object), VALENT_TYPE_MPRIS_REMOTE);
+
   G_OBJECT_CLASS (valent_mpris_remote_parent_class)->dispose (object);
 }
 

--- a/src/plugins/notification/valent-notification-dialog.c
+++ b/src/plugins/notification/valent-notification-dialog.c
@@ -98,6 +98,16 @@ valent_notification_dialog_set_notification (ValentNotificationDialog *self,
  * GObject
  */
 static void
+valent_notification_dialog_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_NOTIFICATION_DIALOG);
+
+  G_OBJECT_CLASS (valent_notification_dialog_parent_class)->dispose (object);
+}
+
+static void
 valent_notification_dialog_finalize (GObject *object)
 {
   ValentNotificationDialog *self = VALENT_NOTIFICATION_DIALOG (object);
@@ -160,6 +170,7 @@ valent_notification_dialog_class_init (ValentNotificationDialogClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
+  object_class->dispose = valent_notification_dialog_dispose;
   object_class->finalize = valent_notification_dialog_finalize;
   object_class->get_property = valent_notification_dialog_get_property;
   object_class->set_property = valent_notification_dialog_set_property;

--- a/src/plugins/notification/valent-notification-preferences.c
+++ b/src/plugins/notification/valent-notification-preferences.c
@@ -222,6 +222,16 @@ valent_notification_preferences_constructed (GObject *object)
 }
 
 static void
+valent_notification_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_NOTIFICATION_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_notification_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_notification_preferences_finalize (GObject *object)
 {
   ValentNotificationPreferences *self = VALENT_NOTIFICATION_PREFERENCES (object);
@@ -238,6 +248,7 @@ valent_notification_preferences_class_init (ValentNotificationPreferencesClass *
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_notification_preferences_constructed;
+  object_class->dispose = valent_notification_preferences_dispose;
   object_class->finalize = valent_notification_preferences_finalize;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/notification/valent-notification-preferences.ui");

--- a/src/plugins/presenter/valent-presenter-remote.c
+++ b/src/plugins/presenter/valent-presenter-remote.c
@@ -133,6 +133,16 @@ valent_presenter_remote_constructed (GObject *object)
 }
 
 static void
+valent_presenter_remote_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_PRESENTER_REMOTE);
+
+  G_OBJECT_CLASS (valent_presenter_remote_parent_class)->dispose (object);
+}
+
+static void
 valent_presenter_remote_get_property (GObject    *object,
                                       guint       prop_id,
                                       GValue     *value,
@@ -177,6 +187,7 @@ valent_presenter_remote_class_init (ValentPresenterRemoteClass *klass)
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_presenter_remote_constructed;
+  object_class->dispose = valent_presenter_remote_dispose;
   object_class->get_property = valent_presenter_remote_get_property;
   object_class->set_property = valent_presenter_remote_set_property;
 

--- a/src/plugins/runcommand/valent-runcommand-editor.c
+++ b/src/plugins/runcommand/valent-runcommand-editor.c
@@ -53,6 +53,16 @@ on_entry_changed (GtkEntry               *entry,
  * GObject
  */
 static void
+valent_runcommand_editor_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_RUNCOMMAND_EDITOR);
+
+  G_OBJECT_CLASS (valent_runcommand_editor_parent_class)->dispose (object);
+}
+
+static void
 valent_runcommand_editor_finalize (GObject *object)
 {
   ValentRuncommandEditor *self = VALENT_RUNCOMMAND_EDITOR (object);
@@ -68,6 +78,7 @@ valent_runcommand_editor_class_init (ValentRuncommandEditorClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
+  object_class->dispose = valent_runcommand_editor_dispose;
   object_class->finalize = valent_runcommand_editor_finalize;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/runcommand/valent-runcommand-editor.ui");

--- a/src/plugins/runcommand/valent-runcommand-preferences.c
+++ b/src/plugins/runcommand/valent-runcommand-preferences.c
@@ -434,6 +434,16 @@ valent_runcommand_preferences_constructed (GObject *object)
 }
 
 static void
+valent_runcommand_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_RUNCOMMAND_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_runcommand_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_runcommand_preferences_finalize (GObject *object)
 {
   ValentRuncommandPreferences *self = VALENT_RUNCOMMAND_PREFERENCES (object);
@@ -450,6 +460,7 @@ valent_runcommand_preferences_class_init (ValentRuncommandPreferencesClass *klas
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_runcommand_preferences_constructed;
+  object_class->dispose = valent_runcommand_preferences_dispose;
   object_class->finalize = valent_runcommand_preferences_finalize;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/runcommand/valent-runcommand-preferences.ui");

--- a/src/plugins/sftp/valent-sftp-preferences.c
+++ b/src/plugins/sftp/valent-sftp-preferences.c
@@ -75,12 +75,23 @@ valent_sftp_preferences_constructed (GObject *object)
 }
 
 static void
+valent_sftp_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_SFTP_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_sftp_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_sftp_preferences_class_init (ValentSftpPreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_sftp_preferences_constructed;
+  object_class->dispose = valent_sftp_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/sftp/valent-sftp-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentSftpPreferences, auto_mount);

--- a/src/plugins/share/valent-share-preferences.c
+++ b/src/plugins/share/valent-share-preferences.c
@@ -150,12 +150,23 @@ valent_share_preferences_constructed (GObject *object)
 }
 
 static void
+valent_share_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_SHARE_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_share_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_share_preferences_class_init (ValentSharePreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_share_preferences_constructed;
+  object_class->dispose = valent_share_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/share/valent-share-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentSharePreferences, download_group);

--- a/src/plugins/share/valent-share-target-chooser.c
+++ b/src/plugins/share/valent-share-target-chooser.c
@@ -311,6 +311,9 @@ valent_share_target_chooser_dispose (GObject *object)
       g_clear_object (&self->manager);
     }
 
+  gtk_widget_dispose_template (GTK_WIDGET (object),
+                               VALENT_TYPE_SHARE_TARGET_CHOOSER);
+
   G_OBJECT_CLASS (valent_share_target_chooser_parent_class)->dispose (object);
 }
 

--- a/src/plugins/share/valent-share-text-dialog.c
+++ b/src/plugins/share/valent-share-text-dialog.c
@@ -125,6 +125,16 @@ valent_share_text_dialog_close_request (GtkWindow *window)
  * GObject
  */
 static void
+valent_share_text_dialog_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_SHARE_TEXT_DIALOG);
+
+  G_OBJECT_CLASS (valent_share_text_dialog_parent_class)->dispose (object);
+}
+
+static void
 valent_share_text_dialog_finalize (GObject *object)
 {
   ValentShareTextDialog *self = VALENT_SHARE_TEXT_DIALOG (object);
@@ -181,6 +191,7 @@ valent_share_text_dialog_class_init (ValentShareTextDialogClass *klass)
   AdwMessageDialogClass *dialog_class = ADW_MESSAGE_DIALOG_CLASS (klass);
 
   object_class->finalize = valent_share_text_dialog_finalize;
+  object_class->dispose = valent_share_text_dialog_dispose;
   object_class->get_property = valent_share_text_dialog_get_property;
   object_class->set_property = valent_share_text_dialog_set_property;
 

--- a/src/plugins/sms/valent-sms-conversation.c
+++ b/src/plugins/sms/valent-sms-conversation.c
@@ -624,8 +624,8 @@ valent_sms_conversation_dispose (GObject *object)
       g_clear_object (&self->thread);
     }
 
-  g_clear_pointer (&self->message_view, gtk_widget_unparent);
-  g_clear_pointer (&self->message_entry, gtk_widget_unparent);
+  gtk_widget_dispose_template (GTK_WIDGET (object),
+                               VALENT_TYPE_SMS_CONVERSATION);
 
   G_OBJECT_CLASS (valent_sms_conversation_parent_class)->dispose (object);
 }

--- a/src/plugins/sms/valent-sms-window.c
+++ b/src/plugins/sms/valent-sms-window.c
@@ -657,6 +657,16 @@ valent_sms_window_constructed (GObject *object)
 }
 
 static void
+valent_sms_window_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_SMS_WINDOW);
+
+  G_OBJECT_CLASS (valent_sms_window_parent_class)->dispose (object);
+}
+
+static void
 valent_sms_window_finalize (GObject *object)
 {
   ValentSmsWindow *self = VALENT_SMS_WINDOW (object);
@@ -720,6 +730,7 @@ valent_sms_window_class_init (ValentSmsWindowClass *klass)
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_sms_window_constructed;
+  object_class->dispose = valent_sms_window_dispose;
   object_class->finalize = valent_sms_window_finalize;
   object_class->get_property = valent_sms_window_get_property;
   object_class->set_property = valent_sms_window_set_property;

--- a/src/plugins/telephony/valent-telephony-preferences.c
+++ b/src/plugins/telephony/valent-telephony-preferences.c
@@ -175,12 +175,23 @@ valent_telephony_preferences_constructed (GObject *object)
 }
 
 static void
+valent_telephony_preferences_dispose (GObject *object)
+{
+  GtkWidget *widget = GTK_WIDGET (object);
+
+  gtk_widget_dispose_template (widget, VALENT_TYPE_TELEPHONY_PREFERENCES);
+
+  G_OBJECT_CLASS (valent_telephony_preferences_parent_class)->dispose (object);
+}
+
+static void
 valent_telephony_preferences_class_init (ValentTelephonyPreferencesClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
   object_class->constructed = valent_telephony_preferences_constructed;
+  object_class->dispose = valent_telephony_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/telephony/valent-telephony-preferences.ui");
   gtk_widget_class_bind_template_child (widget_class, ValentTelephonyPreferences, ringing_group);


### PR DESCRIPTION
We depend on GTK 4.8 now, and this is recommended practice.