### PR TITLE
refactor(device): remove `ValentDevice:type` property

### DIFF
--- a/src/libvalent/device/valent-device-impl.c
+++ b/src/libvalent/device/valent-device-impl.c
@@ -65,20 +65,11 @@ static const GDBusPropertyInfo iface_property_state = {
   NULL
 };
 
-static const GDBusPropertyInfo iface_property_type = {
-  -1,
-  "Type",
-  "s",
-  G_DBUS_PROPERTY_INFO_FLAGS_READABLE,
-  NULL
-};
-
 static const GDBusPropertyInfo * const iface_properties[] = {
   &iface_property_icon_name,
   &iface_property_id,
   &iface_property_name,
   &iface_property_state,
-  &iface_property_type,
   NULL,
 };
 
@@ -106,7 +97,6 @@ static PropertyMapping property_map[] = {
     { "state",     G_TYPE_UINT,    &iface_property_state },
     { "name",      G_TYPE_STRING,  &iface_property_name },
     { "icon-name", G_TYPE_STRING,  &iface_property_icon_name },
-    { "type",      G_TYPE_STRING,  &iface_property_type },
     { "id",        G_TYPE_STRING,  &iface_property_id },
 };
 

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -18,6 +18,12 @@
 #include "valent-device-private.h"
 #include "valent-packet.h"
 
+#define DEVICE_TYPE_DESKTOP  "desktop"
+#define DEVICE_TYPE_LAPTOP   "laptop"
+#define DEVICE_TYPE_PHONE    "phone"
+#define DEVICE_TYPE_TABLET   "tablet"
+#define DEVICE_TYPE_TV       "tv"
+
 #define PAIR_REQUEST_ID      "pair-request"
 #define PAIR_REQUEST_TIMEOUT 30
 
@@ -86,7 +92,6 @@ enum {
   PROP_NAME,
   PROP_PLUGINS,
   PROP_STATE,
-  PROP_TYPE,
   N_PROPERTIES
 };
 
@@ -637,27 +642,25 @@ valent_device_handle_identity (ValentDevice *device,
 
   /* Device Type */
   if (!valent_packet_get_string (packet, "deviceType", &device_type))
-    device_type = "desktop";
+    device_type = DEVICE_TYPE_DESKTOP;
 
   if (valent_set_string (&device->type, device_type))
     {
       const char *device_icon = "computer-symbolic";
 
-      if (g_str_equal (device_type, "desktop"))
+      if (g_str_equal (device_type, DEVICE_TYPE_DESKTOP))
         device_icon = "computer-symbolic";
-      else if (g_str_equal (device_type, "laptop"))
+      else if (g_str_equal (device_type, DEVICE_TYPE_LAPTOP))
         device_icon = "laptop-symbolic";
-      else if (g_str_equal (device_type, "phone"))
+      else if (g_str_equal (device_type, DEVICE_TYPE_PHONE))
         device_icon = "phone-symbolic";
-      else if (g_str_equal (device_type, "tablet"))
+      else if (g_str_equal (device_type, DEVICE_TYPE_TABLET))
         device_icon = "tablet-symbolic";
-      else if (g_str_equal (device_type, "tv"))
+      else if (g_str_equal (device_type, DEVICE_TYPE_TV))
         device_icon = "tv-symbolic";
 
       if (valent_set_string (&device->icon_name, device_icon))
         g_object_notify_by_pspec (G_OBJECT (device), properties [PROP_ICON_NAME]);
-
-      g_object_notify_by_pspec (G_OBJECT (device), properties [PROP_TYPE]);
     }
 
   /* Generally, these should be static, but could change if the connection type
@@ -903,10 +906,6 @@ valent_device_get_property (GObject    *object,
       g_value_set_flags (value, valent_device_get_state (self));
       break;
 
-    case PROP_TYPE:
-      g_value_set_string (value, self->type);
-      break;
-
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -994,8 +993,6 @@ valent_device_class_init (ValentDeviceClass *klass)
    *
    * A symbolic icon name for the device.
    *
-   * See [property@Valent.Device:type].
-   *
    * Since: 1.0
    */
   properties [PROP_ICON_NAME] =
@@ -1066,25 +1063,6 @@ valent_device_class_init (ValentDeviceClass *klass)
                         (G_PARAM_READABLE |
                          G_PARAM_EXPLICIT_NOTIFY |
                          G_PARAM_STATIC_STRINGS));
-
-  /**
-   * ValentDevice:type:
-   *
-   * A string hint, indicating the form-factor of the device.
-   *
-   * Known values include `desktop`, `laptop`, `smartphone`, `tablet` and `tv`.
-   *
-   * This is generally only useful for things like selecting an icon, since the
-   * device will describe its capabilities by other means.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_TYPE] =
-    g_param_spec_string ("type", NULL, NULL,
-                         "desktop",
-                         (G_PARAM_READABLE |
-                          G_PARAM_EXPLICIT_NOTIFY |
-                          G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }

--- a/tests/libvalent/device/test-device-manager.c
+++ b/tests/libvalent/device/test-device-manager.c
@@ -257,7 +257,7 @@ test_manager_dbus (ManagerFixture *fixture,
                     G_CALLBACK (on_properties_changed),
                     fixture);
 
-  g_object_notify (G_OBJECT (fixture->device), "type");
+  g_object_notify (G_OBJECT (fixture->device), "icon-name");
   g_main_loop_run (fixture->loop);
 
   g_assert_true (fixture->data == interface);

--- a/tests/libvalent/device/test-device.c
+++ b/tests/libvalent/device/test-device.c
@@ -136,7 +136,6 @@ test_device_new (void)
   g_autofree char *id = NULL;
   g_autofree char *name = NULL;
   g_auto (GStrv) plugins = NULL;
-  g_autofree char *type = NULL;
   ValentDeviceState state = VALENT_DEVICE_STATE_NONE;
 
   GMenuModel *menu;
@@ -150,7 +149,6 @@ test_device_new (void)
                 "name",      &name,
                 "plugins",   &plugins,
                 "state",     &state,
-                "type",      &type,
                 NULL);
 
   /* id should be set, but everything else should be %FALSE or %NULL */
@@ -160,7 +158,6 @@ test_device_new (void)
   /* Only "Packetless" plugin should be loaded */
   g_assert_cmpuint (g_strv_length (plugins), ==, 1);
   g_assert_cmpuint (state, ==, VALENT_DEVICE_STATE_NONE);
-  g_assert_null (type);
 
   menu = valent_device_get_menu (device);
   g_assert_true (G_IS_MENU (menu));
@@ -179,7 +176,6 @@ test_device_basic (DeviceFixture *fixture,
   g_autofree char *id = NULL;
   g_autofree char *name = NULL;
   g_autofree char *icon_name = NULL;
-  g_autofree char *type = NULL;
   g_auto (GStrv) plugins = NULL;
   ValentDeviceState state = VALENT_DEVICE_STATE_NONE;
 
@@ -190,7 +186,6 @@ test_device_basic (DeviceFixture *fixture,
                 "name",             &name,
                 "plugins",          &plugins,
                 "icon-name",        &icon_name,
-                "type",             &type,
                 "state",            &state,
                 NULL);
 
@@ -203,7 +198,6 @@ test_device_basic (DeviceFixture *fixture,
   g_assert_cmpuint (g_strv_length (plugins), ==, 2);
   g_assert_cmpstr (icon_name, ==, "phone-symbolic");
   g_assert_cmpstr (valent_device_get_icon_name (fixture->device), ==, "phone-symbolic");
-  g_assert_cmpstr (type, ==, "phone");
   g_assert_cmpuint (state, ==, VALENT_DEVICE_STATE_NONE);
   g_assert_cmpuint (valent_device_get_state (fixture->device), ==, VALENT_DEVICE_STATE_NONE);
 }


### PR DESCRIPTION
This is only ever used for selecting an icon, which itself is a device property, while the channel identity holds actual capabilities.

Remove the property for now, as it can be acquired from the channel if necessary, or added later if it becomes convenient.