### PR TITLE
refactor(media): remove the play-pause method

### DIFF
--- a/src/libvalent/media/valent-media-player.c
+++ b/src/libvalent/media/valent-media-player.c
@@ -30,7 +30,6 @@ G_DEFINE_TYPE (ValentMediaPlayer, valent_media_player, VALENT_TYPE_OBJECT)
  * @next: the virtual function pointer for valent_media_player_next()
  * @pause: the virtual function pointer for valent_media_player_pause()
  * @play: the virtual function pointer for valent_media_player_play()
- * @play_pause: the virtual function pointer for valent_media_player_play_pause()
  * @previous: the virtual function pointer for valent_media_player_previous()
  * @seek: the virtual function pointer for valent_media_player_seek()
  * @stop: the virtual function pointer for valent_media_player_stop()
@@ -150,21 +149,6 @@ valent_media_player_real_pause (ValentMediaPlayer *player)
 static void
 valent_media_player_real_play (ValentMediaPlayer *player)
 {
-}
-
-static void
-valent_media_player_real_play_pause (ValentMediaPlayer *player)
-{
-  ValentMediaActions flags = valent_media_player_get_flags (player);
-  ValentMediaState state = valent_media_player_get_state (player);
-
-  if (state == VALENT_MEDIA_STATE_PLAYING &&
-      (flags & VALENT_MEDIA_ACTION_PAUSE) != 0)
-    valent_media_player_pause (player);
-
-  else if (state != VALENT_MEDIA_STATE_PLAYING &&
-           (flags & VALENT_MEDIA_ACTION_PLAY) != 0)
-    valent_media_player_play (player);
 }
 
 static void
@@ -293,7 +277,6 @@ valent_media_player_class_init (ValentMediaPlayerClass *klass)
   player_class->next = valent_media_player_real_next;
   player_class->pause = valent_media_player_real_pause;
   player_class->play = valent_media_player_real_play;
-  player_class->play_pause = valent_media_player_real_play_pause;
   player_class->previous = valent_media_player_real_previous;
   player_class->seek = valent_media_player_real_seek;
   player_class->stop = valent_media_player_real_stop;
@@ -827,33 +810,6 @@ valent_media_player_play (ValentMediaPlayer *player)
   g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
 
   VALENT_MEDIA_PLAYER_GET_CLASS (player)->play (player);
-
-  VALENT_EXIT;
-}
-
-/**
- * valent_media_player_play_pause: (virtual play_pause)
- * @player: a #ValentMediaPlayer
- *
- * Start or pause playback, depending on the current state.
- *
- * If playback is already paused, resumes playback. If playback is stopped,
- * starts playback.
- *
- * If [property@Valent.MediaPlayer:flags] does not include
- * %VALENT_MEDIA_ACTION_PLAY or %VALENT_MEDIA_ACTION_PAUSE, calling this method
- * should have no effect.
- *
- * Since: 1.0
- */
-void
-valent_media_player_play_pause (ValentMediaPlayer *player)
-{
-  VALENT_ENTRY;
-
-  g_return_if_fail (VALENT_IS_MEDIA_PLAYER (player));
-
-  VALENT_MEDIA_PLAYER_GET_CLASS (player)->play_pause (player);
 
   VALENT_EXIT;
 }

--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -106,7 +106,6 @@ struct _ValentMediaPlayerClass
   void                 (*next)         (ValentMediaPlayer *player);
   void                 (*pause)        (ValentMediaPlayer *player);
   void                 (*play)         (ValentMediaPlayer *player);
-  void                 (*play_pause)   (ValentMediaPlayer *player);
   void                 (*previous)     (ValentMediaPlayer *player);
   void                 (*seek)         (ValentMediaPlayer *player,
                                         double             offset);
@@ -150,8 +149,6 @@ VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_pause        (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_play         (ValentMediaPlayer *player);
-VALENT_AVAILABLE_IN_1_0
-void                 valent_media_player_play_pause   (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_previous     (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/media/valent-media.c
+++ b/src/libvalent/media/valent-media.c
@@ -42,40 +42,8 @@ static void   g_list_model_iface_init (GListModelInterface *iface);
 G_DEFINE_FINAL_TYPE_WITH_CODE (ValentMedia, valent_media, VALENT_TYPE_COMPONENT,
                                G_IMPLEMENT_INTERFACE (G_TYPE_LIST_MODEL, g_list_model_iface_init))
 
-enum {
-  PLAYER_CHANGED,
-  PLAYER_SEEKED,
-  N_SIGNALS
-};
-
-static guint signals[N_SIGNALS] = { 0, };
-
 static ValentMedia *default_media = NULL;
 
-
-static void
-on_player_changed (ValentMediaPlayer *player,
-                   GParamSpec        *pspec,
-                   ValentMedia       *self)
-{
-  VALENT_ENTRY;
-
-  g_assert (VALENT_IS_MEDIA (self));
-
-  if (g_strcmp0 (pspec->name, "position") == 0)
-    {
-      double position = 0;
-
-      position = valent_media_player_get_position (player);
-      g_signal_emit (G_OBJECT (self), signals [PLAYER_SEEKED], 0, player, position);
-    }
-  else
-    {
-      g_signal_emit (G_OBJECT (self), signals [PLAYER_CHANGED], 0, player);
-    }
-
-  VALENT_EXIT;
-}
 
 static void
 on_items_changed (GListModel   *list,
@@ -119,10 +87,6 @@ on_items_changed (GListModel   *list,
       ValentMediaPlayer *player = NULL;
 
       player = g_list_model_get_item (list, position + i);
-      g_signal_connect_object (player,
-                               "notify",
-                               G_CALLBACK (on_player_changed),
-                               self, 0);
       g_ptr_array_insert (self->players, real_position + i, player);
     }
 
@@ -250,46 +214,6 @@ valent_media_class_init (ValentMediaClass *klass)
 
   component_class->bind_extension = valent_media_bind_extension;
   component_class->unbind_extension = valent_media_unbind_extension;
-
-  /**
-   * ValentMedia::player-changed:
-   * @media: an #ValentMedia
-   * @player: an #ValentMediaPlayer
-   *
-   * Emitted when the state of a [class@Valent.MediaPlayer] has changed.
-   *
-   * Since: 1.0
-   */
-  signals [PLAYER_CHANGED] =
-    g_signal_new ("player-changed",
-                  G_TYPE_FROM_CLASS (klass),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL,
-                  g_cclosure_marshal_VOID__OBJECT,
-                  G_TYPE_NONE, 1, VALENT_TYPE_MEDIA_PLAYER);
-  g_signal_set_va_marshaller (signals [PLAYER_CHANGED],
-                              G_TYPE_FROM_CLASS (klass),
-                              g_cclosure_marshal_VOID__OBJECTv);
-
-  /**
-   * ValentMedia::player-seeked:
-   * @media: an #ValentMedia
-   * @player: an #ValentMediaPlayer
-   * @offset: the new position in seconds
-   *
-   * Emitted when the playback position of a [class@Valent.MediaPlayer] has been
-   * changed as the result of an external action.
-   *
-   * Since: 1.0
-   */
-  signals [PLAYER_SEEKED] =
-    g_signal_new ("player-seeked",
-                  G_TYPE_FROM_CLASS (klass),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL, NULL,
-                  G_TYPE_NONE, 2, VALENT_TYPE_MEDIA_PLAYER, G_TYPE_DOUBLE);
 }
 
 static void

--- a/src/plugins/mpris/valent-mpris-device.c
+++ b/src/plugins/mpris/valent-mpris-device.c
@@ -243,6 +243,7 @@ valent_mpris_device_play (ValentMediaPlayer *player)
   valent_device_queue_packet (self->device, packet);
 }
 
+#if 0
 static void
 valent_mpris_device_play_pause (ValentMediaPlayer *player)
 {
@@ -259,6 +260,7 @@ valent_mpris_device_play_pause (ValentMediaPlayer *player)
 
   valent_device_queue_packet (self->device, packet);
 }
+#endif
 
 static void
 valent_mpris_device_previous (ValentMediaPlayer *player)
@@ -548,7 +550,6 @@ valent_mpris_device_class_init (ValentMprisDeviceClass *klass)
   player_class->next = valent_mpris_device_next;
   player_class->pause = valent_mpris_device_pause;
   player_class->play = valent_mpris_device_play;
-  player_class->play_pause = valent_mpris_device_play_pause;
   player_class->previous = valent_mpris_device_previous;
   player_class->seek = valent_mpris_device_seek;
   player_class->stop = valent_mpris_device_stop;

--- a/src/plugins/mpris/valent-mpris-impl.c
+++ b/src/plugins/mpris/valent-mpris-impl.c
@@ -159,7 +159,7 @@ player_method_call (GDBusConnection       *connection,
     }
   else if (strcmp (method_name, "PlayPause") == 0)
     {
-      valent_media_player_play_pause (self->player);
+      valent_mpris_play_pause (self->player);
     }
   else if (strcmp (method_name, "Previous") == 0)
     {

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -467,6 +467,7 @@ valent_mpris_player_play (ValentMediaPlayer *player)
                      NULL);
 }
 
+#if 0
 static void
 valent_mpris_player_play_pause (ValentMediaPlayer *player)
 {
@@ -481,6 +482,7 @@ valent_mpris_player_play_pause (ValentMediaPlayer *player)
                      NULL,
                      NULL);
 }
+#endif
 
 static void
 valent_mpris_player_previous (ValentMediaPlayer *player)
@@ -740,7 +742,6 @@ valent_mpris_player_class_init (ValentMPRISPlayerClass *klass)
   player_class->next = valent_mpris_player_next;
   player_class->pause = valent_mpris_player_pause;
   player_class->play = valent_mpris_player_play;
-  player_class->play_pause = valent_mpris_player_play_pause;
   player_class->previous = valent_mpris_player_previous;
   player_class->seek = valent_mpris_player_seek;
   player_class->stop = valent_mpris_player_stop;

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -238,7 +238,7 @@ valent_mpris_plugin_handle_action (ValentMprisPlugin *self,
     valent_media_player_play (player);
 
   else if (strcmp (action, "PlayPause") == 0)
-    valent_media_player_play_pause (player);
+    valent_mpris_play_pause (player);
 
   else if (strcmp (action, "Previous") == 0)
     valent_media_player_previous (player);

--- a/src/plugins/mpris/valent-mpris-remote.c
+++ b/src/plugins/mpris/valent-mpris-remote.c
@@ -106,7 +106,6 @@ valent_mpris_remote_clear (ValentMprisRemote *self)
   gtk_widget_action_set_enabled (widget, "remote.next", FALSE);
   gtk_widget_action_set_enabled (widget, "remote.pause", FALSE);
   gtk_widget_action_set_enabled (widget, "remote.play", FALSE);
-  gtk_widget_action_set_enabled (widget, "remote.play-pause", FALSE);
   gtk_widget_action_set_enabled (widget, "remote.previous", FALSE);
   gtk_widget_action_set_enabled (widget, "remote.seek", FALSE);
   gtk_widget_action_set_enabled (widget, "remote.stop", FALSE);
@@ -131,9 +130,6 @@ valent_mpris_remote_update_flags (ValentMprisRemote *self)
                                  (flags & VALENT_MEDIA_ACTION_PAUSE) != 0);
   gtk_widget_action_set_enabled (widget, "remote.play",
                                  (flags & VALENT_MEDIA_ACTION_PLAY) != 0);
-  gtk_widget_action_set_enabled (widget, "remote.play-pause",
-                                 (flags & (VALENT_MEDIA_ACTION_PLAY |
-                                           VALENT_MEDIA_ACTION_PAUSE)) != 0);
   gtk_widget_action_set_enabled (widget, "remote.previous",
                                  (flags & VALENT_MEDIA_ACTION_PREVIOUS) != 0);
   gtk_widget_action_set_enabled (widget, "remote.seek",
@@ -270,6 +266,8 @@ valent_mpris_remote_update_state (ValentMprisRemote *self)
 
   if (state == VALENT_MEDIA_STATE_PLAYING)
     {
+      gtk_actionable_set_action_name (GTK_ACTIONABLE (self->play_pause_button),
+                                      "remote.pause");
       gtk_image_set_from_icon_name (GTK_IMAGE (child),
                                     "media-playback-pause-symbolic");
       gtk_widget_set_tooltip_text (GTK_WIDGET (self->play_pause_button),
@@ -280,6 +278,8 @@ valent_mpris_remote_update_state (ValentMprisRemote *self)
     }
   else
     {
+      gtk_actionable_set_action_name (GTK_ACTIONABLE (self->play_pause_button),
+                                      "remote.play");
       gtk_image_set_from_icon_name (GTK_IMAGE (child),
                                     "media-playback-start-symbolic");
       gtk_widget_set_tooltip_text (GTK_WIDGET (self->play_pause_button),
@@ -445,9 +445,6 @@ remote_player_action (GtkWidget  *widget,
 
   else if (g_str_equal (action_name, "remote.play"))
     valent_media_player_play (self->player);
-
-  else if (g_str_equal (action_name, "remote.play-pause"))
-    valent_media_player_play_pause (self->player);
 
   else if (g_str_equal (action_name, "remote.previous"))
     valent_media_player_previous (self->player);
@@ -620,7 +617,6 @@ valent_mpris_remote_class_init (ValentMprisRemoteClass *klass)
   gtk_widget_class_install_action (widget_class, "remote.next", NULL, remote_player_action);
   gtk_widget_class_install_action (widget_class, "remote.pause", NULL, remote_player_action);
   gtk_widget_class_install_action (widget_class, "remote.play", NULL, remote_player_action);
-  gtk_widget_class_install_action (widget_class, "remote.play-pause", NULL, remote_player_action);
   gtk_widget_class_install_action (widget_class, "remote.previous", NULL, remote_player_action);
   gtk_widget_class_install_action (widget_class, "remote.repeat", NULL, remote_player_action);
   gtk_widget_class_install_action (widget_class, "remote.seek", "d", remote_player_action);

--- a/src/plugins/mpris/valent-mpris-remote.ui
+++ b/src/plugins/mpris/valent-mpris-remote.ui
@@ -235,7 +235,7 @@
                     <child>
                       <object class="GtkButton" id="play_pause_button">
                         <property name="tooltip-text" translatable="yes">Play</property>
-                        <property name="action-name">remote.play-pause</property>
+                        <property name="action-name">remote.play</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <property name="child">

--- a/src/plugins/mpris/valent-mpris-utils.h
+++ b/src/plugins/mpris/valent-mpris-utils.h
@@ -59,4 +59,18 @@ double               valent_mpris_get_time              (void);
 char               * valent_mpris_time_to_string        (gint64             msecs,
                                                          TotemTimeFlag      flags);
 
+#define valent_mpris_play_pause(player) \
+  G_STMT_START {                                                         \
+      ValentMediaActions flags = valent_media_player_get_flags (player); \
+      ValentMediaState state = valent_media_player_get_state (player);   \
+                                                                         \
+      if (state == VALENT_MEDIA_STATE_PLAYING &&                         \
+          (flags & VALENT_MEDIA_ACTION_PAUSE) != 0)                      \
+        valent_media_player_pause (VALENT_MEDIA_PLAYER (player));        \
+                                                                         \
+      else if (state != VALENT_MEDIA_STATE_PLAYING &&                    \
+               (flags & VALENT_MEDIA_ACTION_PLAY) != 0)                  \
+        valent_media_player_play (VALENT_MEDIA_PLAYER (player));         \
+  } G_STMT_END                                                           \
+
 G_END_DECLS

--- a/tests/fixtures/valent-mock-media-player.c
+++ b/tests/fixtures/valent-mock-media-player.c
@@ -231,17 +231,6 @@ valent_mock_media_player_play (ValentMediaPlayer *player)
 }
 
 static void
-valent_mock_media_player_play_pause (ValentMediaPlayer *player)
-{
-  ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
-
-  if (self->state == VALENT_MEDIA_STATE_PAUSED)
-    valent_mock_media_player_play (player);
-  else if (self->state == VALENT_MEDIA_STATE_PLAYING)
-    valent_mock_media_player_pause (player);
-}
-
-static void
 valent_mock_media_player_previous (ValentMediaPlayer *player)
 {
   ValentMockMediaPlayer *self = VALENT_MOCK_MEDIA_PLAYER (player);
@@ -307,7 +296,6 @@ valent_mock_media_player_class_init (ValentMockMediaPlayerClass *klass)
   player_class->next = valent_mock_media_player_next;
   player_class->pause = valent_mock_media_player_pause;
   player_class->play = valent_mock_media_player_play;
-  player_class->play_pause = valent_mock_media_player_play_pause;
   player_class->previous = valent_mock_media_player_previous;
   player_class->seek = valent_mock_media_player_seek;
   player_class->stop = valent_mock_media_player_stop;

--- a/tests/libvalent/media/test-media-component.c
+++ b/tests/libvalent/media/test-media-component.c
@@ -66,23 +66,6 @@ on_items_changed (GListModel            *list,
 }
 
 static void
-on_player_changed (ValentMedia           *media,
-                   ValentMediaPlayer     *player,
-                   MediaComponentFixture *fixture)
-{
-  fixture->state = TRUE;
-}
-
-static void
-on_player_seeked (ValentMedia           *media,
-                  ValentMediaPlayer     *player,
-                  double                 offset,
-                  MediaComponentFixture *fixture)
-{
-  fixture->state = (offset == 1.0);
-}
-
-static void
 on_player_notify (ValentMediaPlayer     *player,
                   GParamSpec            *pspec,
                   MediaComponentFixture *fixture)
@@ -212,23 +195,6 @@ test_media_component_player (MediaComponentFixture *fixture,
   fixture->emitter = NULL;
 
   g_signal_handlers_disconnect_by_data (fixture->player, fixture);
-
-  /* Test signal propagation */
-  g_signal_connect (fixture->media,
-                    "player-changed",
-                    G_CALLBACK (on_player_changed),
-                    fixture);
-  g_object_notify (G_OBJECT (fixture->player), "state");
-  g_assert_true (fixture->state);
-  fixture->state = FALSE;
-
-  g_signal_connect (fixture->media,
-                    "player-seeked",
-                    G_CALLBACK (on_player_seeked),
-                    fixture);
-  valent_media_player_set_position (fixture->player, 1.0);
-  g_assert_true (fixture->state);
-  fixture->state = FALSE;
 
   /* Remove Player */
   valent_media_adapter_player_removed (fixture->adapter, fixture->player);

--- a/tests/libvalent/media/test-media-component.c
+++ b/tests/libvalent/media/test-media-component.c
@@ -187,10 +187,6 @@ test_media_component_player (MediaComponentFixture *fixture,
   g_assert_true (fixture->emitter == fixture->player);
   fixture->emitter = NULL;
 
-  valent_media_player_play_pause (fixture->player);
-  g_assert_true (fixture->emitter == fixture->player);
-  fixture->emitter = NULL;
-
   valent_media_player_pause (fixture->player);
   g_assert_true (fixture->emitter == fixture->player);
   fixture->emitter = NULL;

--- a/tests/plugins/mpris/test-mpris-component.c
+++ b/tests/plugins/mpris/test-mpris-component.c
@@ -192,11 +192,6 @@ test_mpris_component_player (MprisComponentFixture *fixture,
   g_assert_true (fixture->data == fixture->player);
   fixture->data = NULL;
 
-  valent_media_player_play_pause (fixture->player);
-  g_main_loop_run (fixture->loop);
-  g_assert_true (fixture->data == fixture->player);
-  fixture->data = NULL;
-
   valent_media_player_pause (fixture->player);
   g_main_loop_run (fixture->loop);
   g_assert_true (fixture->data == fixture->player);

--- a/tests/plugins/mpris/test-mpris-impl.c
+++ b/tests/plugins/mpris/test-mpris-impl.c
@@ -339,10 +339,6 @@ test_mpris_impl_player (MPRISImplFixture *fixture,
   g_assert_true (fixture->state);
   fixture->state = FALSE;
 
-  valent_media_player_play_pause (player);
-  g_assert_true (fixture->state);
-  fixture->state = FALSE;
-
   valent_media_player_pause (player);
   g_assert_true (fixture->state);
   fixture->state = FALSE;

--- a/tests/plugins/mpris/test-mpris-plugin.c
+++ b/tests/plugins/mpris/test-mpris-plugin.c
@@ -479,12 +479,14 @@ test_mpris_plugin_handle_player (ValentTestFixture *fixture,
   v_assert_packet_cmpstr (packet, "action", ==, "Pause");
   json_node_unref (packet);
 
+#if 0
   valent_media_player_play_pause (fixture->data);
   packet = valent_test_fixture_expect_packet (fixture);
   v_assert_packet_type (packet, "kdeconnect.mpris.request");
   v_assert_packet_cmpstr (packet, "player", ==, "Mock Player");
   v_assert_packet_cmpstr (packet, "action", ==, "PlayPause");
   json_node_unref (packet);
+#endif
 
   valent_media_player_stop (fixture->data);
   packet = valent_test_fixture_expect_packet (fixture);


### PR DESCRIPTION
There's no need for this cluttering the public API.