### PR TITLE
refactor(component): infer the priority key

### DIFF
--- a/src/libvalent/clipboard/valent-clipboard.c
+++ b/src/libvalent/clipboard/valent-clipboard.c
@@ -215,9 +215,8 @@ valent_clipboard_get_default (void)
   if (default_clipboard == NULL)
     {
       default_clipboard = g_object_new (VALENT_TYPE_CLIPBOARD,
-                                        "plugin-domain",   "clipboard",
-                                        "plugin-priority", "ClipboardAdapterPriority",
-                                        "plugin-type",     VALENT_TYPE_CLIPBOARD_ADAPTER,
+                                        "plugin-domain", "clipboard",
+                                        "plugin-type",   VALENT_TYPE_CLIPBOARD_ADAPTER,
                                         NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_clipboard),

--- a/src/libvalent/contacts/valent-contacts.c
+++ b/src/libvalent/contacts/valent-contacts.c
@@ -256,9 +256,8 @@ valent_contacts_get_default (void)
   if (default_contacts == NULL)
     {
       default_contacts = g_object_new (VALENT_TYPE_CONTACTS,
-                                       "plugin-domain",   "contacts",
-                                       "plugin-priority", "ContactsAdapterPriority",
-                                       "plugin-type",     VALENT_TYPE_CONTACTS_ADAPTER,
+                                       "plugin-domain", "contacts",
+                                       "plugin-type",   VALENT_TYPE_CONTACTS_ADAPTER,
                                        NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_contacts),

--- a/src/libvalent/core/valent-component.c
+++ b/src/libvalent/core/valent-component.c
@@ -52,7 +52,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentComponent, valent_component, VALENT_T
 enum {
   PROP_0,
   PROP_PLUGIN_DOMAIN,
-  PROP_PLUGIN_PRIORITY,
   PROP_PLUGIN_TYPE,
   N_PROPERTIES
 };
@@ -373,6 +372,17 @@ valent_component_constructed (GObject *object)
 
   priv->context = valent_context_new (NULL, priv->plugin_domain, NULL);
 
+  /* Infer the priority key */
+  if (g_type_name (priv->plugin_type) != NULL)
+    {
+      const char *type_name = g_type_name (priv->plugin_type);
+
+      if (g_str_has_prefix (type_name, "Valent"))
+        priv->plugin_priority = g_strdup_printf ("X-%sPriority", &type_name[6]);
+      else
+        priv->plugin_priority = g_strdup_printf ("X-%sPriority", type_name);
+    }
+
   /* Setup PeasEngine */
   plugins = peas_engine_get_plugin_list (priv->engine);
 
@@ -439,10 +449,6 @@ valent_component_get_property (GObject    *object,
       g_value_set_string (value, priv->plugin_domain);
       break;
 
-    case PROP_PLUGIN_PRIORITY:
-      g_value_set_string (value, priv->plugin_priority);
-      break;
-
     case PROP_PLUGIN_TYPE:
       g_value_set_gtype (value, priv->plugin_type);
       break;
@@ -465,10 +471,6 @@ valent_component_set_property (GObject      *object,
     {
     case PROP_PLUGIN_DOMAIN:
       priv->plugin_domain = g_value_dup_string (value);
-      break;
-
-    case PROP_PLUGIN_PRIORITY:
-      priv->plugin_priority = g_value_dup_string (value);
       break;
 
     case PROP_PLUGIN_TYPE:
@@ -507,24 +509,6 @@ valent_component_class_init (ValentComponentClass *klass)
    */
   properties [PROP_PLUGIN_DOMAIN] =
     g_param_spec_string ("plugin-domain", NULL, NULL,
-                         NULL,
-                         (G_PARAM_READWRITE |
-                          G_PARAM_CONSTRUCT_ONLY |
-                          G_PARAM_EXPLICIT_NOTIFY |
-                          G_PARAM_STATIC_STRINGS));
-
-  /**
-   * ValentComponent:plugin-priority:
-   *
-   * The priority key for the component.
-   *
-   * This is the name of a key in the `.plugin` file used to determine the
-   * preferred implementation.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_PRIORITY] =
-    g_param_spec_string ("plugin-priority", NULL, NULL,
                          NULL,
                          (G_PARAM_READWRITE |
                           G_PARAM_CONSTRUCT_ONLY |

--- a/src/libvalent/input/valent-input.c
+++ b/src/libvalent/input/valent-input.c
@@ -88,9 +88,8 @@ valent_input_get_default (void)
   if (default_input == NULL)
     {
       default_input = g_object_new (VALENT_TYPE_INPUT,
-                                    "plugin-domain",   "input",
-                                    "plugin-priority", "InputAdapterPriority",
-                                    "plugin-type",     VALENT_TYPE_INPUT_ADAPTER,
+                                    "plugin-domain", "input",
+                                    "plugin-type",   VALENT_TYPE_INPUT_ADAPTER,
                                     NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_input),

--- a/src/libvalent/media/valent-media.c
+++ b/src/libvalent/media/valent-media.c
@@ -267,9 +267,8 @@ valent_media_get_default (void)
   if (default_media == NULL)
     {
       default_media = g_object_new (VALENT_TYPE_MEDIA,
-                                    "plugin-domain",   "media",
-                                    "plugin-priority", "MediaAdapterPriority",
-                                    "plugin-type",     VALENT_TYPE_MEDIA_ADAPTER,
+                                    "plugin-domain", "media",
+                                    "plugin-type",   VALENT_TYPE_MEDIA_ADAPTER,
                                     NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_media),

--- a/src/libvalent/mixer/valent-mixer.c
+++ b/src/libvalent/mixer/valent-mixer.c
@@ -328,9 +328,8 @@ valent_mixer_get_default (void)
   if (default_mixer == NULL)
     {
       default_mixer = g_object_new (VALENT_TYPE_MIXER,
-                                    "plugin-domain",   "mixer",
-                                    "plugin-priority", "MixerAdapterPriority",
-                                    "plugin-type",     VALENT_TYPE_MIXER_ADAPTER,
+                                    "plugin-domain", "mixer",
+                                    "plugin-type",   VALENT_TYPE_MIXER_ADAPTER,
                                     NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_mixer),

--- a/src/libvalent/notifications/valent-notifications.c
+++ b/src/libvalent/notifications/valent-notifications.c
@@ -313,9 +313,8 @@ valent_notifications_get_default (void)
   if (default_listener == NULL)
     {
       default_listener = g_object_new (VALENT_TYPE_NOTIFICATIONS,
-                                       "plugin-domain",   "notifications",
-                                       "plugin-priority", "NotificationsAdapterPriority",
-                                       "plugin-type",     VALENT_TYPE_NOTIFICATIONS_ADAPTER,
+                                       "plugin-domain", "notifications",
+                                       "plugin-type",   VALENT_TYPE_NOTIFICATIONS_ADAPTER,
                                        NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_listener),

--- a/src/libvalent/session/valent-session.c
+++ b/src/libvalent/session/valent-session.c
@@ -242,9 +242,8 @@ valent_session_get_default (void)
   if (default_adapter == NULL)
     {
       default_adapter = g_object_new (VALENT_TYPE_SESSION,
-                                      "plugin-domain",   "session",
-                                      "plugin-priority", "SessionAdapterPriority",
-                                      "plugin-type",     VALENT_TYPE_SESSION_ADAPTER,
+                                      "plugin-domain", "session",
+                                      "plugin-type",   VALENT_TYPE_SESSION_ADAPTER,
                                       NULL);
 
       g_object_add_weak_pointer (G_OBJECT (default_adapter),

--- a/src/libvalent/ui/style.css
+++ b/src/libvalent/ui/style.css
@@ -6,3 +6,11 @@
   border-bottom: 0;
 }
 
+
+/*
+ * ValentMediaRemote
+ */
+window.media-remote .content {
+  background: @card_shade_color;
+}
+

--- a/src/libvalent/ui/valent-media-remote.ui
+++ b/src/libvalent/ui/valent-media-remote.ui
@@ -10,11 +10,17 @@
     <property name="height-request">294</property>
     <property name="default-width">360</property>
     <property name="default-height">648</property>
+    <style>
+      <class name="media-remote"/>
+    </style>
     <property name="content">
       <object class="GtkWindowHandle">
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
+            <style>
+              <class name="content"/>
+            </style>
 
             <!-- Player -->
             <child>
@@ -234,7 +240,6 @@
                                 </accessibility>
                                 <style>
                                   <class name="circular"/>
-                                  <class name="flat"/>
                                 </style>
                               </object>
                             </child>
@@ -274,7 +279,7 @@
                                 <property name="child">
                                   <object class="GtkImage">
                                     <property name="icon-name">media-playback-start-symbolic</property>
-                                    <property name="pixel-size">16</property>
+                                    <property name="pixel-size">32</property>
                                     <property name="margin-bottom">16</property>
                                     <property name="margin-end">16</property>
                                     <property name="margin-start">16</property>
@@ -338,7 +343,6 @@
                                 </accessibility>
                                 <style>
                                   <class name="circular"/>
-                                  <class name="flat"/>
                                 </style>
                               </object>
                             </child>


### PR DESCRIPTION
Remove `Valent.Component:plugin-priority` key, since it can reliably be inferred from the `:plugin-type`.