### PR TITLE
refactor(battery): don't send connect-time update unsolicited

### DIFF
--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -433,7 +433,6 @@ valent_battery_plugin_update_state (ValentDevicePlugin *plugin,
     {
       valent_battery_plugin_update_gaction (self);
       valent_battery_plugin_watch_battery (self, TRUE);
-      valent_battery_plugin_send_state (self);
       valent_battery_plugin_request_state (self);
     }
   else


### PR DESCRIPTION
Don't send an unsolicited battery update at connect time, since there is a packet for requesting this devices should send.