### PR TITLE
feat(mpris): open the media remote when `Raise()` is called

### DIFF
--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -504,7 +504,7 @@ valent_device_manager_lookup (ValentDeviceManager *manager,
     {
       ValentDevice *device = g_ptr_array_index (manager->devices, i);
 
-      if (strcmp (id, valent_device_get_id (device)) == 0)
+      if (g_str_equal (id, valent_device_get_id (device)))
         return device;
     }
 

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -1589,7 +1589,7 @@ valent_device_handle_packet (ValentDevice *device,
 
   type = valent_packet_get_type (packet);
 
-  if G_UNLIKELY (strcmp (type, "kdeconnect.pair") == 0)
+  if G_UNLIKELY (g_str_equal (type, "kdeconnect.pair"))
     {
       valent_device_handle_pair (device, packet);
     }

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -454,11 +454,11 @@ valent_battery_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* The remote battery state changed */
-  if (strcmp (type, "kdeconnect.battery") == 0)
+  if (g_str_equal (type, "kdeconnect.battery"))
     valent_battery_plugin_handle_battery (self, packet);
 
   /* A request for the local battery state */
-  else if (strcmp (type, "kdeconnect.battery.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.battery.request"))
     valent_battery_plugin_handle_battery_request (self, packet);
 
   else

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -448,10 +448,10 @@ valent_clipboard_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* The remote clipboard content changed */
-  if (strcmp (type, "kdeconnect.clipboard") == 0)
+  if (g_str_equal (type, "kdeconnect.clipboard"))
     valent_clipboard_plugin_handle_clipboard (self, packet);
 
-  else if (strcmp (type, "kdeconnect.clipboard.connect") == 0)
+  else if (g_str_equal (type, "kdeconnect.clipboard.connect"))
     valent_clipboard_plugin_handle_clipboard_connect (self, packet);
 
   else

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -114,28 +114,28 @@ valent_connectivity_report_plugin_send_state (ValentConnectivityReportPlugin *se
 static const char *
 get_network_type_icon (const char *network_type)
 {
-  if (strcmp (network_type, "GSM") == 0 ||
-      strcmp (network_type, "CDMA") == 0 ||
-      strcmp (network_type, "iDEN") == 0)
+  if (g_str_equal (network_type, "GSM") ||
+      g_str_equal (network_type, "CDMA") ||
+      g_str_equal (network_type, "iDEN"))
     return "network-cellular-2g-symbolic";
 
-  if (strcmp (network_type, "UMTS") == 0 ||
-      strcmp (network_type, "CDMA2000") == 0)
+  if (g_str_equal (network_type, "UMTS") ||
+      g_str_equal (network_type, "CDMA2000"))
     return "network-cellular-3g-symbolic";
 
-  if (strcmp (network_type, "EDGE") == 0)
+  if (g_str_equal (network_type, "EDGE"))
     return "network-cellular-edge-symbolic";
 
-  if (strcmp (network_type, "GPRS") == 0)
+  if (g_str_equal (network_type, "GPRS"))
     return "network-cellular-gprs-symbolic";
 
-  if (strcmp (network_type, "HSPA") == 0)
+  if (g_str_equal (network_type, "HSPA"))
     return "network-cellular-hspa-symbolic";
 
-  if (strcmp (network_type, "LTE") == 0)
+  if (g_str_equal (network_type, "LTE"))
     return "network-cellular-4g-symbolic";
 
-  if (strcmp (network_type, "5G") == 0)
+  if (g_str_equal (network_type, "5G"))
     return "network-cellular-5g-symbolic";
 
   return "network-cellular-symbolic";
@@ -419,11 +419,11 @@ valent_connectivity_report_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* A remote connectivity report */
-  if (strcmp (type, "kdeconnect.connectivity_report") == 0)
+  if (g_str_equal (type, "kdeconnect.connectivity_report"))
     valent_connectivity_report_plugin_handle_connectivity_report (self, packet);
 
   /* A request for a local connectivity report */
-  else if (strcmp (type, "kdeconnect.connectivity_report.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.connectivity_report.request"))
     valent_connectivity_report_plugin_handle_connectivity_report_request (self, packet);
 
   else

--- a/src/plugins/connectivity_report/valent-telephony.c
+++ b/src/plugins/connectivity_report/valent-telephony.c
@@ -147,11 +147,11 @@ on_properties_changed (GDBusProxy      *proxy,
 
   while (g_variant_iter_loop (&iter, "{sv}", &property, &value))
     {
-      if (strcmp (property, "AccessTechnologies") == 0)
+      if (g_str_equal (property, "AccessTechnologies"))
         changed = TRUE;
-      else if (strcmp (property, "SignalQuality") == 0)
+      else if (g_str_equal (property, "SignalQuality"))
         changed = TRUE;
-      else if (strcmp (property, "State") == 0)
+      else if (g_str_equal (property, "State"))
         changed = TRUE;
     }
 

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -443,19 +443,19 @@ valent_contacts_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* A response to a request for a listing of contacts */
-  if (strcmp (type, "kdeconnect.contacts.response_uids_timestamps") == 0)
+  if (g_str_equal (type, "kdeconnect.contacts.response_uids_timestamps"))
     valent_contact_plugin_handle_response_uids_timestamps (self, packet);
 
   /* A response to a request for contacts */
-  else if (strcmp (type, "kdeconnect.contacts.response_vcards") == 0)
+  else if (g_str_equal (type, "kdeconnect.contacts.response_vcards"))
     valent_contact_plugin_handle_response_vcards (self, packet);
 
   /* A request for a listing of contacts */
-  else if (strcmp (type, "kdeconnect.contacts.request_all_uids_timestamps") == 0)
+  else if (g_str_equal (type, "kdeconnect.contacts.request_all_uids_timestamps"))
     valent_contact_plugin_handle_request_all_uids_timestamps (self, packet);
 
   /* A request for contacts */
-  else if (strcmp (type, "kdeconnect.contacts.request_vcards_by_uid") == 0)
+  else if (g_str_equal (type, "kdeconnect.contacts.request_vcards_by_uid"))
     valent_contact_plugin_handle_request_vcards_by_uid (self, packet);
 
   else

--- a/src/plugins/findmyphone/valent-findmyphone-plugin.c
+++ b/src/plugins/findmyphone/valent-findmyphone-plugin.c
@@ -124,7 +124,7 @@ valent_findmyphone_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.findmyphone.request") == 0)
+  if (g_str_equal (type, "kdeconnect.findmyphone.request"))
     valent_findmyphone_plugin_handle_findmyphone_request (self);
   else
     g_assert_not_reached ();

--- a/src/plugins/lock/valent-lock-plugin.c
+++ b/src/plugins/lock/valent-lock-plugin.c
@@ -218,9 +218,9 @@ valent_lock_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.lock") == 0)
+  if (g_str_equal (type, "kdeconnect.lock"))
     valent_lock_plugin_handle_lock (self, packet);
-  else if (strcmp (type, "kdeconnect.lock.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.lock.request"))
     valent_lock_plugin_handle_lock_request (self, packet);
   else
     g_assert_not_reached ();

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -573,15 +573,15 @@ valent_mousepad_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* A request to simulate input */
-  if (strcmp (type, "kdeconnect.mousepad.request") == 0)
+  if (g_str_equal (type, "kdeconnect.mousepad.request"))
     valent_mousepad_plugin_handle_mousepad_request (self, packet);
 
   /* A confirmation of input we requested */
-  else if (strcmp (type, "kdeconnect.mousepad.echo") == 0)
+  else if (g_str_equal (type, "kdeconnect.mousepad.echo"))
     valent_mousepad_plugin_handle_mousepad_echo (self, packet);
 
   /* The remote keyboard is ready/not ready for input */
-  else if (strcmp (type, "kdeconnect.mousepad.keyboardstate") == 0)
+  else if (g_str_equal (type, "kdeconnect.mousepad.keyboardstate"))
     valent_mousepad_plugin_handle_mousepad_keyboardstate (self, packet);
 
   else

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -134,7 +134,7 @@ on_player_signal (GDBusProxy        *proxy,
   g_assert (VALENT_IS_MPRIS_PLAYER (player));
   g_assert (signal_name != NULL);
 
-  if (strcmp (signal_name, "Seeked") == 0)
+  if (g_str_equal (signal_name, "Seeked"))
     {
       int64_t position_us = 0;
 

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -265,22 +265,22 @@ valent_mpris_plugin_handle_action (ValentMprisPlugin *self,
   g_assert (VALENT_IS_MEDIA_PLAYER (player));
   g_assert (action && *action);
 
-  if (strcmp (action, "Next") == 0)
+  if (g_str_equal (action, "Next"))
     valent_media_player_next (player);
 
-  else if (strcmp (action, "Pause") == 0)
+  else if (g_str_equal (action, "Pause"))
     valent_media_player_pause (player);
 
-  else if (strcmp (action, "Play") == 0)
+  else if (g_str_equal (action, "Play"))
     valent_media_player_play (player);
 
-  else if (strcmp (action, "PlayPause") == 0)
+  else if (g_str_equal (action, "PlayPause"))
     valent_mpris_play_pause (player);
 
-  else if (strcmp (action, "Previous") == 0)
+  else if (g_str_equal (action, "Previous"))
     valent_media_player_previous (player);
 
-  else if (strcmp (action, "Stop") == 0)
+  else if (g_str_equal (action, "Stop"))
     valent_media_player_stop (player);
 
   else
@@ -878,10 +878,10 @@ valent_mpris_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.mpris") == 0)
+  if (g_str_equal (type, "kdeconnect.mpris"))
     valent_mpris_plugin_handle_mpris (self, packet);
 
-  else if (strcmp (type, "kdeconnect.mpris.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.mpris.request"))
     valent_mpris_plugin_handle_mpris_request (self, packet);
 
   else

--- a/src/plugins/mpris/valent-mpris-utils.c
+++ b/src/plugins/mpris/valent-mpris-utils.c
@@ -131,13 +131,13 @@ valent_mpris_repeat_from_string (const char *loop_status)
 {
   g_return_val_if_fail (loop_status != NULL, VALENT_MEDIA_REPEAT_NONE);
 
-  if (strcmp (loop_status, "None") == 0)
+  if (g_str_equal (loop_status, "None"))
     return VALENT_MEDIA_REPEAT_NONE;
 
-  if (strcmp (loop_status, "Playlist") == 0)
+  if (g_str_equal (loop_status, "Playlist"))
     return VALENT_MEDIA_REPEAT_ALL;
 
-  if (strcmp (loop_status, "Track") == 0)
+  if (g_str_equal (loop_status, "Track"))
     return VALENT_MEDIA_REPEAT_ONE;
 
   return VALENT_MEDIA_REPEAT_NONE;
@@ -181,13 +181,13 @@ valent_mpris_state_from_string (const char *playback_status)
 {
   g_return_val_if_fail (playback_status != NULL, VALENT_MEDIA_STATE_STOPPED);
 
-  if (strcmp (playback_status, "Stopped") == 0)
+  if (g_str_equal (playback_status, "Stopped"))
     return VALENT_MEDIA_STATE_STOPPED;
 
-  if (strcmp (playback_status, "Playing") == 0)
+  if (g_str_equal (playback_status, "Playing"))
     return VALENT_MEDIA_STATE_PLAYING;
 
-  if (strcmp (playback_status, "Paused") == 0)
+  if (g_str_equal (playback_status, "Paused"))
     return VALENT_MEDIA_STATE_PAUSED;
 
   return VALENT_MEDIA_STATE_STOPPED;

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -1059,16 +1059,16 @@ valent_notification_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.notification") == 0)
+  if (g_str_equal (type, "kdeconnect.notification"))
     valent_notification_plugin_handle_notification (self, packet);
 
-  else if (strcmp (type, "kdeconnect.notification.action") == 0)
+  else if (g_str_equal (type, "kdeconnect.notification.action"))
     valent_notification_plugin_handle_notification_action (self, packet);
 
-  else if (strcmp (type, "kdeconnect.notification.reply") == 0)
+  else if (g_str_equal (type, "kdeconnect.notification.reply"))
     valent_notification_plugin_handle_notification_reply (self, packet);
 
-  else if (strcmp (type, "kdeconnect.notification.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.notification.request"))
     valent_notification_plugin_handle_notification_request (self, packet);
 
   else

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -184,10 +184,10 @@ valent_photo_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.photo") == 0)
+  if (g_str_equal (type, "kdeconnect.photo"))
     valent_photo_plugin_handle_photo (self, packet);
 
-  else if (strcmp (type, "kdeconnect.photo.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.photo.request"))
     valent_photo_plugin_handle_photo_request (self, packet);
 
   else

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -138,7 +138,7 @@ valent_ping_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.ping") == 0)
+  if (g_str_equal (type, "kdeconnect.ping"))
     valent_ping_plugin_handle_ping (self, packet);
   else
     g_assert_not_reached ();

--- a/src/plugins/presenter/valent-presenter-plugin.c
+++ b/src/plugins/presenter/valent-presenter-plugin.c
@@ -222,7 +222,7 @@ valent_presenter_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.presenter") == 0)
+  if (g_str_equal (type, "kdeconnect.presenter"))
     valent_presenter_plugin_handle_presenter (self, packet);
   else
     g_assert_not_reached ();

--- a/src/plugins/runcommand/valent-runcommand-plugin.c
+++ b/src/plugins/runcommand/valent-runcommand-plugin.c
@@ -488,11 +488,11 @@ valent_runcommand_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (VALENT_IS_PACKET (packet));
 
   /* A request for the local command list or local execution */
-  if (strcmp (type, "kdeconnect.runcommand.request") == 0)
+  if (g_str_equal (type, "kdeconnect.runcommand.request"))
     valent_runcommand_plugin_handle_runcommand_request (self, packet);
 
   /* A response to a request for the remote command list */
-  else if (strcmp (type, "kdeconnect.runcommand") == 0)
+  else if (g_str_equal (type, "kdeconnect.runcommand"))
     valent_runcommand_plugin_handle_runcommand (self, packet);
 
   else

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -673,10 +673,10 @@ valent_sftp_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.sftp") == 0)
+  if (g_str_equal (type, "kdeconnect.sftp"))
     valent_sftp_plugin_handle_sftp (self, packet);
 
-  else if (strcmp (type, "kdeconnect.sftp.request") == 0)
+  else if (g_str_equal (type, "kdeconnect.sftp.request"))
     valent_sftp_plugin_handle_request (self, packet);
 
   else

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -1221,7 +1221,7 @@ valent_share_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.share.request") == 0)
+  if (g_str_equal (type, "kdeconnect.share.request"))
     {
       if (valent_packet_check_field (packet, "filename"))
         valent_share_plugin_handle_file (self, packet);
@@ -1235,7 +1235,7 @@ valent_share_plugin_handle_packet (ValentDevicePlugin *plugin,
       else
         g_warning ("%s(): unsupported share request", G_STRFUNC);
     }
-  else if (strcmp (type, "kdeconnect.share.request.update") == 0)
+  else if (g_str_equal (type, "kdeconnect.share.request.update"))
     {
       valent_share_plugin_handle_file_update (self, packet);
     }

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -512,7 +512,7 @@ valent_sms_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.sms.messages") == 0)
+  if (g_str_equal (type, "kdeconnect.sms.messages"))
     valent_sms_plugin_handle_messages (self, packet);
   else
     g_assert_not_reached ();

--- a/src/plugins/sms/valent-sms-utils.c
+++ b/src/plugins/sms/valent-sms-utils.c
@@ -320,9 +320,9 @@ valent_phone_number_compare_normalized (const char *number1,
   number2_len = strlen (number2);
 
   if (number1_len > number2_len)
-    return strcmp (number1 + number1_len - number2_len, number2) == 0;
+    return g_str_equal (number1 + number1_len - number2_len, number2);
   else
-    return strcmp (number2 + number2_len - number1_len, number1) == 0;
+    return g_str_equal (number2 + number2_len - number1_len, number1);
 }
 
 /**
@@ -355,9 +355,9 @@ valent_phone_number_equal (const char *number1,
   num2_len = strlen (normalized2);
 
   if (num1_len > num2_len)
-    return strcmp (normalized1 + num1_len - num2_len, normalized2) == 0;
+    return g_str_equal (normalized1 + num1_len - num2_len, normalized2);
   else
-    return strcmp (normalized2 + num2_len - num1_len, normalized1) == 0;
+    return g_str_equal (normalized2 + num2_len - num1_len, normalized1);
 }
 
 /**

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -415,7 +415,7 @@ valent_systemvolume_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.systemvolume.request") == 0)
+  if (g_str_equal (type, "kdeconnect.systemvolume.request"))
     valent_systemvolume_plugin_handle_request (self, packet);
   else
     g_assert_not_reached ();

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -412,7 +412,7 @@ valent_telephony_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.telephony") == 0)
+  if (g_str_equal (type, "kdeconnect.telephony"))
     valent_telephony_plugin_handle_telephony (self, packet);
   else
     g_assert_not_reached ();

--- a/tests/fixtures/valent-mock-device-plugin.c
+++ b/tests/fixtures/valent-mock-device-plugin.c
@@ -184,9 +184,9 @@ valent_mock_device_plugin_handle_packet (ValentDevicePlugin *plugin,
   g_assert (type != NULL);
   g_assert (VALENT_IS_PACKET (packet));
 
-  if (strcmp (type, "kdeconnect.mock.echo") == 0)
+  if (g_str_equal (type, "kdeconnect.mock.echo"))
     valent_mock_device_plugin_handle_echo (self, packet);
-  else if (strcmp (type, "kdeconnect.mock.transfer") == 0)
+  else if (g_str_equal (type, "kdeconnect.mock.transfer"))
     valent_mock_device_plugin_handle_transfer (self, packet);
   else
     g_assert_not_reached ();

--- a/tests/fixtures/valent-test-fixture.c
+++ b/tests/fixtures/valent-test-fixture.c
@@ -87,8 +87,8 @@ valent_test_fixture_init (ValentTestFixture *fixture,
       ValentContext *context = NULL;
       g_autoptr (ValentContext) plugin_context = NULL;
 
-      if (strcmp (module_name, "mock") == 0 ||
-          strcmp (module_name, "packetless") == 0)
+      if (g_str_equal (module_name, "mock") ||
+          g_str_equal (module_name, "packetless"))
         continue;
 
       context = valent_device_get_context (fixture->device);


### PR DESCRIPTION
When first fetching the `CanRaise` property, set it to `TRUE` if there is a default `GApplication`. Then if `Raise()` is called on the application interface of an exported player, activate `app.media-remote` to open the default media remote.