### PR TITLE
refactor(plugins): remove deprecated packets

### DIFF
--- a/doc/schemas/kdeconnect.battery.request.json
+++ b/doc/schemas/kdeconnect.battery.request.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "title": "kdeconnect.battery.request",
-    "description": "This packet is sent to request a battery status update.",
+    "description": "⚠️ Deprecated: This packet is sent to request a battery status update.",
     "examples": [
         {
             "id": 0,
@@ -33,7 +33,7 @@
             "properties": {
                 "request": {
                     "type": "boolean",
-                    "description": "Whether to request a status update. It only makes sense for this to be `true`."
+                    "description": "⚠️ Deprecated: Whether to request a status update. It only makes sense for this to be `true`."
                 }
             }
         }

--- a/doc/schemas/kdeconnect.connectivity_report.request.json
+++ b/doc/schemas/kdeconnect.connectivity_report.request.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "title": "kdeconnect.connectivity_report.request",
-    "description": "This packet is sent to request a connectivity report.",
+    "description": "⚠️ Deprecated: This packet is sent to request a connectivity report.",
     "examples": [
         {
             "id": 0,

--- a/doc/sdk/protocol.py
+++ b/doc/sdk/protocol.py
@@ -64,8 +64,8 @@ A mapping collection of string keys to values.
 
 * ⚠️ **Deprecated**
 
-    Packets missing these fields may be ignored or result in undefined
-    behaviour.
+    Clients are free to ignore these packets and fields, and encouraged to stop
+    using them when possible.
 
 * 🔒 **Required**
 

--- a/src/plugins/battery/battery.plugin.desktop.in
+++ b/src/plugins/battery/battery.plugin.desktop.in
@@ -12,7 +12,7 @@ Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
 X-DevicePluginCategory=System;Monitor;
-X-DevicePluginIncoming=kdeconnect.battery;kdeconnect.battery.request
-X-DevicePluginOutgoing=kdeconnect.battery;kdeconnect.battery.request
+X-DevicePluginIncoming=kdeconnect.battery
+X-DevicePluginOutgoing=kdeconnect.battery
 X-DevicePluginSettings=ca.andyholmes.Valent.Plugin.battery
 

--- a/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
+++ b/src/plugins/connectivity_report/connectivity_report.plugin.desktop.in
@@ -12,7 +12,7 @@ Website=https://github.com/andyholmes/valent
 Help=https://github.com/andyholmes/valent
 Hidden=false
 X-DevicePluginCategory=System;Monitor;
-X-DevicePluginIncoming=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
-X-DevicePluginOutgoing=kdeconnect.connectivity_report;kdeconnect.connectivity_report.request
+X-DevicePluginIncoming=kdeconnect.connectivity_report
+X-DevicePluginOutgoing=kdeconnect.connectivity_report
 X-DevicePluginSettings=ca.andyholmes.Valent.Plugin.connectivity_report
 

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -25,7 +25,6 @@ struct _ValentConnectivityReportPlugin
   unsigned int        telephony_watch : 1;
 };
 
-static void   valent_connectivity_report_plugin_request_state (ValentConnectivityReportPlugin *self);
 static void   valent_connectivity_report_plugin_send_state    (ValentConnectivityReportPlugin *self);
 
 G_DEFINE_FINAL_TYPE (ValentConnectivityReportPlugin, valent_connectivity_report_plugin, VALENT_TYPE_DEVICE_PLUGIN)
@@ -70,16 +69,6 @@ valent_connectivity_report_plugin_watch_telephony (ValentConnectivityReportPlugi
       g_signal_handlers_disconnect_by_data (self->telephony, self);
       self->telephony_watch = FALSE;
     }
-}
-
-static void
-valent_connectivity_report_plugin_handle_connectivity_report_request (ValentConnectivityReportPlugin *self,
-                                                                      JsonNode                       *packet)
-{
-  g_assert (VALENT_IS_CONNECTIVITY_REPORT_PLUGIN (self));
-  g_assert (VALENT_IS_PACKET (packet));
-
-  valent_connectivity_report_plugin_send_state (self);
 }
 
 static void
@@ -332,17 +321,6 @@ valent_connectivity_report_plugin_handle_connectivity_report (ValentConnectivity
     }
 }
 
-static void
-valent_connectivity_report_plugin_request_state (ValentConnectivityReportPlugin *self)
-{
-  g_autoptr (JsonNode) packet = NULL;
-
-  g_assert (VALENT_IS_CONNECTIVITY_REPORT_PLUGIN (self));
-
-  packet = valent_packet_new ("kdeconnect.connectivity_report.request");
-  valent_device_plugin_queue_packet (VALENT_DEVICE_PLUGIN (self), packet);
-}
-
 /*
  * GActions
  */
@@ -376,7 +354,6 @@ valent_connectivity_report_plugin_update_state (ValentDevicePlugin *plugin,
   if (available)
     {
       valent_connectivity_report_plugin_watch_telephony (self, TRUE);
-      valent_connectivity_report_plugin_request_state (self);
     }
   else
     {
@@ -399,11 +376,6 @@ valent_connectivity_report_plugin_handle_packet (ValentDevicePlugin *plugin,
   /* A remote connectivity report */
   if (g_str_equal (type, "kdeconnect.connectivity_report"))
     valent_connectivity_report_plugin_handle_connectivity_report (self, packet);
-
-  /* A request for a local connectivity report */
-  else if (g_str_equal (type, "kdeconnect.connectivity_report.request"))
-    valent_connectivity_report_plugin_handle_connectivity_report_request (self, packet);
-
   else
     g_assert_not_reached ();
 }

--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -43,5 +43,5 @@ leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:117
 leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:119
 
 # tests/plugins/lan/
-memleak:src/plugins/lan/valent-lan-channel-service.c:537
+memleak:src/plugins/lan/valent-lan-channel-service.c:546
 

--- a/tests/fixtures/data/plugin-battery.json
+++ b/tests/fixtures/data/plugin-battery.json
@@ -8,7 +8,6 @@
       "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
-        "kdeconnect.battery.request"
       ],
       "outgoingCapabilities": [
         "kdeconnect.battery"
@@ -76,13 +75,6 @@
       "currentCharge": 100,
       "isCharging": false,
       "thresholdEvent": 0
-    }
-  },
-  "request-state": {
-    "id": 0,
-    "type": "kdeconnect.battery.request",
-    "body": {
-        "request": true
     }
   }
 }

--- a/tests/fixtures/data/plugin-connectivity_report.json
+++ b/tests/fixtures/data/plugin-connectivity_report.json
@@ -8,12 +8,10 @@
       "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
-        "kdeconnect.connectivity_report",
-        "kdeconnect.connectivity_report.request"
+        "kdeconnect.connectivity_report"
       ],
       "outgoingCapabilities": [
-        "kdeconnect.connectivity_report",
-        "kdeconnect.connectivity_report.request"
+        "kdeconnect.connectivity_report"
       ]
     }
   },
@@ -120,10 +118,5 @@
         }
       }
     }
-  },
-  "request-state": {
-    "id": 0,
-    "type": "kdeconnect.connectivity_report.request",
-    "body": {}
   }
 }

--- a/tests/plugins/battery/test-battery-gadget.c
+++ b/tests/plugins/battery/test-battery-gadget.c
@@ -33,13 +33,7 @@ test_battery_plugin_gadget (ValentTestFixture *fixture,
   g_assert_true (fixture->device == device);
   g_object_unref (device);
 
-  VALENT_TEST_CHECK ("Plugin requests the battery state on connect");
   valent_test_fixture_connect (fixture, TRUE);
-
-  packet = valent_test_fixture_expect_packet (fixture);
-  v_assert_packet_type (packet, "kdeconnect.battery.request");
-  v_assert_packet_true (packet, "request");
-  json_node_unref (packet);
 
   VALENT_TEST_CHECK ("Gadget handles various battery states");
   packet = valent_test_fixture_lookup_packet (fixture, "missing-battery");

--- a/tests/plugins/connectivity_report/test-connectivity_report-gadget.c
+++ b/tests/plugins/connectivity_report/test-connectivity_report-gadget.c
@@ -33,12 +33,7 @@ test_connectivity_report_plugin_gadget (ValentTestFixture *fixture,
   g_assert_true (fixture->device == device);
   g_object_unref (device);
 
-  VALENT_TEST_CHECK ("Plugin requests the connectivity status on connect");
   valent_test_fixture_connect (fixture, TRUE);
-
-  packet = valent_test_fixture_expect_packet (fixture);
-  v_assert_packet_type (packet, "kdeconnect.connectivity_report.request");
-  json_node_unref (packet);
 
   VALENT_TEST_CHECK ("Plugin handles the \"modemless\" state");
   packet = valent_test_fixture_lookup_packet (fixture, "modemless-report");


### PR DESCRIPTION
Remove support for `kdeconnect.battery.request` and `kdeconnect.connectivity_report.request`.