### PR TITLE
refactor(core): remove a cast-macro and other minor cleanups

### DIFF
--- a/src/libvalent/core/valent-extension.c
+++ b/src/libvalent/core/valent-extension.c
@@ -557,8 +557,8 @@ valent_extension_get_context (ValentExtension *extension)
  *
  * Since: 1.0
  */
-GObject *
-(valent_extension_get_object) (ValentExtension *extension)
+gpointer
+valent_extension_get_object (ValentExtension *extension)
 {
   ValentExtensionPrivate *priv = valent_extension_get_instance_private (extension);
 
@@ -658,7 +658,7 @@ valent_extension_plugin_state_changed (ValentExtension   *extension,
   if (state == VALENT_PLUGIN_STATE_ERROR && error != NULL)
     priv->plugin_error = g_error_copy (error);
 
-  if (priv->plugin_state != state || error != NULL)
+  if (priv->plugin_state != state || priv->plugin_error != NULL)
     {
       priv->plugin_state = state;
       valent_object_notify_by_pspec (VALENT_OBJECT (extension),

--- a/src/libvalent/core/valent-extension.h
+++ b/src/libvalent/core/valent-extension.h
@@ -44,7 +44,7 @@ struct _ValentExtensionClass
 VALENT_AVAILABLE_IN_1_0
 ValentContext     * valent_extension_get_context          (ValentExtension    *extension);
 VALENT_AVAILABLE_IN_1_0
-GObject           * valent_extension_get_object           (ValentExtension    *extension);
+gpointer            valent_extension_get_object           (ValentExtension    *extension);
 VALENT_AVAILABLE_IN_1_0
 GSettings         * valent_extension_get_settings         (ValentExtension    *extension);
 VALENT_AVAILABLE_IN_1_0
@@ -57,9 +57,6 @@ void                valent_extension_plugin_state_changed (ValentExtension    *e
 VALENT_AVAILABLE_IN_1_0
 void                valent_extension_toggle_actions       (ValentExtension    *extension,
                                                            gboolean            enabled);
-
-/* Convenience Macros */
-#define valent_extension_get_object(e) ((void *)valent_extension_get_object (e))
 
 G_END_DECLS
 


### PR DESCRIPTION
Remove a casting macro for `valent_extension_get_object()` and just use `gpointer` with the `(type GObject.Object)` annotation.

Always check the extension's error pointer, instead of the incoming argument.