### PR TITLE
refactor(core): disable Python plugins by default

### DIFF
--- a/tests/plugins/gnome/mock_gnome_clipboard.py
+++ b/tests/plugins/gnome/mock_gnome_clipboard.py
@@ -26,14 +26,14 @@ class ClipboardTestFixture(dbusmock.DBusTestCase):
         cls.dbus_con = cls.get_dbus(system_bus=False)
 
     def setUp(self) -> None:
-        self.p_mock = self.spawn_server('org.gnome.Shell.Extensions.Valent.Clipboard',
+        self.p_mock = self.spawn_server('org.gnome.Shell',
                                         '/org/gnome/Shell/Extensions/Valent/Clipboard',
                                         'org.gnome.Shell.Extensions.Valent.Clipboard',
                                         system_bus=False,
                                         stdout=subprocess.PIPE)
 
         # Get a proxy for the notification object's Mock interface
-        mock = dbus.Interface(self.dbus_con.get_object('org.gnome.Shell.Extensions.Valent.Clipboard',
+        mock = dbus.Interface(self.dbus_con.get_object('org.gnome.Shell',
                                                        '/org/gnome/Shell/Extensions/Valent/Clipboard'),
                               dbusmock.MOCK_IFACE)
 

--- a/tests/plugins/gnome/test-gnome-clipboard.c
+++ b/tests/plugins/gnome/test-gnome-clipboard.c
@@ -8,6 +8,10 @@
 #include <valent.h>
 #include <libvalent-test.h>
 
+#define CLIPBOARD_NAME "org.gnome.Shell"
+#define CLIPBOARD_PATH "/org/gnome/Shell/Extensions/Valent/Clipboard"
+#define CLIPBOARD_IFACE "org.gnome.Shell.Extensions.Valent.Clipboard"
+
 
 typedef struct
 {
@@ -116,9 +120,9 @@ get_bytes (GnomeClipboardFixture  *fixture,
            char                  **text)
 {
   g_dbus_connection_call (fixture->connection,
-                          "org.gnome.Shell.Extensions.Valent.Clipboard",
-                          "/org/gnome/Shell/Extensions/Valent/Clipboard",
-                          "org.gnome.Shell.Extensions.Valent.Clipboard",
+                          CLIPBOARD_NAME,
+                          CLIPBOARD_PATH,
+                          CLIPBOARD_IFACE,
                           "GetBytes",
                           g_variant_new ("(s)", "text/plain;charset=utf-8"),
                           NULL,
@@ -152,9 +156,9 @@ set_bytes (GnomeClipboardFixture *fixture,
                                        strlen (text),
                                        sizeof (char));
   g_dbus_connection_call (fixture->connection,
-                          "org.gnome.Shell.Extensions.Valent.Clipboard",
-                          "/org/gnome/Shell/Extensions/Valent/Clipboard",
-                          "org.gnome.Shell.Extensions.Valent.Clipboard",
+                          CLIPBOARD_NAME,
+                          CLIPBOARD_PATH,
+                          CLIPBOARD_IFACE,
                           "SetBytes",
                           g_variant_new ("(s@ay)", "text/plain;charset=utf-8",
                                          content),


### PR DESCRIPTION
Add another hidden environment variable, `VALENT_PLUGIN_LOADERS`, to control whether Python3 plugins can be loaded.