### PR TITLE
test: cleanups and coverage increases

### DIFF
--- a/src/libvalent/ui/valent-menu-list.c
+++ b/src/libvalent/ui/valent-menu-list.c
@@ -36,9 +36,6 @@ enum {
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
-/*
- * GMenuModel Submenu Callbacks
- */
 static void
 valent_menu_list_item_activate (GtkListBoxRow *row)
 {
@@ -130,16 +127,24 @@ on_submenu_removed (GtkListBoxRow  *row,
                     ValentMenuList *self)
 {
   GtkWidget *stack;
+  GtkWidget *main;
   GtkWidget *submenu;
+
+  g_assert (GTK_IS_WIDGET (row));
+  g_assert (VALENT_MENU_LIST (self));
 
   submenu = g_object_get_data (G_OBJECT (row), "valent-submenu-item");
   g_return_if_fail (GTK_IS_WIDGET (submenu));
 
-  stack = gtk_widget_get_ancestor (submenu, GTK_TYPE_STACK);
-  g_return_if_fail (GTK_IS_WIDGET (stack));
+  /* If the parent is being destroyed, the stack or page may not exist */
+  if ((stack = gtk_widget_get_ancestor (submenu, GTK_TYPE_STACK)) == NULL)
+    return;
+
+  if ((main = gtk_stack_get_child_by_name (GTK_STACK (stack), "main")) == NULL)
+    return;
 
   if (gtk_stack_get_visible_child (GTK_STACK (stack)) == submenu)
-    gtk_stack_set_visible_child_name (GTK_STACK (stack), "main");
+    gtk_stack_set_visible_child (GTK_STACK (stack), main);
 
   gtk_stack_remove (GTK_STACK (stack), submenu);
 }

--- a/tests/fixtures/valent-test-utils.c
+++ b/tests/fixtures/valent-test-utils.c
@@ -349,7 +349,7 @@ valent_test_await_pending (void)
 }
 
 static gboolean
-valent_test_wait_cb (gpointer data)
+valent_test_await_timeout_cb (gpointer data)
 {
   gboolean *done = data;
 
@@ -360,17 +360,17 @@ valent_test_wait_cb (gpointer data)
 }
 
 /**
- * valent_test_wait:
+ * valent_test_await_timeout:
  * @duration: the time to wait, in milliseconds
  *
  * Iterate the default main context for @duration.
  */
 void
-valent_test_wait (unsigned int duration)
+valent_test_await_timeout (unsigned int duration)
 {
   gboolean done = FALSE;
 
-  g_timeout_add (duration, valent_test_wait_cb, &done);
+  g_timeout_add (duration, valent_test_await_timeout_cb, &done);
 
   while (!done)
     g_main_context_iteration (NULL, FALSE);

--- a/tests/fixtures/valent-test-utils.h
+++ b/tests/fixtures/valent-test-utils.h
@@ -32,7 +32,7 @@ void             valent_test_await_boolean (gboolean         *done);
 void             valent_test_await_pending (void);
 void             valent_test_await_signal  (gpointer          object,
                                             const char       *signal_name);
-void             valent_test_wait          (unsigned int      duration);
+void             valent_test_await_timeout (unsigned int      duration);
 JsonNode       * valent_test_load_json     (const char       *path);
 GSettings      * valent_test_mock_settings (const char       *domain);
 ValentChannel ** valent_test_channel_pair  (JsonNode         *identity,

--- a/tests/libvalent/device/test-device-transfer.c
+++ b/tests/libvalent/device/test-device-transfer.c
@@ -58,7 +58,7 @@ test_device_transfer (ValentTestFixture *fixture,
   g_assert_no_error (error);
 
   /* Ensure the download task has time to set the file mtime */
-  valent_test_wait (1);
+  valent_test_await_timeout (1);
 
   dest_dir = valent_get_user_directory (G_USER_DIRECTORY_DOWNLOAD);
   dest = valent_get_user_file (dest_dir, "image.png", FALSE);

--- a/tests/libvalent/session/test-session-component.c
+++ b/tests/libvalent/session/test-session-component.c
@@ -85,12 +85,12 @@ test_session_component_self (SessionComponentFixture *fixture,
 
   /* Compare session & adapter */
   g_object_get (fixture->session,
-                "active",      &session_active,
-                "locked",      &session_locked,
+                "active", &session_active,
+                "locked", &session_locked,
                 NULL);
   g_object_get (fixture->adapter,
-                "active",      &adapter_active,
-                "locked",      &adapter_locked,
+                "active", &adapter_active,
+                "locked", &adapter_locked,
                 NULL);
   g_assert_true (session_active == adapter_active);
   g_assert_true (session_locked == adapter_locked);
@@ -105,10 +105,13 @@ test_session_component_self (SessionComponentFixture *fixture,
                     "notify",
                     G_CALLBACK (on_notify),
                     &emitter);
-  valent_session_set_locked (fixture->session, !session_locked);
+  g_object_set (fixture->session,
+                "locked", !session_locked,
+                NULL);
 
-  g_assert_true (valent_session_get_locked (fixture->session));
   g_assert_true (fixture->session == emitter);
+  g_assert_true (valent_session_get_locked (fixture->session));
+  g_assert_true (valent_session_adapter_get_locked (fixture->adapter));
 }
 
 int

--- a/tests/libvalent/ui/meson.build
+++ b/tests/libvalent/ui/meson.build
@@ -13,6 +13,7 @@ libvalent_ui_tests = [
   'test-device-preferences-group',
   'test-device-preferences-window',
   'test-media-remote',
+  'test-menu-stack',
   'test-preferences-page',
   'test-preferences-window',
   'test-window',

--- a/tests/libvalent/ui/test-device-page.c
+++ b/tests/libvalent/ui/test-device-page.c
@@ -12,17 +12,17 @@ test_device_page_basic (ValentTestFixture *fixture,
                         gconstpointer      user_data)
 {
   GtkWindow *window;
-  GtkWidget *panel;
+  GtkWidget *page;
   ValentDevice *device = NULL;
   PeasEngine *engine;
 
-  panel = g_object_new (VALENT_TYPE_DEVICE_PAGE,
-                        "device", fixture->device,
-                        NULL);
-  g_assert_true (VALENT_IS_DEVICE_PAGE (panel));
+  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+                       "device", fixture->device,
+                       NULL);
+  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
 
   window = g_object_new (ADW_TYPE_WINDOW,
-                         "content", panel,
+                         "content", page,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
 
@@ -30,11 +30,16 @@ test_device_page_basic (ValentTestFixture *fixture,
   valent_test_await_pending ();
 
   /* Properties */
-  g_object_get (panel,
+  g_object_get (page,
                 "device", &device,
                 NULL);
   g_assert_true (fixture->device == device);
   g_clear_object (&device);
+
+  /* GActions (activate, since state can't be checked) */
+  gtk_widget_activate_action (page, "page.unpair", NULL);
+  gtk_widget_activate_action (page, "page.preferences", NULL);
+  gtk_widget_activate_action (page, "page.pair", NULL);
 
   /* Unload the plugin */
   engine = valent_get_plugin_engine ();
@@ -52,26 +57,23 @@ test_device_page_dialogs (ValentTestFixture *fixture,
                           gconstpointer      user_data)
 {
   GtkWindow *window;
-  GtkWidget *panel;
+  GtkWidget *page;
 
-  panel = g_object_new (VALENT_TYPE_DEVICE_PAGE,
-                        "device", fixture->device,
-                        NULL);
-  g_assert_true (VALENT_IS_DEVICE_PAGE (panel));
+  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+                       "device", fixture->device,
+                       NULL);
+  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
 
   window = g_object_new (ADW_TYPE_WINDOW,
-                         "content", panel,
+                         "content", page,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
 
   gtk_window_present (window);
   valent_test_await_pending ();
 
-  /* Preferences can be opened and closed */
-  gtk_widget_activate_action (panel, "panel.preferences", NULL);
-
-  /* Closing the window closes the preferences */
-  gtk_widget_activate_action (panel, "panel.preferences", NULL);
+  /* Preferences can be opened, and closed when the window closes */
+  gtk_widget_activate_action (page, "page.preferences", NULL);
 
   gtk_window_destroy (window);
 

--- a/tests/libvalent/ui/test-menu-stack.c
+++ b/tests/libvalent/ui/test-menu-stack.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#include <valent.h>
+#include <libvalent-test.h>
+
+#include "valent-device-page.h"
+
+
+
+static void
+test_device_menu_basic (ValentTestFixture *fixture,
+                        gconstpointer      user_data)
+{
+  GtkWindow *window;
+  GtkWidget *page;
+  GMenuModel *device_menu;
+  g_autoptr (GIcon) icon = NULL;
+  g_autoptr (GMenu) section = NULL;
+  g_autoptr (GMenu) submenu = NULL;
+  g_autoptr (GMenu) menu_all = NULL;
+  g_autoptr (GMenuItem) menu_item = NULL;
+
+  device_menu = valent_device_get_menu (fixture->device);
+  icon = g_themed_icon_new ("dialog-information-symbolic");
+
+  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+                       "device", fixture->device,
+                       NULL);
+  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
+
+  window = g_object_new (ADW_TYPE_WINDOW,
+                         "content", page,
+                         NULL);
+  g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
+
+  gtk_window_present (window);
+  valent_test_await_pending ();
+
+  /* Menu Item */
+  menu_item = g_menu_item_new ("Menu Item", "window.close");
+  g_menu_item_set_attribute (menu_item, "hidden-when", "s", "action-disabled");
+  g_menu_item_set_icon (menu_item, icon);
+
+  g_menu_append_item (G_MENU (device_menu), menu_item);
+
+  /* Section */
+  section = g_menu_new ();
+  g_menu_append_item (section, menu_item);
+
+  g_menu_append_section (G_MENU (device_menu), "Section", G_MENU_MODEL (section));
+
+  /* Submenu */
+  submenu = g_menu_new ();
+  g_menu_append_item (submenu, menu_item);
+
+  g_menu_append_submenu (G_MENU (device_menu), "Submenu", G_MENU_MODEL (submenu));
+
+  /* Remove Items */
+  g_menu_remove (G_MENU (device_menu), 2);
+  g_menu_remove (G_MENU (device_menu), 1);
+  g_menu_remove (G_MENU (device_menu), 0);
+
+  /* All Types */
+  menu_all = g_menu_new ();
+  g_menu_append_item (menu_all, menu_item);
+  g_menu_append_section (menu_all, "Section", G_MENU_MODEL (section));
+  g_menu_append_section (menu_all, "Submenu", G_MENU_MODEL (submenu));
+
+
+  /* Add the menu to the device menu */
+  /* g_menu_append_section (G_MENU (valent_device_get_menu (fixture->device)), */
+  /*                        "Test Menu", */
+  /*                        G_MENU_MODEL (menu)); */
+
+  /* Properties */
+  gtk_window_destroy (window);
+
+  while (window != NULL)
+    g_main_context_iteration (NULL, FALSE);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  const char *path = "plugin-mock.json";
+
+  valent_test_ui_init (&argc, &argv, NULL);
+
+  g_test_add ("/libvalent/ui/menu-stack/basic",
+              ValentTestFixture, path,
+              valent_test_fixture_init,
+              test_device_menu_basic,
+              valent_test_fixture_clear);
+
+  return g_test_run ();
+}
+

--- a/tests/plugins/fdo/test-fdo-notifications.c
+++ b/tests/plugins/fdo/test-fdo-notifications.c
@@ -204,7 +204,7 @@ test_fdo_notifications_source (FdoNotificationsFixture *fixture,
    * NOTE: this is longer than most tests due to the chained async functions
    *       being called in ValentFdoNotifications.
    */
-  valent_test_wait (1000);
+  valent_test_await_timeout (1000);
 
   g_signal_connect (fixture->notifications,
                     "notification-added",

--- a/tests/plugins/fdo/test-fdo-session.c
+++ b/tests/plugins/fdo/test-fdo-session.c
@@ -94,7 +94,7 @@ test_fdo_session_adapter (FdoSessionFixture *fixture,
   /* Wait a bit longer for the D-Bus calls to resolve
    * NOTE: this is longer than most tests due to the chained async functions
    */
-  valent_test_wait (1000);
+  valent_test_await_timeout (1000);
 
   g_signal_connect (fixture->session,
                     "notify",

--- a/tests/plugins/findmyphone/test-findmyphone-plugin.c
+++ b/tests/plugins/findmyphone/test-findmyphone-plugin.c
@@ -27,7 +27,7 @@ test_findmyphone_plugin_handle_request (ValentTestFixture *fixture,
 
   /* Start ringing */
   valent_test_fixture_handle_packet (fixture, packet);
-  valent_test_wait (1);
+  valent_test_await_timeout (1);
 
   /* Stop ringing */
   valent_test_fixture_handle_packet (fixture, packet);

--- a/tests/plugins/gtk/test-gtk-notifications.c
+++ b/tests/plugins/gtk/test-gtk-notifications.c
@@ -150,7 +150,7 @@ test_gtk_notifications_source (GtkNotificationsFixture *fixture,
    * NOTE: this is longer than most tests due to the chained async functions
    *       being called in ValentGtkNotifications.
    */
-  valent_test_wait (1000);
+  valent_test_await_timeout (1000);
 
   g_signal_connect (fixture->notifications,
                     "notification-added",

--- a/tests/plugins/lan/test-lan-plugin.c
+++ b/tests/plugins/lan/test-lan-plugin.c
@@ -428,7 +428,7 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
       /* In this test case we are neglecting to send our identity packet, so
        * we expect the test service to close the connection after 1000ms */
       if (g_strcmp0 (user_data, TEST_IDENTITY_TIMEOUT) == 0)
-        valent_test_wait (1100);
+        valent_test_await_timeout (1100);
     }
 
   identity = json_object_get_member (json_node_get_object (fixture->packets),
@@ -446,7 +446,7 @@ test_lan_service_outgoing_broadcast (LanBackendFixture *fixture,
       /* In this test case we are neglecting to negotiate a TLS connection, so
        * we expect the test service to close the connection after 1000ms */
       if (g_strcmp0 (user_data, TEST_TLS_AUTH_TIMEOUT) == 0)
-        valent_test_wait (1100);
+        valent_test_await_timeout (1100);
     }
 
   tls_stream = valent_lan_encrypt_server_connection (connection,

--- a/tests/plugins/notification/test-notification-plugin.c
+++ b/tests/plugins/notification/test-notification-plugin.c
@@ -59,7 +59,7 @@ test_notification_plugin_handle_notification (ValentTestFixture *fixture,
 
   // FIXME: Without this the notification plugin will reliably segfault, which
   //        ostensibly implies ValentDevicePlugin is not thread-safe
-  valent_test_wait (1000);
+  valent_test_await_timeout (1000);
 
   /* Receive a notification with actions */
   packet = valent_test_fixture_lookup_packet (fixture, "notification-actions");

--- a/tests/plugins/share/test-share-download.c
+++ b/tests/plugins/share/test-share-download.c
@@ -31,7 +31,7 @@ test_share_download_single (ValentTestFixture *fixture,
   g_assert_no_error (error);
 
   /* Ensure the download task has an opportunity to finish completely */
-  valent_test_wait (1);
+  valent_test_await_timeout (1);
 
   dest_dir = valent_get_user_directory (G_USER_DIRECTORY_DOWNLOAD);
   dest = valent_get_user_file (dest_dir, "image.png", FALSE);


### PR DESCRIPTION
Cleanup a few tests and increase the coverage by exercising some code paths.

* refactor: rename `valent_test_wait()` to `valent_test_await_timeout()`
* refactor: various code style cleanups
* fix(ui): use-after-free in `ValentWindow` and `ValentMenuList`
* test: add more real-world checks for the main window
* test: add `test-menu-stack` and test the stack/list more