### PR TITLE
docs: add missing album art fields to protocol reference

### DIFF
--- a/doc/schemas/kdeconnect.mpris.json
+++ b/doc/schemas/kdeconnect.mpris.json
@@ -1,8 +1,18 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "title": "kdeconnect.mpris",
-    "description": "This packet is an MPRIS player update.",
+    "description": "This packet is used to expose media players to a remote device and transfer album art.",
     "examples": [
+        {
+            "id": 0,
+            "type": "kdeconnect.mpris",
+            "body": {
+                "playerList": [
+                    "Test Player"
+                ],
+                "supportAlbumArtPayload": true
+            }
+        },
         {
             "id": 0,
             "type": "kdeconnect.mpris",
@@ -28,18 +38,13 @@
             "id": 0,
             "type": "kdeconnect.mpris",
             "body": {
-                "playerList": [
-                    "Test Player"
-                ]
-            }
-        },
-        {
-            "id": 0,
-            "type": "kdeconnect.mpris",
-            "body": {
                 "player": "Test Player",
                 "albumArtUrl": "file:///path/to/image.png",
                 "transferringAlbumArt": true
+            },
+            "payloadSize": 882,
+            "payloadTransferInfo": {
+                "port": 1739
             }
         }
     ],
@@ -142,6 +147,10 @@
                     "minimum": 0,
                     "maximum": 100,
                     "description": "Current player volume (%)."
+                },
+                "supportAlbumArtPayload": {
+                    "type": "boolean",
+                    "description": "Indicates this device supports receiving album art payloads. This field should be set when responding with a list of players."
                 },
                 "transferringAlbumArt": {
                     "type": "boolean",

--- a/doc/schemas/kdeconnect.mpris.request.json
+++ b/doc/schemas/kdeconnect.mpris.request.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "title": "kdeconnect.mpris.request",
-    "description": "This packet is a request for player information or control.",
+    "description": "This packet is used to request the status of remote media players, issue commands, and request the transfer of album art payloads.",
     "examples": [
         {
             "id": 0,
@@ -25,6 +25,14 @@
             "body": {
                 "player": "Test Player",
                 "action": "Play"
+            }
+        },
+        {
+            "id": 0,
+            "type": "kdeconnect.mpris.request",
+            "body": {
+                "player": "Test Player",
+                "albumArtUrl": "file:///path/to/image.png"
             }
         }
     ],

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -537,7 +537,7 @@ valent_mpris_plugin_send_player_list (ValentMprisPlugin *self)
 
   json_builder_end_array (builder);
 
-  /* Album Art */
+  /* Indicate that the remote device may send us album art payloads */
   json_builder_set_member_name (builder, "supportAlbumArtPayload");
   json_builder_add_boolean_value (builder, TRUE);
 


### PR DESCRIPTION
There were a few undocumented field for the `mpris` plugin, which were also therefore not being fuzzed in tests.