### PR TITLE
fix(sms): fix data races in signal emission

### DIFF
--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -14,8 +14,8 @@ leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:885
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:888
 
 # src/plugins/sms/
-memleak:src/plugins/sms/valent-sms-store.c:809
-memleak:src/plugins/sms/valent-sms-store.c:859
+memleak:src/plugins/sms/valent-sms-store.c:814
+memleak:src/plugins/sms/valent-sms-store.c:864
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:583
 leakNoVarFunctionCall:src/plugins/sms/valent-sms-conversation.c:588
 


### PR DESCRIPTION
`ValentMessageStore` defers signal emissions to the main thread, but was not using a thread safe struct.