### PR TITLE
feat(ui): add `valent_ui_init()`

### DIFF
--- a/src/libvalent/ui/meson.build
+++ b/src/libvalent/ui/meson.build
@@ -48,6 +48,7 @@ libvalent_ui_public_sources = [
   'valent-preferences-page.c',
   'valent-preferences-window.c',
   'valent-time-helpers.c',
+  'valent-ui-main.c',
   'valent-ui-utils.c',
   'valent-window.c',
 ]

--- a/src/libvalent/ui/valent-application.c
+++ b/src/libvalent/ui/valent-application.c
@@ -13,6 +13,7 @@
 #include "valent-application.h"
 #include "valent-application-plugin.h"
 #include "valent-component-private.h"
+#include "valent-ui-utils.h"
 #include "valent-window.h"
 
 
@@ -361,7 +362,7 @@ valent_application_startup (GApplication *application)
   G_APPLICATION_CLASS (valent_application_parent_class)->startup (application);
 
   g_application_hold (application);
-  adw_init ();
+  valent_ui_init ();
 
   /* Service Actions */
   g_action_map_add_action_entries (G_ACTION_MAP (application),

--- a/src/libvalent/ui/valent-device-page.h
+++ b/src/libvalent/ui/valent-device-page.h
@@ -11,7 +11,6 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_DEVICE_PAGE (valent_device_page_get_type())
 
-_VALENT_EXTERN
 G_DECLARE_FINAL_TYPE (ValentDevicePage, valent_device_page, VALENT, DEVICE_PAGE, GtkBox)
 
 void   valent_device_page_close_preferences (ValentDevicePage *panel);

--- a/src/libvalent/ui/valent-device-preferences-window.c
+++ b/src/libvalent/ui/valent-device-preferences-window.c
@@ -13,7 +13,6 @@
 
 #include "valent-device-preferences-group.h"
 #include "valent-device-preferences-window.h"
-#include "valent-preferences-window.h"
 
 
 struct _ValentDevicePreferencesWindow

--- a/src/libvalent/ui/valent-device-preferences-window.h
+++ b/src/libvalent/ui/valent-device-preferences-window.h
@@ -11,7 +11,6 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_DEVICE_PREFERENCES_WINDOW (valent_device_preferences_window_get_type())
 
-_VALENT_EXTERN
 G_DECLARE_FINAL_TYPE (ValentDevicePreferencesWindow, valent_device_preferences_window, VALENT, DEVICE_PREFERENCES_WINDOW, AdwPreferencesWindow)
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-media-remote.h
+++ b/src/libvalent/ui/valent-media-remote.h
@@ -11,7 +11,6 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MEDIA_REMOTE (valent_media_remote_get_type())
 
-_VALENT_EXTERN
 G_DECLARE_FINAL_TYPE (ValentMediaRemote, valent_media_remote, VALENT, MEDIA_REMOTE, AdwWindow)
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-preferences-window.h
+++ b/src/libvalent/ui/valent-preferences-window.h
@@ -11,7 +11,6 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_PREFERENCES_WINDOW (valent_preferences_window_get_type())
 
-_VALENT_EXTERN
 G_DECLARE_FINAL_TYPE (ValentPreferencesWindow, valent_preferences_window, VALENT, PREFERENCES_WINDOW, AdwPreferencesWindow)
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-ui-main.c
+++ b/src/libvalent/ui/valent-ui-main.c
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#define G_LOG_DOMAIN "valent-ui-main"
+
+#include "config.h"
+
+#include <adwaita.h>
+#include <gtk/gtk.h>
+#include <libvalent-core.h>
+#include <libvalent-media.h>
+
+#include "valent-application.h"
+#include "valent-application-plugin.h"
+
+#include "valent-device-gadget.h"
+#include "valent-device-page.h"
+#include "valent-device-preferences-group.h"
+#include "valent-device-preferences-window.h"
+#include "valent-media-remote.h"
+#include "valent-menu-list.h"
+#include "valent-menu-stack.h"
+#include "valent-preferences-page.h"
+#include "valent-preferences-window.h"
+#include "valent-window.h"
+#include "valent-ui-utils.h"
+
+
+static GtkWindow *media_remote = NULL;
+
+
+/*
+ * GActions
+ */
+static void
+media_remote_action (GSimpleAction *action,
+                     GVariant      *parameter,
+                     gpointer       user_data)
+{
+  if (media_remote == NULL)
+    {
+      media_remote = g_object_new (VALENT_TYPE_MEDIA_REMOTE,
+                                   "players", valent_media_get_default (),
+                                   NULL);
+      g_object_add_weak_pointer (G_OBJECT (media_remote),
+                                 (gpointer) &media_remote);
+    }
+
+  gtk_window_present_with_time (media_remote, GDK_CURRENT_TIME);
+}
+
+static void
+valent_ui_init_actions (void)
+{
+  GApplication *application = g_application_get_default ();
+  static const GActionEntry actions[] = {
+    { "media-remote", media_remote_action, NULL, NULL, NULL },
+  };
+
+  if (application != NULL)
+    {
+      g_action_map_add_action_entries (G_ACTION_MAP (application),
+                                       actions,
+                                       G_N_ELEMENTS (actions),
+                                       application);
+    }
+}
+
+static void
+valent_ui_init_resources (void)
+{
+  g_autoptr (GtkCssProvider) theme = NULL;
+
+  /* Custom CSS */
+  theme = gtk_css_provider_new ();
+  gtk_css_provider_load_from_resource (theme, "/ca/andyholmes/Valent/ui/style.css");
+  gtk_style_context_add_provider_for_display (gdk_display_get_default (),
+                                              GTK_STYLE_PROVIDER (theme),
+                                              GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+}
+
+static void
+valent_ui_init_types (void)
+{
+  g_type_ensure (VALENT_TYPE_APPLICATION);
+  g_type_ensure (VALENT_TYPE_APPLICATION_PLUGIN);
+
+  g_type_ensure (VALENT_TYPE_DEVICE_GADGET);
+  g_type_ensure (VALENT_TYPE_DEVICE_PAGE);
+  g_type_ensure (VALENT_TYPE_DEVICE_PREFERENCES_GROUP);
+  g_type_ensure (VALENT_TYPE_DEVICE_PREFERENCES_WINDOW);
+  g_type_ensure (VALENT_TYPE_MEDIA_REMOTE);
+  g_type_ensure (VALENT_TYPE_MENU_LIST);
+  g_type_ensure (VALENT_TYPE_MENU_STACK);
+  g_type_ensure (VALENT_TYPE_PREFERENCES_PAGE);
+  g_type_ensure (VALENT_TYPE_PREFERENCES_WINDOW);
+  g_type_ensure (VALENT_TYPE_WINDOW);
+}
+
+/**
+ * valent_ui_init:
+ *
+ * Initialize Valent's default user interface.
+ *
+ * Returns: %TRUE if successful, or %FALSE on failure
+ *
+ * Since: 1.0
+ */
+gboolean
+valent_ui_init (void)
+{
+  static gboolean initialized = -1;
+
+  if G_LIKELY (initialized != -1)
+    return initialized;
+
+  if ((initialized = gtk_init_check ()))
+    {
+      adw_init ();
+
+      valent_ui_init_types ();
+      valent_ui_init_resources ();
+      valent_ui_init_actions ();
+    }
+
+  return initialized;
+}

--- a/src/libvalent/ui/valent-ui-utils.c
+++ b/src/libvalent/ui/valent-ui-utils.c
@@ -5,6 +5,7 @@
 
 #include "config.h"
 
+#include <gtk/gtk.h>
 #include <pango/pango.h>
 #include <libvalent-core.h>
 

--- a/src/libvalent/ui/valent-ui-utils.h
+++ b/src/libvalent/ui/valent-ui-utils.h
@@ -12,6 +12,8 @@
 G_BEGIN_DECLS
 
 VALENT_AVAILABLE_IN_1_0
-char * valent_string_to_markup (const char *text);
+char     * valent_string_to_markup (const char *text);
+VALENT_AVAILABLE_IN_1_0
+gboolean   valent_ui_init          (void);
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-window.c
+++ b/src/libvalent/ui/valent-window.c
@@ -17,7 +17,6 @@
 
 #include "valent-application-credits.h"
 #include "valent-device-page.h"
-#include "valent-media-remote.h"
 #include "valent-preferences-window.h"
 #include "valent-window.h"
 
@@ -354,25 +353,6 @@ about_action (GtkWidget  *widget,
 }
 
 static void
-media_remote_action (GtkWidget  *widget,
-                     const char *action_name,
-                     GVariant   *parameter)
-{
-  static GtkWindow *media_remote = NULL;
-
-  if (media_remote == NULL)
-    {
-      media_remote = g_object_new (VALENT_TYPE_MEDIA_REMOTE,
-                                   "players", valent_media_get_default (),
-                                   NULL);
-      g_object_add_weak_pointer (G_OBJECT (media_remote),
-                                 (gpointer) &media_remote);
-    }
-
-  gtk_window_present (media_remote);
-}
-
-static void
 page_action (GtkWidget  *widget,
              const char *action_name,
              GVariant   *parameter)
@@ -573,7 +553,6 @@ valent_window_class_init (ValentWindowClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-  g_autoptr (GtkCssProvider) theme = NULL;
 
   object_class->constructed = valent_window_constructed;
   object_class->dispose = valent_window_dispose;
@@ -587,7 +566,6 @@ valent_window_class_init (ValentWindowClass *klass)
   gtk_widget_class_bind_template_child (widget_class, ValentWindow, device_list);
 
   gtk_widget_class_install_action (widget_class, "win.about", NULL, about_action);
-  gtk_widget_class_install_action (widget_class, "win.media-remote", NULL, media_remote_action);
   gtk_widget_class_install_action (widget_class, "win.page", "s", page_action);
   gtk_widget_class_install_action (widget_class, "win.preferences", NULL, preferences_action);
   gtk_widget_class_install_action (widget_class, "win.previous", NULL, previous_action);
@@ -607,13 +585,6 @@ valent_window_class_init (ValentWindowClass *klass)
                           G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
-
-  /* Custom CSS */
-  theme = gtk_css_provider_new ();
-  gtk_css_provider_load_from_resource (theme, "/ca/andyholmes/Valent/ui/style.css");
-  gtk_style_context_add_provider_for_display (gdk_display_get_default (),
-                                              GTK_STYLE_PROVIDER (theme),
-                                              GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 }
 
 static void

--- a/src/libvalent/ui/valent-window.h
+++ b/src/libvalent/ui/valent-window.h
@@ -11,7 +11,6 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_WINDOW (valent_window_get_type())
 
-_VALENT_EXTERN
 G_DECLARE_FINAL_TYPE (ValentWindow, valent_window, VALENT, WINDOW, AdwApplicationWindow)
 
 G_END_DECLS

--- a/src/libvalent/ui/valent-window.ui
+++ b/src/libvalent/ui/valent-window.ui
@@ -111,7 +111,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">Media Remote</attribute>
-        <attribute name="action">win.media-remote</attribute>
+        <attribute name="action">app.media-remote</attribute>
       </item>
     </section>
     <section>

--- a/tests/fixtures/valent-test-utils.c
+++ b/tests/fixtures/valent-test-utils.c
@@ -542,14 +542,6 @@ valent_type_ensure (void)
   g_type_ensure (VALENT_TYPE_NOTIFICATION);
   g_type_ensure (VALENT_TYPE_SESSION);
   g_type_ensure (VALENT_TYPE_SESSION_ADAPTER);
-
-  /* UI */
-  g_type_ensure (VALENT_TYPE_APPLICATION);
-  g_type_ensure (VALENT_TYPE_APPLICATION_PLUGIN);
-
-  g_type_ensure (VALENT_TYPE_DEVICE_GADGET);
-  g_type_ensure (VALENT_TYPE_DEVICE_PREFERENCES_GROUP);
-  g_type_ensure (VALENT_TYPE_PREFERENCES_PAGE);
 }
 
 /**
@@ -619,8 +611,7 @@ valent_test_ui_init (int    *argcp,
 
   gtk_disable_setlocale ();
   setlocale (LC_ALL, "en_US.UTF-8");
-  gtk_init ();
-  adw_init ();
+  valent_ui_init ();
 
   /* NOTE: Set manually since GDK_DEBUG=default-settings doesn't work for us */
   g_object_set (gtk_settings_get_default (),

--- a/tests/libvalent/ui/test-device-page.c
+++ b/tests/libvalent/ui/test-device-page.c
@@ -4,7 +4,7 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-device-page.h"
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentDevicePage"))
 
 
 static void
@@ -16,10 +16,10 @@ test_device_page_basic (ValentTestFixture *fixture,
   ValentDevice *device = NULL;
   PeasEngine *engine;
 
-  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+  page = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                        "device", fixture->device,
                        NULL);
-  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
+  g_assert_nonnull (page);
 
   window = g_object_new (ADW_TYPE_WINDOW,
                          "content", page,
@@ -59,10 +59,10 @@ test_device_page_dialogs (ValentTestFixture *fixture,
   GtkWindow *window;
   GtkWidget *page;
 
-  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+  page = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                        "device", fixture->device,
                        NULL);
-  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
+  g_assert_nonnull (page);
 
   window = g_object_new (ADW_TYPE_WINDOW,
                          "content", page,

--- a/tests/libvalent/ui/test-device-preferences-window.c
+++ b/tests/libvalent/ui/test-device-preferences-window.c
@@ -4,7 +4,7 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-device-preferences-window.h"
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentDevicePreferencesWindow"))
 
 
 static void
@@ -16,7 +16,7 @@ test_device_preference_window_basic (ValentTestFixture *fixture,
   PeasEngine *engine;
   PeasPluginInfo *info;
 
-  window = g_object_new (VALENT_TYPE_DEVICE_PREFERENCES_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device", fixture->device,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);

--- a/tests/libvalent/ui/test-media-remote.c
+++ b/tests/libvalent/ui/test-media-remote.c
@@ -4,8 +4,9 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-media-remote.h"
 #include "valent-mock-media-player.h"
+
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentMediaRemote"))
 
 
 static void
@@ -17,7 +18,7 @@ test_media_remote (void)
   g_autoptr (GListStore) players = NULL;
 
   list = g_list_store_new (VALENT_TYPE_MEDIA_PLAYER);
-  remote = g_object_new (VALENT_TYPE_MEDIA_REMOTE,
+  remote = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "players", list,
                          NULL);
 

--- a/tests/libvalent/ui/test-menu-stack.c
+++ b/tests/libvalent/ui/test-menu-stack.c
@@ -4,8 +4,7 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-device-page.h"
-
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentDevicePage"))
 
 
 static void
@@ -24,10 +23,10 @@ test_device_menu_basic (ValentTestFixture *fixture,
   device_menu = valent_device_get_menu (fixture->device);
   icon = g_themed_icon_new ("dialog-information-symbolic");
 
-  page = g_object_new (VALENT_TYPE_DEVICE_PAGE,
+  page = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                        "device", fixture->device,
                        NULL);
-  g_assert_true (VALENT_IS_DEVICE_PAGE (page));
+  g_assert_nonnull (page);
 
   window = g_object_new (ADW_TYPE_WINDOW,
                          "content", page,

--- a/tests/libvalent/ui/test-preferences-window.c
+++ b/tests/libvalent/ui/test-preferences-window.c
@@ -4,7 +4,7 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-preferences-window.h"
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentPreferencesWindow"))
 
 
 static void
@@ -14,7 +14,7 @@ test_preferences_window_basic (void)
   PeasEngine *engine;
   PeasPluginInfo *info;
 
-  window = g_object_new (VALENT_TYPE_PREFERENCES_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                         NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
 
@@ -38,7 +38,7 @@ test_preferences_window_navigation (void)
 {
   GtkWindow *window;
 
-  window = g_object_new (VALENT_TYPE_PREFERENCES_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                         NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
 
@@ -59,7 +59,7 @@ test_preferences_window_rename (void)
 {
   GtkWindow *window;
 
-  window = g_object_new (VALENT_TYPE_PREFERENCES_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                         NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
 

--- a/tests/libvalent/ui/test-window.c
+++ b/tests/libvalent/ui/test-window.c
@@ -4,8 +4,7 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
-#include "valent-window.h"
-
+#define VALENT_TYPE_TEST_SUBJECT (g_type_from_name ("ValentWindow"))
 
 typedef struct
 {
@@ -35,7 +34,7 @@ test_window_basic (TestWindowFixture *fixture,
   g_autoptr (ValentDeviceManager) manager = NULL;
   GtkWindow *window;
 
-  window = g_object_new (VALENT_TYPE_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device-manager", fixture->manager,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
@@ -64,7 +63,7 @@ test_window_device_management (TestWindowFixture *fixture,
   g_autoptr (ValentDevice) device = NULL;
   GtkWindow *window;
 
-  window = g_object_new (VALENT_TYPE_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device-manager", fixture->manager,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
@@ -95,7 +94,7 @@ test_window_navigation (TestWindowFixture *fixture,
   GtkWindow *window;
   g_autoptr (ValentDevice) device = NULL;
 
-  window = g_object_new (VALENT_TYPE_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device-manager", fixture->manager,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);
@@ -131,10 +130,10 @@ test_window_dialogs (TestWindowFixture *fixture,
   GtkWindow *window;
 
   /* Preferences */
-  window = g_object_new (VALENT_TYPE_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device-manager", fixture->manager,
                          NULL);
-  g_assert_true (VALENT_IS_WINDOW (window));
+  g_assert_nonnull (window);
 
   gtk_window_present (window);
   valent_test_await_pending ();
@@ -154,7 +153,7 @@ test_window_dialogs (TestWindowFixture *fixture,
   // FIXME: throws warning for uninstalled icon
 
   /* About */
-  window = g_object_new (VALENT_TYPE_WINDOW,
+  window = g_object_new (VALENT_TYPE_TEST_SUBJECT,
                          "device-manager", fixture->manager,
                          NULL);
   g_object_add_weak_pointer (G_OBJECT (window), (gpointer)&window);


### PR DESCRIPTION
Add a function similar to `gtk_init_check()` that can be used to initialize assets for Valent's default user interface.