### PR TITLE
refactor: downgrade packet fields from "warning" to "debug"

### DIFF
--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -584,8 +584,8 @@ valent_device_manager_ensure_device (ValentDeviceManager *manager,
 
   if (!valent_packet_get_string (identity, "deviceId", &device_id))
     {
-      g_warning ("%s(): expected \"deviceId\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"deviceId\" field holding a string",
+               G_STRFUNC);
       return NULL;
     }
 

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -279,15 +279,15 @@ valent_clipboard_plugin_handle_clipboard_connect (ValentClipboardPlugin *self,
 
   if (!valent_packet_get_int (packet, "timestamp", &timestamp))
     {
-      g_warning ("%s(): expected \"timestamp\" field holding an integer",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"timestamp\" field holding an integer",
+               G_STRFUNC);
       return;
     }
 
   if (!valent_packet_get_string (packet, "content", &content))
     {
-      g_warning ("%s(): expected \"content\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"content\" field holding a string",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -216,8 +216,8 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
 
   if (!valent_packet_get_object (packet, "signalStrengths", &signal_strengths))
     {
-      g_warning ("%s(): expected \"signalStrengths\" field holding an object",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"signalStrengths\" field holding an object",
+               G_STRFUNC);
       return;
     }
 
@@ -239,7 +239,8 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
 
       if G_UNLIKELY (json_node_get_value_type (signal_node) != JSON_TYPE_OBJECT)
         {
-          g_warning ("%s(): expected entry value holding an object", G_STRFUNC);
+          g_debug ("%s(): expected entry value holding an object",
+                   G_STRFUNC);
           continue;
         }
 

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -103,7 +103,8 @@ valent_contact_plugin_handle_request_vcards_by_uid (ValentContactsPlugin *self,
 
   if (!valent_packet_get_array (packet, "uids", &uids))
     {
-      g_warning ("%s(): expected \"uids\" field holding an array", G_STRFUNC);
+      g_debug ("%s(): expected \"uids\" field holding an array",
+               G_STRFUNC);
       return;
     }
 
@@ -122,8 +123,8 @@ valent_contact_plugin_handle_request_vcards_by_uid (ValentContactsPlugin *self,
 
       if G_UNLIKELY (uid == NULL || *uid == '\0')
         {
-          g_warning ("%s(): expected \"uids\" element to contain a string",
-                     G_STRFUNC);
+          g_debug ("%s(): expected \"uids\" element to contain a string",
+                   G_STRFUNC);
           continue;
         }
 

--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -217,8 +217,8 @@ on_incoming_connection (ValentChannelService   *service,
   /* Ignore identity packets without a deviceId */
   if (!valent_packet_get_string (peer_identity, "deviceId", &device_id))
     {
-      g_warning ("%s(): expected \"deviceId\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"deviceId\" field holding a string",
+               G_STRFUNC);
       return TRUE;
     }
 
@@ -393,8 +393,8 @@ on_incoming_broadcast (ValentLanChannelService  *self,
   /* Ignore broadcasts without a deviceId or from ourselves */
   if (!valent_packet_get_string (peer_identity, "deviceId", &device_id))
     {
-      g_warning ("%s(): expected \"deviceId\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"deviceId\" field holding a string",
+               G_STRFUNC);
       return TRUE;
     }
 
@@ -410,10 +410,10 @@ on_incoming_broadcast (ValentLanChannelService  *self,
   if (!valent_packet_get_int (peer_identity, "tcpPort", &port) ||
       (port < VALENT_LAN_PROTOCOL_PORT_MIN || port > VALENT_LAN_PROTOCOL_PORT_MAX))
     {
-      g_warning ("%s(): expected \"tcpPort\" field holding a uint16 between %u-%u",
-                 G_STRFUNC,
-                 VALENT_LAN_PROTOCOL_PORT_MIN,
-                 VALENT_LAN_PROTOCOL_PORT_MAX);
+      g_debug ("%s(): expected \"tcpPort\" field holding a uint16 between %u-%u",
+               G_STRFUNC,
+               VALENT_LAN_PROTOCOL_PORT_MIN,
+               VALENT_LAN_PROTOCOL_PORT_MAX);
       return TRUE;
     }
 

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -142,8 +142,8 @@ valent_mousepad_plugin_handle_mousepad_request (ValentMousepadPlugin *self,
 
       if ((keyval = valent_mousepad_keycode_to_keyval (keycode)) == 0)
         {
-          g_warning ("%s(): expected \"specialKey\" field holding a keycode",
-                     G_STRFUNC);
+          g_debug ("%s(): expected \"specialKey\" field holding a keycode",
+                   G_STRFUNC);
           return;
         }
 
@@ -262,7 +262,8 @@ valent_mousepad_plugin_handle_mousepad_keyboardstate (ValentMousepadPlugin *self
   /* Update the remote keyboard state */
   if (!valent_packet_get_boolean (packet, "state", &state))
     {
-      g_warning ("%s(): expected \"state\" field holding a boolean", G_STRFUNC);
+      g_debug ("%s(): expected \"state\" field holding a boolean",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -596,8 +596,8 @@ valent_mpris_plugin_receive_album_art (ValentMprisPlugin *self,
 
   if (!valent_packet_get_string (packet, "albumArtUrl", &url))
     {
-      g_warning ("%s(): expected \"albumArtUrl\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"albumArtUrl\" field holding a string",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -323,14 +323,16 @@ valent_notification_plugin_show_notification (ValentNotificationPlugin *self,
   /* Ensure we have a notification id */
   if (!valent_packet_get_string (packet, "id", &id))
     {
-      g_warning ("%s(): expected \"id\" field holding a string", G_STRFUNC);
+      g_debug ("%s(): expected \"id\" field holding a string",
+               G_STRFUNC);
       return;
     }
 
   /* This should never be absent, but we check anyways */
   if (!valent_packet_get_string (packet, "appName", &app_name))
     {
-      g_warning ("%s(): expected \"appName\" field holding a string", G_STRFUNC);
+      g_debug ("%s(): expected \"appName\" field holding a string",
+               G_STRFUNC);
       return;
     }
 
@@ -346,7 +348,8 @@ valent_notification_plugin_show_notification (ValentNotificationPlugin *self,
 
   if (title == NULL || text == NULL)
     {
-      g_warning ("%s(): expected either title and text, or ticker", G_STRFUNC);
+      g_debug ("%s(): expected either title and text, or ticker",
+               G_STRFUNC);
       return;
     }
 
@@ -495,7 +498,8 @@ valent_notification_plugin_handle_notification (ValentNotificationPlugin *self,
 
       if (!valent_packet_get_string (packet, "id", &id))
         {
-          g_warning ("%s(): expected \"id\" field holding a string", G_STRFUNC);
+          g_debug ("%s(): expected \"id\" field holding a string",
+                   G_STRFUNC);
           return;
         }
 
@@ -807,7 +811,7 @@ notification_reply_action (GSimpleAction *action,
   /* If the reply ID is empty, we've received a broken request */
   if (reply_id == NULL || *reply_id == '\0')
     {
-      g_warning ("%s(): expected requestReplyId", G_STRFUNC);
+      g_debug ("%s(): expected requestReplyId", G_STRFUNC);
       return;
     }
 

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -84,8 +84,8 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
 
   if (!valent_packet_get_string (packet, "filename", &filename))
     {
-      g_warning ("%s(): expected \"filename\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"filename\" field holding a string",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -84,13 +84,15 @@ sftp_session_new (ValentSftpPlugin *self,
   if (!valent_packet_get_int (packet, "port", &port) ||
       (port < 0 || port > G_MAXUINT16))
     {
-      g_warning ("%s(): expected \"port\" field holding a uint16", G_STRFUNC);
+      g_debug ("%s(): expected \"port\" field holding a uint16",
+               G_STRFUNC);
       return NULL;
     }
 
   if ((host = get_device_host (self)) == NULL)
     {
-      g_warning ("%s(): failed to get host address", G_STRFUNC);
+      g_warning ("%s(): failed to get host address",
+                 G_STRFUNC);
       return NULL;
     }
 

--- a/src/plugins/share/valent-share-download.c
+++ b/src/plugins/share/valent-share-download.c
@@ -367,15 +367,15 @@ valent_share_download_update (ValentShareDownload *self,
 
   if (!valent_packet_get_int (packet, "numberOfFiles", &self->number_of_files))
     {
-      g_warning ("%s(): expected \"numberOfFiles\" field holding an integer",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"numberOfFiles\" field holding an integer",
+               G_STRFUNC);
       return;
     }
 
   if (!valent_packet_get_int (packet, "totalPayloadSize", &self->payload_size))
     {
-      g_warning ("%s(): expected \"totalPayloadSize\" field holding an integer",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"totalPayloadSize\" field holding an integer",
+               G_STRFUNC);
       return;
     }
 }

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -937,8 +937,8 @@ valent_share_plugin_handle_file (ValentSharePlugin *self,
 
   if (!valent_packet_get_string (packet, "filename", &filename))
     {
-      g_warning ("%s(): expected \"filename\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"filename\" field holding a string",
+               G_STRFUNC);
       return;
     }
 
@@ -1041,15 +1041,15 @@ valent_share_plugin_handle_file_update (ValentSharePlugin *self,
 
   if (!valent_packet_check_field (packet, "numberOfFiles"))
     {
-      g_warning ("%s(): expected \"numberOfFiles\" field holding an integer",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"numberOfFiles\" field holding an integer",
+               G_STRFUNC);
       return;
     }
 
   if (!valent_packet_check_field (packet, "totalPayloadSize"))
     {
-      g_warning ("%s(): expected \"totalPayloadSize\" field holding an integer",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"totalPayloadSize\" field holding an integer",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -322,7 +322,8 @@ valent_systemvolume_plugin_handle_sink_change (ValentSystemvolumePlugin *self,
 
   if (!valent_packet_get_string (packet, "name", &name))
     {
-      g_warning ("%s(): expected \"name\" field holding a string", G_STRFUNC);
+      g_debug ("%s(): expected \"name\" field holding a string",
+               G_STRFUNC);
       return;
     }
 

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -260,7 +260,8 @@ valent_telephony_plugin_handle_telephony (ValentTelephonyPlugin *self,
 
   if (!valent_packet_get_string (packet, "event", &event))
     {
-      g_warning ("%s(): expected \"event\" field holding a string", G_STRFUNC);
+      g_debug ("%s(): expected \"event\" field holding a string",
+               G_STRFUNC);
       return;
     }
 

--- a/tests/fixtures/valent-mock-device-plugin.c
+++ b/tests/fixtures/valent-mock-device-plugin.c
@@ -80,8 +80,8 @@ valent_mock_device_plugin_handle_transfer (ValentMockDevicePlugin *self,
 
   if (!valent_packet_get_string (packet, "filename", &filename))
     {
-      g_warning ("%s(): expected \"filename\" field holding a string",
-                 G_STRFUNC);
+      g_debug ("%s(): expected \"filename\" field holding a string",
+               G_STRFUNC);
       return;
     }
 


### PR DESCRIPTION
Missing and invalid packet fields are worth noting in release builds, but shouldn't be concerning the user.

Replace all the reasonable instances of `g_warning()` with `g_debug()`.