### PR TITLE
refactor(core): add abstract base class for extensions in Valent

### DIFF
--- a/src/libvalent/clipboard/valent-clipboard-adapter.c
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.c
@@ -6,7 +6,6 @@
 #include "config.h"
 
 #include <gio/gio.h>
-#include <libpeas/peas.h>
 #include <libvalent-core.h>
 
 #include "valent-clipboard-adapter.h"
@@ -35,11 +34,10 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
-  int64_t         timestamp;
+  int64_t  timestamp;
 } ValentClipboardAdapterPrivate;
 
-G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentClipboardAdapter, valent_clipboard_adapter, VALENT_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentClipboardAdapter, valent_clipboard_adapter, VALENT_TYPE_EXTENSION)
 
 /**
  * ValentClipboardAdapterClass:
@@ -53,14 +51,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentClipboardAdapter, valent_clipboard_ad
  *
  * The virtual function table for #ValentClipboardAdapter.
  */
-
-enum {
-  PROP_0,
-  PROP_PLUGIN_INFO,
-  N_PROPERTIES
-};
-
-static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 enum {
   CHANGED,
@@ -166,53 +156,8 @@ valent_clipboard_adapter_real_changed (ValentClipboardAdapter *adapter)
  * GObject
  */
 static void
-valent_clipboard_adapter_get_property (GObject    *object,
-                                       guint       prop_id,
-                                       GValue     *value,
-                                       GParamSpec *pspec)
-{
-  ValentClipboardAdapter *self = VALENT_CLIPBOARD_ADAPTER (object);
-  ValentClipboardAdapterPrivate *priv = valent_clipboard_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_clipboard_adapter_set_property (GObject      *object,
-                                       guint         prop_id,
-                                       const GValue *value,
-                                       GParamSpec   *pspec)
-{
-  ValentClipboardAdapter *self = VALENT_CLIPBOARD_ADAPTER (object);
-  ValentClipboardAdapterPrivate *priv = valent_clipboard_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_clipboard_adapter_class_init (ValentClipboardAdapterClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  object_class->get_property = valent_clipboard_adapter_get_property;
-  object_class->set_property = valent_clipboard_adapter_set_property;
-
   klass->changed = valent_clipboard_adapter_real_changed;
   klass->get_mimetypes = valent_clipboard_adapter_real_get_mimetypes;
   klass->get_timestamp = valent_clipboard_adapter_real_get_timestamp;
@@ -220,23 +165,6 @@ valent_clipboard_adapter_class_init (ValentClipboardAdapterClass *klass)
   klass->read_bytes_finish = valent_clipboard_adapter_real_read_bytes_finish;
   klass->write_bytes = valent_clipboard_adapter_real_write_bytes;
   klass->write_bytes_finish = valent_clipboard_adapter_real_write_bytes_finish;
-
-  /**
-   * ValentClipboardAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /**
    * ValentClipboardAdapter::changed:

--- a/src/libvalent/clipboard/valent-clipboard-adapter.h
+++ b/src/libvalent/clipboard/valent-clipboard-adapter.h
@@ -7,45 +7,45 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include "../core/valent-object.h"
+#include "../core/valent-extension.h"
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_CLIPBOARD_ADAPTER (valent_clipboard_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentClipboardAdapter, valent_clipboard_adapter, VALENT, CLIPBOARD_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentClipboardAdapter, valent_clipboard_adapter, VALENT, CLIPBOARD_ADAPTER, ValentExtension)
 
 struct _ValentClipboardAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  GStrv               (*get_mimetypes)      (ValentClipboardAdapter  *adapter);
-  int64_t             (*get_timestamp)      (ValentClipboardAdapter  *adapter);
-  void                (*read_bytes)         (ValentClipboardAdapter  *adapter,
-                                             const char              *mimetype,
-                                             GCancellable            *cancellable,
-                                             GAsyncReadyCallback      callback,
-                                             gpointer                 user_data);
-  GBytes            * (*read_bytes_finish)  (ValentClipboardAdapter  *adapter,
-                                             GAsyncResult            *result,
-                                             GError                 **error);
-  void                (*write_bytes)        (ValentClipboardAdapter  *adapter,
-                                             const char              *mimetype,
-                                             GBytes                  *bytes,
-                                             GCancellable            *cancellable,
-                                             GAsyncReadyCallback      callback,
-                                             gpointer                 user_data);
-  gboolean            (*write_bytes_finish) (ValentClipboardAdapter  *adapter,
-                                             GAsyncResult            *result,
-                                             GError                 **error);
+  GStrv                  (*get_mimetypes)      (ValentClipboardAdapter  *adapter);
+  int64_t                (*get_timestamp)      (ValentClipboardAdapter  *adapter);
+  void                   (*read_bytes)         (ValentClipboardAdapter  *adapter,
+                                                const char              *mimetype,
+                                                GCancellable            *cancellable,
+                                                GAsyncReadyCallback      callback,
+                                                gpointer                 user_data);
+  GBytes               * (*read_bytes_finish)  (ValentClipboardAdapter  *adapter,
+                                                GAsyncResult            *result,
+                                                GError                 **error);
+  void                   (*write_bytes)        (ValentClipboardAdapter  *adapter,
+                                                const char              *mimetype,
+                                                GBytes                  *bytes,
+                                                GCancellable            *cancellable,
+                                                GAsyncReadyCallback      callback,
+                                                gpointer                 user_data);
+  gboolean               (*write_bytes_finish) (ValentClipboardAdapter  *adapter,
+                                                GAsyncResult            *result,
+                                                GError                 **error);
 
   /* signals */
-  void                (*changed)            (ValentClipboardAdapter  *adapter);
+  void                   (*changed)            (ValentClipboardAdapter  *adapter);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/contacts/valent-contacts-adapter.c
+++ b/src/libvalent/contacts/valent-contacts-adapter.c
@@ -6,7 +6,6 @@
 #include "config.h"
 
 #include <gio/gio.h>
-#include <libpeas/peas.h>
 #include <libvalent-core.h>
 
 #include "valent-contact-store.h"
@@ -36,13 +35,12 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
   GPtrArray      *stores;
 } ValentContactsAdapterPrivate;
 
 static void   g_list_model_iface_init (GListModelInterface *iface);
 
-G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentContactsAdapter, valent_contacts_adapter, VALENT_TYPE_OBJECT,
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentContactsAdapter, valent_contacts_adapter, VALENT_TYPE_EXTENSION,
                                   G_ADD_PRIVATE (ValentContactsAdapter)
                                   G_IMPLEMENT_INTERFACE (G_TYPE_LIST_MODEL, g_list_model_iface_init))
 
@@ -51,14 +49,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentContactsAdapter, valent_contacts_adapter
  *
  * The virtual function table for #ValentContactsAdapter.
  */
-
-enum {
-  PROP_0,
-  PROP_PLUGIN_INFO,
-  N_PROPERTIES
-};
-
-static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
 /*
@@ -119,70 +109,11 @@ valent_contacts_adapter_finalize (GObject *object)
 }
 
 static void
-valent_contacts_adapter_get_property (GObject    *object,
-                                      guint       prop_id,
-                                      GValue     *value,
-                                      GParamSpec *pspec)
-{
-  ValentContactsAdapter *self = VALENT_CONTACTS_ADAPTER (object);
-  ValentContactsAdapterPrivate *priv = valent_contacts_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_contacts_adapter_set_property (GObject      *object,
-                                      guint         prop_id,
-                                      const GValue *value,
-                                      GParamSpec   *pspec)
-{
-  ValentContactsAdapter *self = VALENT_CONTACTS_ADAPTER (object);
-  ValentContactsAdapterPrivate *priv = valent_contacts_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_contacts_adapter_class_init (ValentContactsAdapterClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->finalize = valent_contacts_adapter_finalize;
-  object_class->get_property = valent_contacts_adapter_get_property;
-  object_class->set_property = valent_contacts_adapter_set_property;
-
-  /**
-   * ValentContactsAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }
 
 static void

--- a/src/libvalent/contacts/valent-contacts-adapter.h
+++ b/src/libvalent/contacts/valent-contacts-adapter.h
@@ -7,7 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include "../core/valent-component.h"
+#include "../core/valent-extension.h"
 #include "valent-contact-store.h"
 
 G_BEGIN_DECLS
@@ -15,14 +15,14 @@ G_BEGIN_DECLS
 #define VALENT_TYPE_CONTACTS_ADAPTER (valent_contacts_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentContactsAdapter, valent_contacts_adapter, VALENT, CONTACTS_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentContactsAdapter, valent_contacts_adapter, VALENT, CONTACTS_ADAPTER, ValentExtension)
 
 struct _ValentContactsAdapterClass
 {
-  ValentObjectClass  parent_class;
+  ValentExtensionClass  parent_class;
 
   /*< private >*/
-  gpointer           padding[8];
+  gpointer              padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/core/libvalent-core.h
+++ b/src/libvalent/core/libvalent-core.h
@@ -14,6 +14,7 @@ G_BEGIN_DECLS
 #include "valent-context.h"
 #include "valent-core-enums.h"
 #include "valent-debug.h"
+#include "valent-extension.h"
 #include "valent-global.h"
 #include "valent-macros.h"
 #include "valent-object.h"

--- a/src/libvalent/core/meson.build
+++ b/src/libvalent/core/meson.build
@@ -14,6 +14,7 @@ libvalent_core_public_headers = [
   'valent-certificate.h',
   'valent-component.h',
   'valent-context.h',
+  'valent-extension.h',
   'valent-global.h',
   'valent-macros.h',
   'valent-object.h',
@@ -25,6 +26,7 @@ libvalent_core_private_headers = [
 ]
 
 libvalent_core_enum_headers = [
+  'valent-extension.h',
   'valent-transfer.h',
 ]
 
@@ -40,6 +42,7 @@ libvalent_core_public_sources = [
   'valent-certificate.c',
   'valent-component.c',
   'valent-context.c',
+  'valent-extension.c',
   'valent-debug.c',
   'valent-global.c',
   'valent-object.c',

--- a/src/libvalent/core/valent-application-plugin.h
+++ b/src/libvalent/core/valent-application-plugin.h
@@ -7,43 +7,41 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include "valent-object.h"
+#include "valent-extension.h"
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_APPLICATION_PLUGIN (valent_application_plugin_get_type ())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentApplicationPlugin, valent_application_plugin, VALENT, APPLICATION_PLUGIN, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentApplicationPlugin, valent_application_plugin, VALENT, APPLICATION_PLUGIN, ValentExtension)
 
 struct _ValentApplicationPluginClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  gboolean            (*activate)        (ValentApplicationPlugin  *plugin);
-  int                 (*command_line)    (ValentApplicationPlugin  *plugin,
-                                          GApplicationCommandLine  *command_line);
-  gboolean            (*dbus_register)   (ValentApplicationPlugin  *plugin,
-                                          GDBusConnection          *connection,
-                                          const char               *object_path,
-                                          GError                  **error);
-  void                (*dbus_unregister) (ValentApplicationPlugin  *plugin,
-                                          GDBusConnection          *connection,
-                                          const char               *object_path);
-  gboolean            (*open)            (ValentApplicationPlugin  *plugin,
-                                          GFile                   **files,
-                                          int                       n_files,
-                                          const char               *hint);
-  void                (*shutdown)        (ValentApplicationPlugin  *plugin);
-  void                (*startup)         (ValentApplicationPlugin  *plugin);
+  gboolean               (*activate)        (ValentApplicationPlugin  *plugin);
+  int                    (*command_line)    (ValentApplicationPlugin  *plugin,
+                                             GApplicationCommandLine  *command_line);
+  gboolean               (*dbus_register)   (ValentApplicationPlugin  *plugin,
+                                             GDBusConnection          *connection,
+                                             const char               *object_path,
+                                             GError                  **error);
+  void                   (*dbus_unregister) (ValentApplicationPlugin  *plugin,
+                                             GDBusConnection          *connection,
+                                             const char               *object_path);
+  gboolean               (*open)            (ValentApplicationPlugin  *plugin,
+                                             GFile                   **files,
+                                             int                       n_files,
+                                             const char               *hint);
+  void                   (*shutdown)        (ValentApplicationPlugin  *plugin);
+  void                   (*startup)         (ValentApplicationPlugin  *plugin);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
-VALENT_AVAILABLE_IN_1_0
-GApplication * valent_application_plugin_get_application (ValentApplicationPlugin  *plugin);
 VALENT_AVAILABLE_IN_1_0
 gboolean       valent_application_plugin_activate        (ValentApplicationPlugin  *plugin);
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/core/valent-application.c
+++ b/src/libvalent/core/valent-application.c
@@ -47,7 +47,7 @@ valent_application_enable_plugin (ValentApplication *self,
   plugin->extension = peas_engine_create_extension (valent_get_plugin_engine (),
                                                     plugin->info,
                                                     VALENT_TYPE_APPLICATION_PLUGIN,
-                                                    "application", self,
+                                                    "object", self,
                                                     NULL);
   g_return_if_fail (G_IS_OBJECT (plugin->extension));
 }

--- a/src/libvalent/core/valent-component.c
+++ b/src/libvalent/core/valent-component.c
@@ -168,6 +168,7 @@ valent_component_enable_plugin (ValentComponent *self,
   plugin->extension = peas_engine_create_extension (priv->engine,
                                                     plugin->info,
                                                     priv->plugin_type,
+                                                    "object", self,
                                                     NULL);
   g_return_if_fail (G_IS_OBJECT (plugin->extension));
 

--- a/src/libvalent/core/valent-extension.c
+++ b/src/libvalent/core/valent-extension.c
@@ -1,0 +1,696 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#define G_LOG_DOMAIN "valent-extension"
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <libpeas/peas.h>
+
+#include "valent-context.h"
+#include "valent-core-enums.h"
+#include "valent-extension.h"
+#include "valent-object.h"
+
+
+/**
+ * ValentExtension:
+ *
+ * An abstract base class for extensions.
+ *
+ * `ValentExtension` is a base class for extensions with conveniences for
+ * [iface@Gio.Action], [class@Gio.Settings] backed by [class@Valent.Context].
+ *
+ * ## Plugin Actions
+ *
+ * `ValentExtension` implements the [iface@Gio.ActionGroup] and
+ * [iface@Gio.ActionMap] interfaces, providing a simple way for plugins to
+ * expose functions and states. Each [iface@Gio.Action] added to the action map
+ * will be included in the object action group with the plugin's module name as
+ * a prefix (eg. `share.uri`).
+ *
+ * ## `.plugin` File
+ *
+ * Implementations may define the extra fields in the `.plugin` file, to take
+ * advantage of core features in the base class.
+ *
+ * The field names are inferred from the GType name of the implementation, with
+ * `Valent` being stripped if present. For example `ValentDevicePlugin` becomes
+ * `X-DevicePluginSettings`, while `NameDevicePlugin` would become
+ * `X-NameDevicePluginSettings`.
+ *
+ * - Extension Category Field
+ *
+ *     A list of categories separated by semi-colons, serving as a hint for
+ *     organizational purposes. This should be in the form `Main;Additional;`,
+ *     with values from the freedesktop.org Desktop Menu Specification.
+ *
+ *     Field pattern: `X-<type name>Category`
+ *
+ * - [class@Gio.Settings] Schema Field
+ *
+ *     A [class@Gio.Settings] schema ID for the extensions's settings. See
+ *     [method@Valent.Context.get_plugin_settings] for more information.
+ *
+ *     Field pattern: `X-<type name>Settings`
+ *
+ * Since: 1.0
+ */
+
+typedef struct
+{
+  GObject           *object;
+
+  PeasPluginInfo    *plugin_info;
+  ValentPluginState  plugin_state;
+  GError            *plugin_error;
+
+  GHashTable        *actions;
+  ValentContext     *context;
+  GSettings         *settings;
+} ValentExtensionPrivate;
+
+static void   g_action_group_iface_init (GActionGroupInterface *iface);
+static void   g_action_map_iface_init   (GActionMapInterface   *iface);
+
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentExtension, valent_extension, VALENT_TYPE_OBJECT,
+                                  G_ADD_PRIVATE (ValentExtension)
+                                  G_IMPLEMENT_INTERFACE (G_TYPE_ACTION_GROUP, g_action_group_iface_init)
+                                  G_IMPLEMENT_INTERFACE (G_TYPE_ACTION_MAP, g_action_map_iface_init))
+
+/**
+ * ValentExtensionClass:
+ *
+ * The virtual function table for `ValentExtension`.
+ */
+
+enum {
+  PROP_0,
+  PROP_CONTEXT,
+  PROP_OBJECT,
+  PROP_PLUGIN_INFO,
+  PROP_PLUGIN_STATE,
+  PROP_SETTINGS,
+  N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES] = { NULL, };
+
+
+/*
+ * GActionGroup
+ */
+static void
+valent_extension_activate_action (GActionGroup *action_group,
+                                  const char   *action_name,
+                                  GVariant     *parameter)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_group);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    g_action_activate (action, parameter);
+}
+
+static void
+valent_extension_change_action_state (GActionGroup *action_group,
+                                      const char   *action_name,
+                                      GVariant     *value)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_group);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    g_action_change_state (action, value);
+}
+
+static char **
+valent_extension_list_actions (GActionGroup *action_group)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_group);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  g_auto (GStrv) actions = NULL;
+  GHashTableIter iter;
+  gpointer key;
+  unsigned int i = 0;
+
+  actions = g_new0 (char *, g_hash_table_size (priv->actions) + 1);
+
+  g_hash_table_iter_init (&iter, priv->actions);
+
+  while (g_hash_table_iter_next (&iter, &key, NULL))
+    actions[i++] = g_strdup (key);
+
+  return g_steal_pointer (&actions);
+}
+
+static gboolean
+valent_extension_query_action (GActionGroup        *action_group,
+                               const char          *action_name,
+                               gboolean            *enabled,
+                               const GVariantType **parameter_type,
+                               const GVariantType **state_type,
+                               GVariant           **state_hint,
+                               GVariant           **state)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_group);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) == NULL)
+    return FALSE;
+
+  if (enabled)
+    *enabled = g_action_get_enabled (action);
+
+  if (parameter_type)
+    *parameter_type = g_action_get_parameter_type (action);
+
+  if (state_type)
+    *state_type = g_action_get_state_type (action);
+
+  if (state_hint)
+    *state_hint = g_action_get_state_hint (action);
+
+  if (state)
+    *state = g_action_get_state (action);
+
+  return TRUE;
+}
+
+static void
+g_action_group_iface_init (GActionGroupInterface *iface)
+{
+  iface->activate_action = valent_extension_activate_action;
+  iface->change_action_state = valent_extension_change_action_state;
+  iface->list_actions = valent_extension_list_actions;
+  iface->query_action = valent_extension_query_action;
+}
+
+/*
+ * GActionMap
+ */
+static void
+on_action_enabled_changed (GAction      *action,
+                           GParamSpec   *pspec,
+                           GActionGroup *action_group)
+{
+  g_action_group_action_enabled_changed (action_group,
+                                         g_action_get_name (action),
+                                         g_action_get_enabled (action));
+}
+
+static void
+on_action_state_changed (GAction      *action,
+                         GParamSpec   *pspec,
+                         GActionGroup *action_group)
+{
+  g_autoptr (GVariant) value = NULL;
+
+  value = g_action_get_state (action);
+  g_action_group_action_state_changed (action_group,
+                                       g_action_get_name (action),
+                                       value);
+}
+
+static void
+valent_extension_disconnect_action (ValentExtension *self,
+                                    GAction         *action)
+{
+  g_signal_handlers_disconnect_by_func (action, on_action_enabled_changed, self);
+  g_signal_handlers_disconnect_by_func (action, on_action_state_changed, self);
+}
+
+static GAction *
+valent_extension_lookup_action (GActionMap *action_map,
+                                const char *action_name)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_map);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  return g_hash_table_lookup (priv->actions, action_name);
+}
+
+static void
+valent_extension_add_action (GActionMap *action_map,
+                             GAction    *action)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_map);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  const char *action_name;
+  GAction *replacing;
+
+  action_name = g_action_get_name (action);
+
+  if ((replacing = g_hash_table_lookup (priv->actions, action_name)) == action)
+    return;
+
+  if (replacing != NULL)
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (action_map), action_name);
+      valent_extension_disconnect_action (self, replacing);
+    }
+
+  g_signal_connect (action,
+                    "notify::enabled",
+                    G_CALLBACK (on_action_enabled_changed),
+                    action_map);
+
+  if (g_action_get_state_type (action) != NULL)
+    g_signal_connect (action,
+                      "notify::state",
+                      G_CALLBACK (on_action_state_changed),
+                      action_map);
+
+  g_hash_table_replace (priv->actions,
+                        g_strdup (action_name),
+                        g_object_ref (action));
+  g_action_group_action_added (G_ACTION_GROUP (action_map), action_name);
+}
+
+static void
+valent_extension_remove_action (GActionMap *action_map,
+                                const char *action_name)
+{
+  ValentExtension *self = VALENT_EXTENSION (action_map);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  GAction *action;
+
+  if ((action = g_hash_table_lookup (priv->actions, action_name)) != NULL)
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (action_map), action_name);
+      valent_extension_disconnect_action (self, action);
+      g_hash_table_remove (priv->actions, action_name);
+    }
+}
+
+static void
+g_action_map_iface_init (GActionMapInterface *iface)
+{
+  iface->add_action = valent_extension_add_action;
+  iface->lookup_action = valent_extension_lookup_action;
+  iface->remove_action = valent_extension_remove_action;
+}
+
+/*
+ * ValentExtension
+ */
+static void
+valent_extension_set_object (ValentExtension *self,
+                             gpointer         object)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  g_assert (VALENT_IS_EXTENSION (self));
+  g_assert (object == NULL || G_IS_OBJECT (object));
+
+  if (priv->object == object)
+    return;
+
+  priv->object = object;
+  g_object_add_weak_pointer (G_OBJECT (priv->object), (gpointer *)&priv->object);
+}
+
+/*
+ * GObject
+ */
+static void
+valent_extension_dispose (GObject *object)
+{
+  ValentExtension *self = VALENT_EXTENSION (object);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+  GHashTableIter iter;
+  const char *action_name;
+  GAction *action;
+
+  g_hash_table_iter_init (&iter, priv->actions);
+
+  while (g_hash_table_iter_next (&iter, (void **)&action_name, (void **)&action))
+    {
+      g_action_group_action_removed (G_ACTION_GROUP (self), action_name);
+      valent_extension_disconnect_action (self, action);
+      g_hash_table_iter_remove (&iter);
+    }
+
+  valent_extension_plugin_state_changed (self, VALENT_PLUGIN_STATE_INACTIVE, NULL);
+
+  G_OBJECT_CLASS (valent_extension_parent_class)->dispose (object);
+}
+
+static void
+valent_extension_finalize (GObject *object)
+{
+  ValentExtension *self = VALENT_EXTENSION (object);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  g_clear_weak_pointer (&priv->object);
+  g_clear_error (&priv->plugin_error);
+  g_clear_pointer (&priv->actions, g_hash_table_unref);
+  g_clear_object (&priv->context);
+  g_clear_object (&priv->settings);
+
+  G_OBJECT_CLASS (valent_extension_parent_class)->finalize (object);
+}
+
+static void
+valent_extension_get_property (GObject    *object,
+                               guint       prop_id,
+                               GValue     *value,
+                               GParamSpec *pspec)
+{
+  ValentExtension *self = VALENT_EXTENSION (object);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_CONTEXT:
+      g_value_set_object (value, valent_extension_get_context (self));
+      break;
+
+    case PROP_OBJECT:
+      g_value_set_object (value, priv->object);
+      break;
+
+    case PROP_PLUGIN_INFO:
+      g_value_set_boxed (value, priv->plugin_info);
+      break;
+
+    case PROP_PLUGIN_STATE:
+      g_value_set_enum (value, priv->plugin_state);
+      break;
+
+    case PROP_SETTINGS:
+      g_value_set_object (value, valent_extension_get_settings (self));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_extension_set_property (GObject      *object,
+                               guint         prop_id,
+                               const GValue *value,
+                               GParamSpec   *pspec)
+{
+  ValentExtension *self = VALENT_EXTENSION (object);
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_CONTEXT:
+      priv->context = g_value_dup_object (value);
+      break;
+
+    case PROP_OBJECT:
+      valent_extension_set_object (self, g_value_get_object (value));
+      break;
+
+    case PROP_PLUGIN_INFO:
+      priv->plugin_info = g_value_get_boxed (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+valent_extension_class_init (ValentExtensionClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->dispose = valent_extension_dispose;
+  object_class->finalize = valent_extension_finalize;
+  object_class->get_property = valent_extension_get_property;
+  object_class->set_property = valent_extension_set_property;
+
+  /**
+   * ValentExtension:context: (getter get_context)
+   *
+   * The [class@Valent.Device] this plugin is bound to.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_CONTEXT] =
+    g_param_spec_object ("context", NULL, NULL,
+                         VALENT_TYPE_CONTEXT,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentExtension:object: (getter get_object)
+   *
+   * The [class@GObject.Object] this plugin is bound to.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_OBJECT] =
+    g_param_spec_object ("object", NULL, NULL,
+                         G_TYPE_OBJECT,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentExtension:plugin-info:
+   *
+   * The [struct@Peas.PluginInfo] describing this plugin.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_PLUGIN_INFO] =
+    g_param_spec_boxed ("plugin-info", NULL, NULL,
+                        PEAS_TYPE_PLUGIN_INFO,
+                        (G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_EXPLICIT_NOTIFY |
+                         G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentExtension:plugin-state:
+   *
+   * The [enum@Valent.PluginState] describing the state of the extension.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_PLUGIN_STATE] =
+    g_param_spec_enum ("plugin-state", NULL, NULL,
+                       VALENT_TYPE_PLUGIN_STATE,
+                       VALENT_PLUGIN_STATE_ACTIVE,
+                       (G_PARAM_READABLE |
+                        G_PARAM_EXPLICIT_NOTIFY |
+                        G_PARAM_STATIC_STRINGS));
+
+  /**
+   * ValentExtension:settings: (getter get_settings)
+   *
+   * The [class@Gio.Settings] for this plugin.
+   *
+   * Since: 1.0
+   */
+  properties [PROP_SETTINGS] =
+    g_param_spec_object ("settings", NULL, NULL,
+                         G_TYPE_SETTINGS,
+                         (G_PARAM_READABLE |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+}
+
+static void
+valent_extension_init (ValentExtension *self)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
+
+  priv->actions = g_hash_table_new_full (g_str_hash,
+                                         g_str_equal,
+                                         g_free,
+                                         g_object_unref);
+}
+
+/**
+ * valent_extension_get_context: (get-property context)
+ * @extension: a `ValentExtension`
+ *
+ * Get the settings for this plugin.
+ *
+ * Returns: (transfer none) (nullable): a #ValentContext
+ *
+ * Since: 1.0
+ */
+ValentContext *
+valent_extension_get_context (ValentExtension *extension)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+
+  g_return_val_if_fail (VALENT_IS_EXTENSION (extension), NULL);
+
+  if (priv->context == NULL)
+    {
+      ValentContext *context = NULL;
+      const char *module_name = NULL;
+
+      /* FIXME: context = valent_object_get_context (priv->object); */
+      module_name = peas_plugin_info_get_module_name (priv->plugin_info);
+      priv->context = valent_context_new (context, "plugin", module_name);
+    }
+
+  return priv->context;
+}
+
+/**
+ * valent_extension_get_object: (get-property object)
+ * @extension: a `ValentExtension`
+ *
+ * Get the object this plugin is bound to.
+ *
+ * Returns: (type GObject.Object) (transfer none) (nullable): a `GObject`
+ *
+ * Since: 1.0
+ */
+GObject *
+(valent_extension_get_object) (ValentExtension *extension)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+
+  g_return_val_if_fail (VALENT_IS_EXTENSION (extension), NULL);
+
+  return priv->object;
+}
+
+/**
+ * valent_extension_get_settings: (get-property settings)
+ * @extension: a `ValentExtension`
+ *
+ * Get the settings for this plugin.
+ *
+ * Returns: (transfer none) (nullable): a `GSettings`
+ *
+ * Since: 1.0
+ */
+GSettings *
+valent_extension_get_settings (ValentExtension *extension)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+
+  g_return_val_if_fail (VALENT_IS_EXTENSION (extension), NULL);
+
+  if (priv->settings == NULL)
+    {
+      GType type_base = g_type_parent (G_OBJECT_TYPE (extension));
+      const char *type_name = g_type_name (type_base);
+      g_autofree char *key = NULL;
+
+      if (g_str_has_prefix (type_name, "Valent"))
+        key = g_strdup_printf ("X-%sSettings", &type_name[strlen ("Valent")]);
+      else
+        key = g_strdup_printf ("X-%sSettings", type_name);
+
+      priv->settings = valent_context_get_plugin_settings (priv->context,
+                                                           priv->plugin_info,
+                                                           key);
+    }
+
+  return priv->settings;
+}
+
+/**
+ * valent_extension_plugin_state_check:
+ * @extension: a `ValentExtension`
+ * @error: (nullable): a `GError`
+ *
+ * Get the extension state, while propagating any errors that describe it.
+ *
+ * Returns: a `ValentPluginState`
+ *
+ * Since: 1.0
+ */
+ValentPluginState
+valent_extension_plugin_state_check (ValentExtension  *extension,
+                                     GError          **error)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+
+  g_return_val_if_fail (VALENT_IS_EXTENSION (extension), VALENT_PLUGIN_STATE_INACTIVE);
+  g_return_val_if_fail (error == NULL || *error == NULL, VALENT_PLUGIN_STATE_INACTIVE);
+
+  if (priv->plugin_error != NULL && error != NULL)
+    *error = g_error_copy (priv->plugin_error);
+
+  return priv->plugin_state;
+}
+
+/**
+ * valent_extension_plugin_state_changed:
+ * @extension: a `ValentExtension`
+ * @state: a `ValentPluginState`
+ * @error: (nullable): a `GError`
+ *
+ * Emits [signal@GObject.Object::notify] for
+ * [property@Valent.Extension:plugin-state].
+ *
+ * Implementations should call this method to inform the managing object of
+ * changes to the state of the extension, especially unrecoverable errors.
+ *
+ * Since: 1.0
+ */
+void
+valent_extension_plugin_state_changed (ValentExtension   *extension,
+                                       ValentPluginState  state,
+                                       GError            *error)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+
+  g_return_if_fail (VALENT_IS_EXTENSION (extension));
+  g_return_if_fail (state != VALENT_PLUGIN_STATE_ERROR || error != NULL);
+
+  g_clear_error (&priv->plugin_error);
+
+  if (state == VALENT_PLUGIN_STATE_ERROR && error != NULL)
+    priv->plugin_error = g_error_copy (error);
+
+  if (priv->plugin_state != state || error != NULL)
+    {
+      priv->plugin_state = state;
+      valent_object_notify_by_pspec (VALENT_OBJECT (extension),
+                                     properties [PROP_PLUGIN_STATE]);
+    }
+}
+
+/**
+ * valent_extension_toggle_actions:
+ * @extension: a `ValentExtension`
+ * @enabled: boolean
+ *
+ * Enable or disable all actions.
+ *
+ * Set the [property@Gio.Action:enabled] property of the actions for @extension to
+ * @enabled.
+ *
+ * Since: 1.0
+ */
+void
+valent_extension_toggle_actions (ValentExtension *extension,
+                                 gboolean         enabled)
+{
+  ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
+  GHashTableIter iter;
+  GSimpleAction *action;
+
+  g_return_if_fail (VALENT_IS_EXTENSION (extension));
+
+  g_hash_table_iter_init (&iter, priv->actions);
+
+  while (g_hash_table_iter_next (&iter, NULL, (void **)&action))
+    g_simple_action_set_enabled (action, enabled);
+}
+

--- a/src/libvalent/core/valent-extension.h
+++ b/src/libvalent/core/valent-extension.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Andy Holmes <andrew.g.r.holmes@gmail.com>
+
+#pragma once
+
+#if !defined (VALENT_INSIDE) && !defined (VALENT_COMPILATION)
+# error "Only <valent.h> can be included directly."
+#endif
+
+#include "valent-context.h"
+
+G_BEGIN_DECLS
+
+/**
+ * ValentPluginState:
+ * @VALENT_PLUGIN_STATE_ACTIVE: the plugin functionality is available
+ * @VALENT_PLUGIN_STATE_INACTIVE: the plugin functionality is unavailable
+ * @VALENT_PLUGIN_STATE_ERROR: the plugin encountered an unrecoverable error
+ * Since: 1.0
+ */
+typedef enum
+{
+  VALENT_PLUGIN_STATE_ACTIVE,
+  VALENT_PLUGIN_STATE_INACTIVE,
+  VALENT_PLUGIN_STATE_ERROR,
+} ValentPluginState;
+
+
+#define VALENT_TYPE_EXTENSION (valent_extension_get_type ())
+
+VALENT_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (ValentExtension, valent_extension, VALENT, EXTENSION, ValentObject)
+
+struct _ValentExtensionClass
+{
+  ValentObjectClass   parent_class;
+
+  /* virtual functions */
+
+  /*< private >*/
+  gpointer            padding[8];
+};
+
+VALENT_AVAILABLE_IN_1_0
+ValentContext     * valent_extension_get_context          (ValentExtension    *extension);
+VALENT_AVAILABLE_IN_1_0
+GObject           * valent_extension_get_object           (ValentExtension    *extension);
+VALENT_AVAILABLE_IN_1_0
+GSettings         * valent_extension_get_settings         (ValentExtension    *extension);
+VALENT_AVAILABLE_IN_1_0
+ValentPluginState   valent_extension_plugin_state_check   (ValentExtension    *extension,
+                                                           GError            **error);
+VALENT_AVAILABLE_IN_1_0
+void                valent_extension_plugin_state_changed (ValentExtension    *extension,
+                                                           ValentPluginState   state,
+                                                           GError             *error);
+VALENT_AVAILABLE_IN_1_0
+void                valent_extension_toggle_actions       (ValentExtension    *extension,
+                                                           gboolean            enabled);
+
+/* Convenience Macros */
+#define valent_extension_get_object(e) ((void *)valent_extension_get_object (e))
+
+G_END_DECLS
+

--- a/src/libvalent/device/valent-channel-service.h
+++ b/src/libvalent/device/valent-channel-service.h
@@ -7,6 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
+#include "../core/valent-extension.h"
 #include "valent-channel.h"
 
 G_BEGIN_DECLS
@@ -14,23 +15,23 @@ G_BEGIN_DECLS
 #define VALENT_TYPE_CHANNEL_SERVICE (valent_channel_service_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentChannelService, valent_channel_service, VALENT, CHANNEL_SERVICE, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentChannelService, valent_channel_service, VALENT, CHANNEL_SERVICE, ValentExtension)
 
 struct _ValentChannelServiceClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  void                (*build_identity) (ValentChannelService  *service);
-  void                (*identify)       (ValentChannelService  *service,
-                                         const char            *target);
+  void                   (*build_identity) (ValentChannelService  *service);
+  void                   (*identify)       (ValentChannelService  *service,
+                                            const char            *target);
 
   /* signals */
-  void                (*channel)        (ValentChannelService  *service,
-                                         ValentChannel         *channel);
+  void                   (*channel)        (ValentChannelService  *service,
+                                            ValentChannel         *channel);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/device/valent-device-plugin.h
+++ b/src/libvalent/device/valent-device-plugin.h
@@ -8,8 +8,8 @@
 #endif
 
 #include <json-glib/json-glib.h>
-#include <libpeas/peas.h>
 
+#include "../core/valent-extension.h"
 #include "valent-device.h"
 
 G_BEGIN_DECLS
@@ -21,69 +21,62 @@ G_DECLARE_DERIVABLE_TYPE (ValentDevicePlugin, valent_device_plugin, VALENT, DEVI
 
 struct _ValentDevicePluginClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  void                (*handle_packet) (ValentDevicePlugin *plugin,
-                                        const char         *type,
-                                        JsonNode           *packet);
-  void                (*update_state)  (ValentDevicePlugin *plugin,
-                                        ValentDeviceState   state);
+  void                   (*handle_packet) (ValentDevicePlugin *plugin,
+                                           const char         *type,
+                                           JsonNode           *packet);
+  void                   (*update_state)  (ValentDevicePlugin *plugin,
+                                           ValentDeviceState   state);
 
   /*< private >*/
   gpointer            padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_handle_packet       (ValentDevicePlugin    *plugin,
-                                                          const char            *type,
-                                                          JsonNode              *packet);
+void   valent_device_plugin_handle_packet     (ValentDevicePlugin *plugin,
+                                               const char         *type,
+                                               JsonNode           *packet);
 VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_update_state        (ValentDevicePlugin    *plugin,
-                                                          ValentDeviceState      state);
+void   valent_device_plugin_queue_packet      (ValentDevicePlugin *plugin,
+                                               JsonNode           *packet);
 VALENT_AVAILABLE_IN_1_0
-ValentContext * valent_device_plugin_get_context         (ValentDevicePlugin    *plugin);
+void   valent_device_plugin_update_state      (ValentDevicePlugin *plugin,
+                                               ValentDeviceState   state);
+
+/* TODO: move to extension? */
 VALENT_AVAILABLE_IN_1_0
-ValentDevice  * valent_device_plugin_get_device          (ValentDevicePlugin    *plugin);
+void   valent_device_plugin_show_notification (ValentDevicePlugin *plugin,
+                                               const char         *id,
+                                               GNotification      *notification);
 VALENT_AVAILABLE_IN_1_0
-GSettings     * valent_device_plugin_get_settings        (ValentDevicePlugin    *plugin);
-VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_queue_packet        (ValentDevicePlugin    *plugin,
-                                                          JsonNode              *packet);
-VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_show_notification   (ValentDevicePlugin    *plugin,
-                                                          const char            *id,
-                                                          GNotification         *notification);
-VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_hide_notification   (ValentDevicePlugin    *plugin,
-                                                          const char            *id);
-VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_toggle_actions      (ValentDevicePlugin    *plugin,
-                                                          gboolean               enabled);
+void   valent_device_plugin_hide_notification (ValentDevicePlugin *plugin,
+                                               const char         *id);
 
 /* TODO: GMenuModel XML */
 VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_set_menu_action     (ValentDevicePlugin    *plugin,
-                                                          const char            *action,
-                                                          const char            *label,
-                                                          const char            *icon_name);
+void   valent_device_plugin_set_menu_action   (ValentDevicePlugin *plugin,
+                                               const char         *action,
+                                               const char         *label,
+                                               const char         *icon_name);
 VALENT_AVAILABLE_IN_1_0
-void            valent_device_plugin_set_menu_item       (ValentDevicePlugin    *plugin,
-                                                          const char            *action,
-                                                          GMenuItem             *item);
+void   valent_device_plugin_set_menu_item     (ValentDevicePlugin *plugin,
+                                               const char         *action,
+                                               GMenuItem          *item);
 
 /* Miscellaneous Helpers */
 VALENT_AVAILABLE_IN_1_0
-void            valent_notification_set_device_action    (GNotification         *notification,
-                                                          ValentDevice          *device,
-                                                          const char            *action,
-                                                          GVariant              *target);
+void   valent_notification_set_device_action  (GNotification      *notification,
+                                               ValentDevice       *device,
+                                               const char         *action,
+                                               GVariant           *target);
 VALENT_AVAILABLE_IN_1_0
-void            valent_notification_add_device_button    (GNotification         *notification,
-                                                          ValentDevice          *device,
-                                                          const char            *label,
-                                                          const char            *action,
-                                                          GVariant              *target);
+void   valent_notification_add_device_button  (GNotification      *notification,
+                                               ValentDevice       *device,
+                                               const char         *label,
+                                               const char         *action,
+                                               GVariant           *target);
 
 G_END_DECLS
 

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -286,7 +286,7 @@ valent_device_enable_plugin (ValentDevice *device,
                                                     plugin->info,
                                                     VALENT_TYPE_DEVICE_PLUGIN,
                                                     "context", plugin->context,
-                                                    "device",  plugin->parent,
+                                                    "object",  plugin->parent,
                                                     NULL);
   g_return_if_fail (G_IS_OBJECT (plugin->extension));
 

--- a/src/libvalent/input/valent-input-adapter.c
+++ b/src/libvalent/input/valent-input-adapter.c
@@ -6,7 +6,6 @@
 #include "config.h"
 
 #include <gio/gio.h>
-#include <libpeas/peas.h>
 #include <libvalent-core.h>
 
 #include "valent-input-adapter.h"
@@ -35,10 +34,10 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
+  uint8_t  active : 1;
 } ValentInputAdapterPrivate;
 
-G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentInputAdapter, valent_input_adapter, VALENT_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentInputAdapter, valent_input_adapter, VALENT_TYPE_EXTENSION)
 
 /**
  * ValentInputAdapterClass:
@@ -49,14 +48,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentInputAdapter, valent_input_adapter, V
  *
  * The virtual function table for #ValentInputAdapter.
  */
-
-enum {
-  PROP_0,
-  PROP_PLUGIN_INFO,
-  N_PROPERTIES
-};
-
-static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
 /* LCOV_EXCL_START */
@@ -93,74 +84,12 @@ valent_input_adapter_real_pointer_motion (ValentInputAdapter *adapter,
  * GObject
  */
 static void
-valent_input_adapter_get_property (GObject    *object,
-                                   guint       prop_id,
-                                   GValue     *value,
-                                   GParamSpec *pspec)
-{
-  ValentInputAdapter *self = VALENT_INPUT_ADAPTER (object);
-  ValentInputAdapterPrivate *priv = valent_input_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_input_adapter_set_property (GObject      *object,
-                                   guint         prop_id,
-                                   const GValue *value,
-                                   GParamSpec   *pspec)
-{
-  ValentInputAdapter *self = VALENT_INPUT_ADAPTER (object);
-  ValentInputAdapterPrivate *priv = valent_input_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_input_adapter_class_init (ValentInputAdapterClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  object_class->get_property = valent_input_adapter_get_property;
-  object_class->set_property = valent_input_adapter_set_property;
-
   klass->keyboard_keysym = valent_input_adapter_real_keyboard_keysym;
   klass->pointer_axis = valent_input_adapter_real_pointer_axis;
   klass->pointer_button = valent_input_adapter_real_pointer_button;
   klass->pointer_motion = valent_input_adapter_real_pointer_motion;
-
-  /**
-   * ValentInputAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }
 
 static void

--- a/src/libvalent/input/valent-input-adapter.h
+++ b/src/libvalent/input/valent-input-adapter.h
@@ -7,32 +7,32 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include "../core/valent-object.h"
+#include "../core/valent-extension.h"
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_INPUT_ADAPTER (valent_input_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentInputAdapter, valent_input_adapter, VALENT, INPUT_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentInputAdapter, valent_input_adapter, VALENT, INPUT_ADAPTER, ValentExtension)
 
 struct _ValentInputAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  void                (*keyboard_keysym) (ValentInputAdapter *adapter,
-                                          unsigned int        keysym,
-                                          gboolean            state);
-  void                (*pointer_axis)    (ValentInputAdapter *adapter,
-                                          double              dx,
-                                          double              dy);
-  void                (*pointer_button)  (ValentInputAdapter *adapter,
-                                          unsigned int        button,
-                                          gboolean            state);
-  void                (*pointer_motion)  (ValentInputAdapter *adapter,
-                                          double              dx,
-                                          double              dy);
+  void                   (*keyboard_keysym) (ValentInputAdapter *adapter,
+                                             unsigned int        keysym,
+                                             gboolean            state);
+  void                   (*pointer_axis)    (ValentInputAdapter *adapter,
+                                             double              dx,
+                                             double              dy);
+  void                   (*pointer_button)  (ValentInputAdapter *adapter,
+                                             unsigned int        button,
+                                             gboolean            state);
+  void                   (*pointer_motion)  (ValentInputAdapter *adapter,
+                                             double              dx,
+                                             double              dy);
 
   /*< private >*/
   gpointer            padding[8];

--- a/src/libvalent/media/valent-media-adapter.c
+++ b/src/libvalent/media/valent-media-adapter.c
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#include <libpeas/peas.h>
 #include <libvalent-core.h>
 
 #include "valent-media-player.h"
@@ -35,13 +34,12 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
   GPtrArray      *players;
 } ValentMediaAdapterPrivate;
 
 static void   g_list_model_iface_init (GListModelInterface *iface);
 
-G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentMediaAdapter, valent_media_adapter, VALENT_TYPE_OBJECT,
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentMediaAdapter, valent_media_adapter, VALENT_TYPE_EXTENSION,
                                   G_ADD_PRIVATE (ValentMediaAdapter)
                                   G_IMPLEMENT_INTERFACE (G_TYPE_LIST_MODEL, g_list_model_iface_init))
 
@@ -52,14 +50,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentMediaAdapter, valent_media_adapter, VALE
  *
  * The virtual function table for #ValentMediaAdapter.
  */
-
-enum {
-  PROP_0,
-  PROP_PLUGIN_INFO,
-  N_PROPERTIES
-};
-
-static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
 /*
@@ -138,73 +128,14 @@ valent_media_adapter_finalize (GObject *object)
 }
 
 static void
-valent_media_adapter_get_property (GObject    *object,
-                                   guint       prop_id,
-                                   GValue     *value,
-                                   GParamSpec *pspec)
-{
-  ValentMediaAdapter *self = VALENT_MEDIA_ADAPTER (object);
-  ValentMediaAdapterPrivate *priv = valent_media_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_media_adapter_set_property (GObject      *object,
-                                   guint         prop_id,
-                                   const GValue *value,
-                                   GParamSpec   *pspec)
-{
-  ValentMediaAdapter *self = VALENT_MEDIA_ADAPTER (object);
-  ValentMediaAdapterPrivate *priv = valent_media_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_media_adapter_class_init (ValentMediaAdapterClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->finalize = valent_media_adapter_finalize;
-  object_class->get_property = valent_media_adapter_get_property;
-  object_class->set_property = valent_media_adapter_set_property;
 
   klass->export_player = valent_media_adapter_real_export_player;
   klass->unexport_player = valent_media_adapter_real_unexport_player;
-
-  /**
-   * ValentMediaAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }
 
 static void

--- a/src/libvalent/media/valent-media-adapter.h
+++ b/src/libvalent/media/valent-media-adapter.h
@@ -7,6 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
+#include "../core/valent-extension.h"
 #include "valent-media-player.h"
 
 G_BEGIN_DECLS
@@ -14,34 +15,34 @@ G_BEGIN_DECLS
 #define VALENT_TYPE_MEDIA_ADAPTER (valent_media_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentMediaAdapter, valent_media_adapter, VALENT, MEDIA_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentMediaAdapter, valent_media_adapter, VALENT, MEDIA_ADAPTER, ValentExtension)
 
 struct _ValentMediaAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  void                (*export_player)   (ValentMediaAdapter   *adapter,
-                                          ValentMediaPlayer    *player);
-  void                (*unexport_player) (ValentMediaAdapter   *adapter,
-                                          ValentMediaPlayer    *player);
+  void                   (*export_player)   (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
+  void                   (*unexport_player) (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0
-void        valent_media_adapter_player_added    (ValentMediaAdapter   *adapter,
-                                                  ValentMediaPlayer    *player);
+void   valent_media_adapter_player_added    (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
 VALENT_AVAILABLE_IN_1_0
-void        valent_media_adapter_player_removed  (ValentMediaAdapter   *adapter,
-                                                  ValentMediaPlayer    *player);
+void   valent_media_adapter_player_removed  (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
 VALENT_AVAILABLE_IN_1_0
-void        valent_media_adapter_export_player   (ValentMediaAdapter   *adapter,
-                                                  ValentMediaPlayer    *player);
+void   valent_media_adapter_export_player   (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
 VALENT_AVAILABLE_IN_1_0
-void        valent_media_adapter_unexport_player (ValentMediaAdapter   *adapter,
-                                                  ValentMediaPlayer    *player);
+void   valent_media_adapter_unexport_player (ValentMediaAdapter *adapter,
+                                             ValentMediaPlayer  *player);
 
 G_END_DECLS
 

--- a/src/libvalent/mixer/valent-mixer-adapter.c
+++ b/src/libvalent/mixer/valent-mixer-adapter.c
@@ -5,7 +5,7 @@
 
 #include "config.h"
 
-#include <libpeas/peas.h>
+#include <gio/gio.h>
 #include <libvalent-core.h>
 
 #include "valent-mixer.h"
@@ -36,14 +36,12 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
-
-  GPtrArray      *streams;
+  GPtrArray *streams;
 } ValentMixerAdapterPrivate;
 
 static void   g_list_model_iface_init (GListModelInterface *iface);
 
-G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentMixerAdapter, valent_mixer_adapter, VALENT_TYPE_OBJECT,
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ValentMixerAdapter, valent_mixer_adapter, VALENT_TYPE_EXTENSION,
                                   G_ADD_PRIVATE (ValentMixerAdapter)
                                   G_IMPLEMENT_INTERFACE (G_TYPE_LIST_MODEL, g_list_model_iface_init))
 
@@ -62,7 +60,6 @@ enum {
   PROP_0,
   PROP_DEFAULT_INPUT,
   PROP_DEFAULT_OUTPUT,
-  PROP_PLUGIN_INFO,
   N_PROPERTIES
 };
 
@@ -167,7 +164,6 @@ valent_mixer_adapter_get_property (GObject    *object,
                                    GParamSpec *pspec)
 {
   ValentMixerAdapter *self = VALENT_MIXER_ADAPTER (object);
-  ValentMixerAdapterPrivate *priv = valent_mixer_adapter_get_instance_private (self);
 
   switch (prop_id)
     {
@@ -177,10 +173,6 @@ valent_mixer_adapter_get_property (GObject    *object,
 
     case PROP_DEFAULT_OUTPUT:
       g_value_set_object (value, valent_mixer_adapter_get_default_output (self));
-      break;
-
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
       break;
 
     default:
@@ -195,7 +187,6 @@ valent_mixer_adapter_set_property (GObject      *object,
                                    GParamSpec   *pspec)
 {
   ValentMixerAdapter *self = VALENT_MIXER_ADAPTER (object);
-  ValentMixerAdapterPrivate *priv = valent_mixer_adapter_get_instance_private (self);
 
   switch (prop_id)
     {
@@ -205,10 +196,6 @@ valent_mixer_adapter_set_property (GObject      *object,
 
     case PROP_DEFAULT_OUTPUT:
       valent_mixer_adapter_set_default_output (self, g_value_get_object (value));
-      break;
-
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
       break;
 
     default:
@@ -263,21 +250,6 @@ valent_mixer_adapter_class_init (ValentMixerAdapterClass *klass)
                          (G_PARAM_READWRITE |
                           G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));
-
-  /**
-   * ValentMixerAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 }

--- a/src/libvalent/mixer/valent-mixer-adapter.h
+++ b/src/libvalent/mixer/valent-mixer-adapter.h
@@ -7,6 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
+#include "../core/valent-extension.h"
 #include "valent-mixer-stream.h"
 
 G_BEGIN_DECLS
@@ -14,22 +15,22 @@ G_BEGIN_DECLS
 #define VALENT_TYPE_MIXER_ADAPTER (valent_mixer_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentMixerAdapter, valent_mixer_adapter, VALENT, MIXER_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentMixerAdapter, valent_mixer_adapter, VALENT, MIXER_ADAPTER, ValentExtension)
 
 struct _ValentMixerAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  ValentMixerStream * (*get_default_input)  (ValentMixerAdapter *adapter);
-  void                (*set_default_input)  (ValentMixerAdapter *adapter,
-                                             ValentMixerStream  *stream);
-  ValentMixerStream * (*get_default_output) (ValentMixerAdapter *adapter);
-  void                (*set_default_output) (ValentMixerAdapter *adapter,
-                                             ValentMixerStream  *stream);
+  ValentMixerStream    * (*get_default_input)  (ValentMixerAdapter *adapter);
+  void                   (*set_default_input)  (ValentMixerAdapter *adapter,
+                                                ValentMixerStream  *stream);
+  ValentMixerStream    * (*get_default_output) (ValentMixerAdapter *adapter);
+  void                   (*set_default_output) (ValentMixerAdapter *adapter,
+                                                ValentMixerStream  *stream);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/notifications/valent-notifications-adapter.c
+++ b/src/libvalent/notifications/valent-notifications-adapter.c
@@ -34,10 +34,10 @@
 
 typedef struct
 {
-  PeasPluginInfo *plugin_info;
+  GPtrArray *notifications;
 } ValentNotificationsAdapterPrivate;
 
-G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentNotificationsAdapter, valent_notifications_adapter, VALENT_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentNotificationsAdapter, valent_notifications_adapter, VALENT_TYPE_EXTENSION)
 
 /**
  * ValentNotificationsAdapterClass:
@@ -48,14 +48,6 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ValentNotificationsAdapter, valent_notifica
  *
  * The virtual function table for #ValentNotificationsAdapter.
  */
-
-enum {
-  PROP_0,
-  PROP_PLUGIN_INFO,
-  N_PROPERTIES
-};
-
-static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 enum {
   NOTIFICATION_ADDED,
@@ -84,72 +76,10 @@ valent_notifications_adapter_real_remove_notification (ValentNotificationsAdapte
  * GObject
  */
 static void
-valent_notifications_adapter_get_property (GObject    *object,
-                                         guint       prop_id,
-                                         GValue     *value,
-                                         GParamSpec *pspec)
-{
-  ValentNotificationsAdapter *self = VALENT_NOTIFICATIONS_ADAPTER (object);
-  ValentNotificationsAdapterPrivate *priv = valent_notifications_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      g_value_set_boxed (value, priv->plugin_info);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
-valent_notifications_adapter_set_property (GObject      *object,
-                                         guint         prop_id,
-                                         const GValue *value,
-                                         GParamSpec   *pspec)
-{
-  ValentNotificationsAdapter *self = VALENT_NOTIFICATIONS_ADAPTER (object);
-  ValentNotificationsAdapterPrivate *priv = valent_notifications_adapter_get_instance_private (self);
-
-  switch (prop_id)
-    {
-    case PROP_PLUGIN_INFO:
-      priv->plugin_info = g_value_get_boxed (value);
-      break;
-
-    default:
-      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    }
-}
-
-static void
 valent_notifications_adapter_class_init (ValentNotificationsAdapterClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-  object_class->get_property = valent_notifications_adapter_get_property;
-  object_class->set_property = valent_notifications_adapter_set_property;
-
   klass->add_notification = valent_notifications_adapter_real_add_notification;
   klass->remove_notification = valent_notifications_adapter_real_remove_notification;
-
-  /**
-   * ValentNotificationsAdapter:plugin-info:
-   *
-   * The [struct@Peas.PluginInfo] describing this adapter.
-   *
-   * Since: 1.0
-   */
-  properties [PROP_PLUGIN_INFO] =
-    g_param_spec_boxed ("plugin-info", NULL, NULL,
-                        PEAS_TYPE_PLUGIN_INFO,
-                        (G_PARAM_READWRITE |
-                         G_PARAM_CONSTRUCT_ONLY |
-                         G_PARAM_EXPLICIT_NOTIFY |
-                         G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
 
   /**
    * ValentNotificationsAdapter::notification-added:

--- a/src/libvalent/notifications/valent-notifications-adapter.h
+++ b/src/libvalent/notifications/valent-notifications-adapter.h
@@ -7,6 +7,7 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
+#include "../core/valent-extension.h"
 #include "valent-notification.h"
 
 G_BEGIN_DECLS
@@ -14,26 +15,26 @@ G_BEGIN_DECLS
 #define VALENT_TYPE_NOTIFICATIONS_ADAPTER (valent_notifications_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentNotificationsAdapter, valent_notifications_adapter, VALENT, NOTIFICATIONS_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentNotificationsAdapter, valent_notifications_adapter, VALENT, NOTIFICATIONS_ADAPTER, ValentExtension)
 
 struct _ValentNotificationsAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  void                (*add_notification)     (ValentNotificationsAdapter  *adapter,
-                                               ValentNotification          *notification);
-  void                (*remove_notification)  (ValentNotificationsAdapter  *adapter,
-                                               const char                  *id);
+  void                   (*add_notification)     (ValentNotificationsAdapter  *adapter,
+                                                  ValentNotification          *notification);
+  void                   (*remove_notification)  (ValentNotificationsAdapter  *adapter,
+                                                  const char                  *id);
 
   /* signals */
-  void                (*notification_added)   (ValentNotificationsAdapter  *adapter,
-                                               ValentNotification          *notification);
-  void                (*notification_removed) (ValentNotificationsAdapter  *adapter,
-                                               const char                  *id);
+  void                   (*notification_added)   (ValentNotificationsAdapter  *adapter,
+                                                  ValentNotification          *notification);
+  void                   (*notification_removed) (ValentNotificationsAdapter  *adapter,
+                                                  const char                  *id);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/session/valent-session-adapter.h
+++ b/src/libvalent/session/valent-session-adapter.h
@@ -7,27 +7,27 @@
 # error "Only <valent.h> can be included directly."
 #endif
 
-#include "../core/valent-object.h"
+#include "../core/valent-extension.h"
 
 G_BEGIN_DECLS
 
 #define VALENT_TYPE_SESSION_ADAPTER (valent_session_adapter_get_type())
 
 VALENT_AVAILABLE_IN_1_0
-G_DECLARE_DERIVABLE_TYPE (ValentSessionAdapter, valent_session_adapter, VALENT, SESSION_ADAPTER, ValentObject)
+G_DECLARE_DERIVABLE_TYPE (ValentSessionAdapter, valent_session_adapter, VALENT, SESSION_ADAPTER, ValentExtension)
 
 struct _ValentSessionAdapterClass
 {
-  ValentObjectClass   parent_class;
+  ValentExtensionClass   parent_class;
 
   /* virtual functions */
-  gboolean            (*get_active) (ValentSessionAdapter *adapter);
-  gboolean            (*get_locked) (ValentSessionAdapter *adapter);
-  void                (*set_locked) (ValentSessionAdapter *adapter,
-                                     gboolean              state);
+  gboolean               (*get_active) (ValentSessionAdapter *adapter);
+  gboolean               (*get_locked) (ValentSessionAdapter *adapter);
+  void                   (*set_locked) (ValentSessionAdapter *adapter,
+                                        gboolean              state);
 
   /*< private >*/
-  gpointer            padding[8];
+  gpointer               padding[8];
 };
 
 VALENT_AVAILABLE_IN_1_0

--- a/src/libvalent/ui/valent-ui-manager.c
+++ b/src/libvalent/ui/valent-ui-manager.c
@@ -94,7 +94,7 @@ valent_ui_manager_activate (ValentApplicationPlugin *plugin)
 
   g_assert (VALENT_IS_UI_MANAGER (plugin));
 
-  application = valent_application_plugin_get_application (plugin);
+  application = valent_extension_get_object (VALENT_EXTENSION (plugin));
   g_action_group_activate_action (G_ACTION_GROUP (application),
                                   "window",
                                   g_variant_new_string ("main"));
@@ -110,7 +110,7 @@ valent_ui_manager_shutdown (ValentApplicationPlugin *plugin)
 
   g_assert (VALENT_IS_UI_MANAGER (plugin));
 
-  application = valent_application_plugin_get_application (plugin);
+  application = valent_extension_get_object (VALENT_EXTENSION (plugin));
 
   for (unsigned int i = 0; i < G_N_ELEMENTS (app_actions); i++)
     g_action_map_remove_action (G_ACTION_MAP (application), app_actions[i].name);
@@ -128,7 +128,7 @@ valent_ui_manager_startup (ValentApplicationPlugin *plugin)
 
   valent_ui_init ();
 
-  application = valent_application_plugin_get_application (plugin);
+  application = valent_extension_get_object (VALENT_EXTENSION (plugin));
   g_action_map_add_action_entries (G_ACTION_MAP (application),
                                    app_actions,
                                    G_N_ELEMENTS (app_actions),

--- a/src/libvalent/valent.h
+++ b/src/libvalent/valent.h
@@ -17,6 +17,7 @@ G_BEGIN_DECLS
 #include "core/valent-context.h"
 #include "core/valent-core-enums.h"
 #include "core/valent-debug.h"
+#include "core/valent-extension.h"
 #include "core/valent-global.h"
 #include "core/valent-macros.h"
 #include "core/valent-object.h"

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -116,7 +116,7 @@ valent_battery_plugin_send_state (ValentBatteryPlugin *self)
   if (valent_battery_current_charge (self->battery) <= 0)
     return;
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   if (!g_settings_get_boolean (settings, "share-state"))
     return;
@@ -260,9 +260,9 @@ valent_battery_plugin_update_notification (ValentBatteryPlugin *self,
 
   g_assert (VALENT_IS_BATTERY_PLUGIN (self));
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   device_name = valent_device_get_name (device);
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   full = g_settings_get_double (settings, "full-notification-level");
   low = g_settings_get_double (settings, "low-notification-level");
@@ -412,7 +412,7 @@ valent_battery_plugin_update_state (ValentDevicePlugin *plugin,
     }
   else
     {
-      valent_device_plugin_toggle_actions (plugin, available);
+      valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
       valent_battery_plugin_watch_battery (self, FALSE);
     }
 }

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -91,7 +91,7 @@ valent_clipboard_read_text_cb (ValentClipboard       *clipboard,
   if (error != NULL)
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_warning ("%s(): %s", G_STRFUNC, error->message);
+        g_debug ("%s(): %s", G_STRFUNC, error->message);
 
       return;
     }
@@ -162,7 +162,7 @@ on_auto_pull_changed (GSettings             *settings,
   if (!self->auto_pull)
     return;
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   state = valent_device_get_state (device);
 
   if ((state & VALENT_DEVICE_STATE_CONNECTED) != 0 ||
@@ -194,7 +194,7 @@ on_auto_push_changed (GSettings             *settings,
   if (!self->auto_push)
     return;
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   state = valent_device_get_state (device);
 
   if ((state & VALENT_DEVICE_STATE_CONNECTED) != 0 ||
@@ -214,6 +214,7 @@ on_clipboard_changed (ValentClipboard       *clipboard,
                       ValentClipboardPlugin *self)
 {
   g_autoptr (GCancellable) destroy = NULL;
+
   g_assert (VALENT_IS_CLIPBOARD (clipboard));
   g_assert (VALENT_IS_CLIPBOARD_PLUGIN (self));
 
@@ -369,7 +370,7 @@ valent_clipboard_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 
   if (available)
     {
@@ -433,7 +434,7 @@ valent_clipboard_plugin_constructed (GObject *object)
                                    G_N_ELEMENTS (actions),
                                    plugin);
 
-  settings = valent_device_plugin_get_settings (plugin);
+  settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
   self->auto_pull = g_settings_get_boolean (settings, "auto-pull");
   g_signal_connect_object (settings,
                            "changed::auto-pull",

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -92,7 +92,7 @@ valent_connectivity_report_plugin_send_state (ValentConnectivityReportPlugin *se
 
   g_return_if_fail (VALENT_IS_CONNECTIVITY_REPORT_PLUGIN (self));
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   if (!g_settings_get_boolean (settings, "share-state"))
     return;
@@ -221,7 +221,7 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
       return;
     }
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   /* Add each signal */
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
@@ -314,7 +314,7 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
       g_autofree char *body = NULL;
       const char *device_name;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
       device_name = valent_device_get_name (device);
 
       /* TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service") */
@@ -381,7 +381,7 @@ valent_connectivity_report_plugin_update_state (ValentDevicePlugin *plugin,
   else
     {
       valent_connectivity_report_plugin_watch_telephony (self, FALSE);
-      valent_device_plugin_toggle_actions (plugin, available);
+      valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
     }
 }
 

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -96,7 +96,7 @@ valent_contact_plugin_handle_request_vcards_by_uid (ValentContactsPlugin *self,
 
 #ifndef __clang_analyzer__
   /* Bail if exporting is disabled */
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   if (self->local_store == NULL || !g_settings_get_boolean (settings, "local-sync"))
     return;
@@ -201,7 +201,7 @@ valent_contact_plugin_handle_request_all_uids_timestamps (ValentContactsPlugin *
   g_assert (VALENT_IS_CONTACTS_PLUGIN (self));
 
   /* Bail if exporting is disabled */
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   if (self->local_store == NULL || !g_settings_get_boolean (settings, "local-sync"))
     return;
@@ -364,7 +364,7 @@ valent_contacts_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 
   if (available)
     valent_contacts_plugin_request_all_uids_timestamps (self);
@@ -422,8 +422,8 @@ valent_contacts_plugin_constructed (GObject *object)
 
   /* Prepare Addressbooks */
   self->cancellable = g_cancellable_new ();
-  device = valent_device_plugin_get_device (plugin);
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (plugin));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   store = valent_contacts_ensure_store (valent_contacts_get_default (),
                                         valent_device_get_id (device),

--- a/src/plugins/findmyphone/valent-findmyphone-plugin.c
+++ b/src/plugins/findmyphone/valent-findmyphone-plugin.c
@@ -74,7 +74,7 @@ valent_findmyphone_plugin_update_state (ValentDevicePlugin *plugin,
   if (!available && valent_findmyphone_ringer_is_owner (self->ringer, self))
     valent_findmyphone_ringer_hide (self->ringer);
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/src/plugins/gtk/valent-gdk-clipboard.c
+++ b/src/plugins/gtk/valent-gdk-clipboard.c
@@ -264,7 +264,6 @@ valent_gdk_clipboard_constructed (GObject *object)
   ValentGdkClipboard *self = VALENT_GDK_CLIPBOARD (object);
   GdkDisplay *display;
 
-  /* Connect to the clipboard */
   if ((display = gdk_display_get_default ()) != NULL)
     {
       self->clipboard = gdk_display_get_clipboard (display);
@@ -272,6 +271,12 @@ valent_gdk_clipboard_constructed (GObject *object)
                                "changed",
                                G_CALLBACK (on_changed),
                                self, 0);
+    }
+  else
+    {
+      valent_extension_plugin_state_changed (VALENT_EXTENSION (self),
+                                             VALENT_PLUGIN_STATE_INACTIVE,
+                                             NULL);
     }
 
   G_OBJECT_CLASS (valent_gdk_clipboard_parent_class)->constructed (object);

--- a/src/plugins/lock/valent-lock-plugin.c
+++ b/src/plugins/lock/valent-lock-plugin.c
@@ -170,14 +170,14 @@ valent_lock_plugin_update_state (ValentDevicePlugin *plugin,
                                      G_CONNECT_SWAPPED);
         }
 
-      valent_device_plugin_toggle_actions (plugin, available);
+      valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
       valent_lock_plugin_update_actions (self);
       valent_lock_plugin_request_state (self);
     }
   else
     {
       g_clear_signal_handler (&self->session_changed_id, self->session);
-      valent_device_plugin_toggle_actions (plugin, available);
+      valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
     }
 }
 

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -460,7 +460,7 @@ mousepad_remote_action (GSimpleAction *action,
     {
       ValentDevice *device;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
       self->remote = g_object_new (VALENT_TYPE_MOUSEPAD_REMOTE,
                                    "device", device,
                                    NULL);

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -134,7 +134,7 @@ valent_mpris_plugin_send_album_art (ValentMprisPlugin *self,
   packet = valent_packet_end (&builder);
 
   /* Start the transfer */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   transfer = valent_device_transfer_new (device, packet, real_file);
 
   g_hash_table_insert (self->transfers,
@@ -690,7 +690,7 @@ valent_mpris_plugin_receive_album_art (ValentMprisPlugin *self,
       return;
     }
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   context = valent_device_get_context (device);
   filename = g_compute_checksum_for_string (G_CHECKSUM_MD5, url, -1);
   file = valent_context_get_cache_file (context, filename);
@@ -760,7 +760,7 @@ valent_mpris_plugin_handle_player_list (ValentMprisPlugin *self,
     }
 
   /* Add new players */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
 
   for (unsigned int i = 0; remote_names[i] != NULL; i++)
     {

--- a/src/plugins/notification/valent-notification-plugin.c
+++ b/src/plugins/notification/valent-notification-plugin.c
@@ -72,7 +72,7 @@ on_notification_added (ValentNotifications      *listener,
   g_assert (VALENT_IS_NOTIFICATION (notification));
   g_assert (VALENT_IS_NOTIFICATION_PLUGIN (self));
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   if (!g_settings_get_boolean (settings, "forward-notifications"))
     return;
@@ -173,7 +173,7 @@ valent_notification_plugin_get_icon_file (ValentNotificationPlugin *self,
     {
       ValentContext *context = NULL;
 
-      context = valent_device_plugin_get_context (VALENT_DEVICE_PLUGIN (self));
+      context = valent_extension_get_context (VALENT_EXTENSION (self));
       file = valent_context_get_cache_file (context, payload_hash);
     }
   else
@@ -307,7 +307,7 @@ valent_notification_plugin_download_icon (ValentNotificationPlugin *self,
                                           GAsyncReadyCallback       callback,
                                           gpointer                  user_data)
 {
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (self);
+  ValentExtension *extension = VALENT_EXTENSION (self);
   g_autoptr (GTask) task = NULL;
   IconTransferData *transfer = NULL;
 
@@ -318,7 +318,7 @@ valent_notification_plugin_download_icon (ValentNotificationPlugin *self,
   transfer = g_new0 (IconTransferData, 1);
   g_rec_mutex_init (&transfer->mutex);
   g_rec_mutex_lock (&transfer->mutex);
-  transfer->device = g_object_ref (valent_device_plugin_get_device (plugin));
+  transfer->device = g_object_ref (valent_extension_get_object (extension));
   transfer->packet = json_node_ref (packet);
   g_rec_mutex_unlock (&transfer->mutex);
 
@@ -397,7 +397,7 @@ valent_notification_plugin_show_notification (ValentNotificationPlugin *self,
       return;
     }
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
 
   /* Start building the GNotification */
   notification = g_notification_new (title);
@@ -681,7 +681,7 @@ valent_notification_plugin_send_notification_with_icon (ValentNotificationPlugin
       ValentDevice *device;
       g_autoptr (ValentTransfer) transfer = NULL;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
       transfer = valent_notification_upload_new (device, packet, icon);
       valent_transfer_execute (transfer,
                                NULL,
@@ -901,7 +901,7 @@ notification_reply_action (GSimpleAction *action,
                                g_object_ref (notification),
                                g_object_ref (dialog));
 
-          device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+          device = valent_extension_get_object (VALENT_EXTENSION (self));
           state = valent_device_get_state (device);
           available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
                       (state & VALENT_DEVICE_STATE_PAIRED) != 0;
@@ -988,7 +988,7 @@ valent_notification_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
   valent_notification_plugin_watch_notifications (self, available);
 
   /* Request Notifications */

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -48,7 +48,7 @@ valent_transfer_execute_cb (ValentTransfer     *transfer,
       g_autofree char *filename = NULL;
       ValentDevice *device;
 
-      device = valent_device_plugin_get_device (plugin);
+      device = valent_extension_get_object (VALENT_EXTENSION (plugin));
       filename = g_file_get_basename (file);
       icon = g_themed_icon_new ("dialog-error-symbolic");
       body = g_strdup_printf (_("Failed to receive “%s” from %s"),
@@ -89,7 +89,7 @@ valent_photo_plugin_handle_photo (ValentPhotoPlugin *self,
       return;
     }
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   cancellable = valent_object_ref_cancellable (VALENT_OBJECT (self));
   directory = valent_get_user_directory (G_USER_DIRECTORY_PICTURES);
   file = valent_get_user_file (directory, filename, TRUE);
@@ -147,7 +147,7 @@ valent_photo_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -37,7 +37,7 @@ valent_ping_plugin_handle_ping (ValentPingPlugin *self,
     message = _("Ping!");
 
   /* Show a notification */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   notification = g_notification_new (valent_device_get_name (device));
   g_notification_set_body (notification, message);
   valent_device_plugin_show_notification (VALENT_DEVICE_PLUGIN (self),
@@ -105,7 +105,7 @@ valent_ping_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/src/plugins/presenter/valent-presenter-plugin.c
+++ b/src/plugins/presenter/valent-presenter-plugin.c
@@ -123,7 +123,7 @@ presenter_remote_action (GSimpleAction *action,
     {
       ValentDevice *device;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
       self->remote = g_object_new (VALENT_TYPE_PRESENTER_REMOTE,
                                    "device", device,
                                    NULL);

--- a/src/plugins/pulseaudio/valent-pa-mixer.c
+++ b/src/plugins/pulseaudio/valent-pa-mixer.c
@@ -206,26 +206,40 @@ on_state_changed (GvcMixerControl      *control,
                   GvcMixerControlState  state,
                   ValentPaMixer        *self)
 {
+  g_autoptr (GError) error = NULL;
+
   g_assert (VALENT_IS_PA_MIXER (self));
 
   switch (state)
     {
     case GVC_STATE_CLOSED:
-      VALENT_NOTE ("%s: Closed", G_OBJECT_TYPE_NAME (self));
+      valent_extension_plugin_state_changed (VALENT_EXTENSION (self),
+                                             VALENT_PLUGIN_STATE_INACTIVE,
+                                             error);
       valent_pa_mixer_unload (self);
       break;
 
     case GVC_STATE_READY:
-      VALENT_NOTE ("%s: Ready", G_OBJECT_TYPE_NAME (self));
+      valent_extension_plugin_state_changed (VALENT_EXTENSION (self),
+                                             VALENT_PLUGIN_STATE_ACTIVE,
+                                             error);
       valent_pa_mixer_load (self);
       break;
 
     case GVC_STATE_CONNECTING:
-      VALENT_NOTE ("%s: Connecting", G_OBJECT_TYPE_NAME (self));
+      valent_extension_plugin_state_changed (VALENT_EXTENSION (self),
+                                             VALENT_PLUGIN_STATE_INACTIVE,
+                                             error);
       break;
 
     case GVC_STATE_FAILED:
-      g_warning ("%s: Failed", G_OBJECT_TYPE_NAME (self));
+      g_set_error_literal (&error,
+                           G_IO_ERROR,
+                           G_IO_ERROR_FAILED,
+                           "failed to connect to PulseAudio server");
+      valent_extension_plugin_state_changed (VALENT_EXTENSION (self),
+                                             VALENT_PLUGIN_STATE_ERROR,
+                                             error);
       valent_pa_mixer_unload (self);
       break;
     }

--- a/src/plugins/runcommand/valent-runcommand-plugin.c
+++ b/src/plugins/runcommand/valent-runcommand-plugin.c
@@ -60,7 +60,7 @@ launcher_init (ValentRuncommandPlugin *self)
 
   self->launcher = g_subprocess_launcher_new (flags);
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   g_subprocess_launcher_setenv (self->launcher,
                                 "VALENT_DEVICE_ID",
                                 valent_device_get_id (device),
@@ -164,7 +164,7 @@ on_commands_changed (GSettings              *settings,
   g_assert (key != NULL);
   g_assert (VALENT_IS_RUNCOMMAND_PLUGIN (self));
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   state = valent_device_get_state (device);
 
   if ((state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
@@ -185,7 +185,7 @@ valent_runcommand_plugin_execute_local_command (ValentRuncommandPlugin *self,
   g_return_if_fail (key != NULL);
 
   /* Lookup the command by UUID */
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
   commands = g_settings_get_value (settings, "commands");
 
   if (!g_variant_lookup (commands, key, "@a{sv}", &command))
@@ -222,7 +222,7 @@ valent_runcommand_plugin_send_command_list (ValentRuncommandPlugin *self)
 
   g_assert (VALENT_IS_RUNCOMMAND_PLUGIN (self));
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
   commands = g_settings_get_value (settings, "commands");
 
   /* The `commandList` dictionary is sent as a string of serialized JSON */
@@ -427,9 +427,9 @@ valent_runcommand_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 
-  settings = valent_device_plugin_get_settings (plugin);
+  settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
 
   if (available)
     {
@@ -501,7 +501,7 @@ valent_runcommand_plugin_dispose (GObject *object)
   GSettings *settings;
 
   /* Stop watching for command changes */
-  settings = valent_device_plugin_get_settings (plugin);
+  settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
   g_clear_signal_handler (&self->commands_changed_id, settings);
 
   G_OBJECT_CLASS (valent_runcommand_plugin_parent_class)->dispose (object);

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -36,7 +36,7 @@ get_device_host (ValentSftpPlugin *self)
 
   /* The plugin doesn't know ValentChannel derivations, so we have to check for
    * a "host" property to ensure it's IP-based */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   channel = valent_device_ref_channel (device);
 
   if G_LIKELY (channel != NULL)
@@ -442,7 +442,7 @@ handle_sftp_error (ValentSftpPlugin *self,
 
   body = valent_packet_get_body (packet);
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   device_name = valent_device_get_name (device);
 
   error_icon = g_themed_icon_new ("dialog-error-symbolic");
@@ -511,7 +511,7 @@ valent_sftp_plugin_handle_request (ValentSftpPlugin *self,
   if (!valent_packet_check_field (packet, "startBrowsing"))
     return;
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
   valent_packet_init (&builder, "kdeconnect.sftp");
 
   if (g_settings_get_boolean (settings, "local-allow"))
@@ -603,7 +603,7 @@ valent_sftp_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 
   /* GMounts */
   if (available)
@@ -612,7 +612,7 @@ valent_sftp_plugin_update_state (ValentDevicePlugin *plugin,
 
       sftp_session_find (self);
 
-      settings = valent_device_plugin_get_settings (plugin);
+      settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
 
       if (g_settings_get_boolean (settings, "auto-mount"))
         valent_sftp_plugin_sftp_request (self);

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -44,7 +44,7 @@ valent_share_plugin_create_download_file (ValentSharePlugin *self,
 
   /* Check for a configured download directory, returning a fallback if
    * necessary, but don't save the fallback as though it were configured. */
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
   download_folder = g_settings_get_string (settings, "download-folder");
 
   if (download_folder == NULL || *download_folder == '\0')
@@ -420,7 +420,7 @@ valent_share_plugin_open_file (ValentSharePlugin *self,
    * `numberOfFiles` field and consider a concurrent multi-file transfer as
    * incomplete.
    */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   transfer = valent_device_transfer_new (device, packet, file);
   g_hash_table_insert (self->transfers,
                        valent_transfer_dup_id (transfer),
@@ -575,7 +575,7 @@ valent_share_plugin_upload_file (ValentSharePlugin *self,
     {
       ValentDevice *device;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
 
       self->upload = valent_share_upload_new (device);
       g_hash_table_replace (self->transfers,
@@ -604,7 +604,7 @@ valent_share_plugin_upload_files (ValentSharePlugin *self,
     {
       ValentDevice *device;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
 
       self->upload = valent_share_upload_new (device);
       g_hash_table_replace (self->transfers,
@@ -953,7 +953,7 @@ valent_share_plugin_handle_file (ValentSharePlugin *self,
                                   valent_packet_get_payload_size (packet));
     }
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   file = valent_share_plugin_create_download_file (self, filename, TRUE);
 
   /* If the packet includes a request to open the file when the transfer
@@ -1068,14 +1068,14 @@ static void
 valent_share_plugin_handle_text (ValentSharePlugin *self,
                                  const char        *text)
 {
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (self);
+  ValentExtension *extension = VALENT_EXTENSION (self);
   const char *name = NULL;
   GtkWindow *window;
 
   g_assert (VALENT_IS_SHARE_PLUGIN (self));
   g_assert (text != NULL);
 
-  name = valent_device_get_name (valent_device_plugin_get_device (plugin));
+  name = valent_device_get_name (valent_extension_get_object (extension));
 
   if (!gtk_is_initialized ())
     {
@@ -1162,7 +1162,7 @@ valent_share_plugin_update_state (ValentDevicePlugin *plugin,
       g_clear_object (&self->upload);
     }
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -411,7 +411,7 @@ messaging_action (GSimpleAction *action,
     {
       ValentContactStore *store;
 
-      device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+      device = valent_extension_get_object (VALENT_EXTENSION (self));
       store = valent_contacts_ensure_store (valent_contacts_get_default (),
                                             valent_device_get_id (device),
                                             valent_device_get_name (device));
@@ -452,7 +452,7 @@ valent_sms_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 
   /* Request summary of messages */
   if (available)
@@ -488,7 +488,7 @@ valent_sms_plugin_constructed (GObject *object)
   ValentContext *context = NULL;
 
   /* Load SMS Store */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   context = valent_device_get_context (device);
   self->store = g_object_new (VALENT_TYPE_SMS_STORE,
                               "domain", "plugin",

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -153,7 +153,7 @@ valent_telephony_plugin_update_media_state (ValentTelephonyPlugin *self,
   g_assert (VALENT_IS_TELEPHONY_PLUGIN (self));
   g_assert (event != NULL && *event != '\0');
 
-  settings = valent_device_plugin_get_settings (VALENT_DEVICE_PLUGIN (self));
+  settings = valent_extension_get_settings (VALENT_EXTENSION (self));
 
   /* Retrieve the user preference for this event */
   if (g_str_equal (event, "ringing"))
@@ -284,7 +284,7 @@ valent_telephony_plugin_handle_telephony (ValentTelephonyPlugin *self,
    * events from the same sender supersede previous events, and replace the
    * older notifications.
    */
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
 
   /* This is a cancelled event */
   if (valent_packet_check_field (packet, "isCancel"))
@@ -377,7 +377,7 @@ valent_telephony_plugin_update_state (ValentDevicePlugin *plugin,
       g_clear_pointer (&self->prev_input, stream_state_free);
     }
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/tests/extra/tsan.supp
+++ b/tests/extra/tsan.supp
@@ -6,7 +6,8 @@
 #
 # The errors below are either known bugs being tracked or undiagnosed.
 #
-mutex:valent_device_get_type_once
+#mutex:valent_device_get_type_once
+mutex:valent_extension_get_type_once
 
 # src/plugins/sms/valent-sms-store.c
 race:valent_sms_store_thread

--- a/tests/fixtures/valent-mock-device-plugin.c
+++ b/tests/fixtures/valent-mock-device-plugin.c
@@ -85,7 +85,7 @@ valent_mock_device_plugin_handle_transfer (ValentMockDevicePlugin *self,
       return;
     }
 
-  device = valent_device_plugin_get_device (VALENT_DEVICE_PLUGIN (self));
+  device = valent_extension_get_object (VALENT_EXTENSION (self));
   cancellable = valent_object_ref_cancellable (VALENT_OBJECT (self));
   directory = valent_get_user_directory (G_USER_DIRECTORY_DOWNLOAD);
   file = valent_get_user_file (directory, filename, TRUE);
@@ -147,7 +147,7 @@ valent_mock_device_plugin_update_state (ValentDevicePlugin *plugin,
   available = (state & VALENT_DEVICE_STATE_CONNECTED) != 0 &&
               (state & VALENT_DEVICE_STATE_PAIRED) != 0;
 
-  valent_device_plugin_toggle_actions (plugin, available);
+  valent_extension_toggle_actions (VALENT_EXTENSION (plugin), available);
 }
 
 static void

--- a/tests/fixtures/valent-test-utils.c
+++ b/tests/fixtures/valent-test-utils.c
@@ -545,11 +545,12 @@ valent_type_ensure (void)
 {
   /* Core */
   g_type_ensure (VALENT_TYPE_APPLICATION);
+  g_type_ensure (VALENT_TYPE_APPLICATION_PLUGIN);
   g_type_ensure (VALENT_TYPE_CONTEXT);
+  g_type_ensure (VALENT_TYPE_EXTENSION);
   g_type_ensure (VALENT_TYPE_OBJECT);
   g_type_ensure (VALENT_TYPE_COMPONENT);
   g_type_ensure (VALENT_TYPE_TRANSFER);
-  g_type_ensure (VALENT_TYPE_APPLICATION_PLUGIN);
 
   /* Device */
   g_type_ensure (VALENT_TYPE_CHANNEL);

--- a/tests/libvalent/core/test-application-plugin.c
+++ b/tests/libvalent/core/test-application-plugin.c
@@ -28,7 +28,7 @@ application_fixture_set_up (ApplicationPluginFixture *fixture,
   fixture->extension = peas_engine_create_extension (engine,
                                                      plugin_info,
                                                      VALENT_TYPE_APPLICATION_PLUGIN,
-                                                     "application", fixture->application,
+                                                     "object", fixture->application,
                                                      NULL);
 }
 
@@ -50,15 +50,15 @@ test_application_plugin_basic (ApplicationPluginFixture *fixture,
 
   VALENT_TEST_CHECK ("GObject properties function correctly");
   g_object_get (fixture->extension,
-                "application",    &application,
-                "plugin-info",    &plugin_info,
+                "object",      &application,
+                "plugin-info", &plugin_info,
                 NULL);
 
   g_assert_true (G_IS_APPLICATION (application));
   g_assert_nonnull (plugin_info);
   g_boxed_free (PEAS_TYPE_PLUGIN_INFO, plugin_info);
 
-  application = valent_application_plugin_get_application (plugin);
+  application = valent_extension_get_object (VALENT_EXTENSION (plugin));
   g_assert_true (G_IS_APPLICATION (application));
 }
 

--- a/tests/libvalent/device/test-device-plugin.c
+++ b/tests/libvalent/device/test-device-plugin.c
@@ -28,7 +28,7 @@ device_fixture_set_up (DevicePluginFixture *fixture,
   fixture->extension = peas_engine_create_extension (engine,
                                                      plugin_info,
                                                      VALENT_TYPE_DEVICE_PLUGIN,
-                                                     "device", fixture->device,
+                                                     "object", fixture->device,
                                                      NULL);
 }
 
@@ -49,7 +49,7 @@ test_device_plugin_basic (DevicePluginFixture *fixture,
 
   /* Test properties */
   g_object_get (fixture->extension,
-                "device",      &device,
+                "object",      &device,
                 "plugin-info", &plugin_info,
                 NULL);
 

--- a/tests/plugins/share/test-share-target.c
+++ b/tests/plugins/share/test-share-target.c
@@ -29,7 +29,7 @@ application_fixture_set_up (ApplicationPluginFixture *fixture,
   fixture->extension = peas_engine_create_extension (engine,
                                                      plugin_info,
                                                      VALENT_TYPE_APPLICATION_PLUGIN,
-                                                     "application",    fixture->application,
+                                                     "object", fixture->application,
                                                      NULL);
 }
 
@@ -52,15 +52,15 @@ test_share_target (ApplicationPluginFixture *fixture,
 
   VALENT_TEST_CHECK ("GObject properties function correctly");
   g_object_get (fixture->extension,
-                "application",    &application,
-                "plugin-info",    &plugin_info,
+                "object",      &application,
+                "plugin-info", &plugin_info,
                 NULL);
 
   g_assert_true (G_IS_APPLICATION (application));
   g_assert_nonnull (plugin_info);
   g_boxed_free (PEAS_TYPE_PLUGIN_INFO, plugin_info);
 
-  application = valent_application_plugin_get_application (plugin);
+  application = valent_extension_get_object (VALENT_EXTENSION (plugin));
   g_assert_true (G_IS_APPLICATION (application));
 }
 


### PR DESCRIPTION
Add a base class for extension types, which includes most of the features found in `Valent.DevicePlugin`.

This also includes the `ValentPluginState` enumeration and adds the `Valent.Extension:plugin-state` property, to allow extensions to propagate errors and other state.