### PR TITLE
fix(lan): support multiple adaptive listening port

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -214,9 +214,8 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/andyholmes/valent.git",
-                    "branch" : "main"
+                    "type" : "dir",
+                    "path" : "../../"
                 }
             ]
         }

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -133,8 +133,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/evolution-data-server.git",
-                    "commit" : "fc0a280168a5ec8aaeae7f9e34c46f10914c7c84",
-                    "tag" : "3.48.1",
+                    "commit" : "3ce4f881f61954c6201dcad634d189afb52bc4a2",
+                    "tag" : "3.48.2",
                     "x-checker-data" : {
                         "type" : "anitya",
                         "project-id" : 10935,

--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -43,5 +43,5 @@ leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:117
 leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:119
 
 # tests/plugins/lan/
-memleak:src/plugins/lan/valent-lan-channel-service.c:516
+memleak:src/plugins/lan/valent-lan-channel-service.c:528
 


### PR DESCRIPTION
Allow the LAN channel service to listen on any TCP port within the protocol range for incoming connections, and ensure the identity packet contains the correct `tcpPort` value.

Flatpak maintenance.

closes #493