### PR TITLE
fix(libvalent): properly restore the default log handlers at shutdown

### DIFF
--- a/src/libvalent/core/valent-debug.c
+++ b/src/libvalent/core/valent-debug.c
@@ -246,7 +246,7 @@ valent_debug_clear (void)
   if (log_channel != NULL)
     {
       g_clear_pointer (&log_channel, g_io_channel_unref);
-      g_log_set_default_handler (valent_log_handler, NULL);
+      g_log_set_default_handler (g_log_default_handler, NULL);
     }
   G_UNLOCK (log_mutex);
 


### PR DESCRIPTION
Set the default log handler to `g_log_default_handler` when `valent_debug_clear()` is called.