### PR TITLE
fix(translations): fix various translation quirks

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -11,6 +11,8 @@ src/libvalent/ui/valent-device-page.c
 src/libvalent/ui/valent-device-page.ui
 src/libvalent/ui/valent-device-preferences-window.c
 src/libvalent/ui/valent-device-preferences-window.ui
+src/libvalent/ui/valent-input-remote.c
+src/libvalent/ui/valent-input-remote.ui
 src/libvalent/ui/valent-media-remote.c
 src/libvalent/ui/valent-media-remote.ui
 src/libvalent/ui/valent-menu-list.c
@@ -49,8 +51,6 @@ src/plugins/lock/lock.plugin.desktop.in
 src/plugins/lock/valent-lock-gadget.c
 src/plugins/mousepad/mousepad.plugin.desktop.in
 src/plugins/mousepad/valent-mousepad-plugin.c
-src/plugins/mousepad/valent-mousepad-remote.c
-src/plugins/mousepad/valent-mousepad-remote.ui
 src/plugins/mpris/mpris.plugin.desktop.in
 src/plugins/mpris/valent-mpris-plugin.c
 src/plugins/notification/notification.plugin.desktop.in

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-06-03 12:35-0700\n"
+"POT-Creation-Date: 2023-07-04 17:27-0700\n"
 "PO-Revision-Date: 2022-03-28 11:21-0700\n"
 "Last-Translator: Andy Holmes <andrew.g.r.holmes@gmail.com>\n"
 "Language-Team: English <andrew.g.r.holmes@gmail.com>\n"
@@ -46,7 +46,7 @@ msgstr ""
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:51
 msgid "Valent"
 msgstr ""
 
@@ -113,54 +113,55 @@ msgid "Pairing request from %s"
 msgstr ""
 
 #: src/libvalent/device/valent-device.c:523
-#: src/libvalent/ui/valent-device-page.ui:143
+#: src/libvalent/ui/valent-device-page.ui:161
 msgid "Reject"
 msgstr ""
 
 #: src/libvalent/device/valent-device.c:529
-#: src/libvalent/ui/valent-device-page.ui:156
+#: src/libvalent/ui/valent-device-page.ui:174
 msgid "Accept"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-page.c:175
-#: src/libvalent/ui/valent-device-page.ui:113
+#: src/libvalent/ui/valent-device-page.ui:131
 msgid "Unavailable"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:21
+#: src/libvalent/ui/valent-device-page.ui:38
 #: src/libvalent/ui/valent-media-remote.ui:239
 #: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:31
+#: src/libvalent/ui/valent-device-page.ui:49
 msgid "Device Menu"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:105
+#: src/libvalent/ui/valent-device-page.ui:123
 msgid "Verification Key"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:134
+#: src/libvalent/ui/valent-device-page.ui:152
 msgid "Request Pairing"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:229
+#: src/libvalent/ui/valent-device-page.ui:247
 #: src/libvalent/ui/valent-window.c:191
 msgid "Disconnected"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:259
-msgid "_Preferences"
+#: src/libvalent/ui/valent-device-page.ui:277
+#: src/libvalent/ui/valent-window.ui:135
+msgid "Preferences"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:265
-msgid "P_air"
+#: src/libvalent/ui/valent-device-page.ui:283
+msgid "Pair"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:270
-msgid "_Unpair"
+#: src/libvalent/ui/valent-device-page.ui:288
+msgid "Unpair"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:15
@@ -186,6 +187,39 @@ msgstr ""
 #: src/libvalent/ui/valent-device-preferences-window.ui:58
 #: src/libvalent/ui/valent-preferences-window.ui:39
 msgid "No Plugins"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:8
+#: src/libvalent/ui/valent-window.ui:125
+msgid "Input Remote"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:153
+msgid "Drag one finger to move"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:162
+msgid "Drag two fingers to scroll"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:171
+msgid "Tap one finger to click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:181
+msgid "Tap two fingers to right click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:190
+msgid "Tap three fingers to middle click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:199
+msgid "Hold one finger to grab"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:209
+msgid "Tap one finger to ungrab"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:250
@@ -218,13 +252,13 @@ msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:113
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Media Remote"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:219
-#: src/plugins/telephony/valent-telephony-preferences.ui:15
-#: src/plugins/telephony/valent-telephony-preferences.ui:43
+#: src/plugins/telephony/valent-telephony-preferences.ui:16
+#: src/plugins/telephony/valent-telephony-preferences.ui:47
 msgid "Volume"
 msgstr ""
 
@@ -258,44 +292,44 @@ msgstr ""
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:375
+#: src/libvalent/ui/valent-preferences-window.c:377
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:382
+#: src/libvalent/ui/valent-preferences-window.c:384
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:389
+#: src/libvalent/ui/valent-preferences-window.c:391
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:396
+#: src/libvalent/ui/valent-preferences-window.c:398
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:403
+#: src/libvalent/ui/valent-preferences-window.c:405
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:410
+#: src/libvalent/ui/valent-preferences-window.c:412
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:417
+#: src/libvalent/ui/valent-preferences-window.c:419
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:424
+#: src/libvalent/ui/valent-preferences-window.c:426
 #: src/plugins/notification/notification.plugin.desktop.in:7
-#: src/plugins/notification/valent-notification-preferences.ui:63
+#: src/plugins/notification/valent-notification-preferences.ui:66
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:431
+#: src/libvalent/ui/valent-preferences-window.c:433
 msgid "Session Manager"
 msgstr ""
 
@@ -424,33 +458,28 @@ msgstr ""
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
 msgid "Refresh"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#: src/libvalent/ui/valent-window.ui:70 src/libvalent/ui/valent-window.ui:73
 msgid "Main Menu"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:91
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:87
+#: src/libvalent/ui/valent-window.ui:99
 msgid "Searching for devices…"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:119
-msgid "Preferences"
-msgstr ""
-
-#: src/libvalent/ui/valent-window.ui:123
-#: src/plugins/sms/valent-sms-window.ui:350
+#: src/libvalent/ui/valent-window.ui:139
 msgid "About Valent"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:129
+#: src/libvalent/ui/valent-window.ui:145
 msgid "Quit"
 msgstr ""
 
@@ -481,24 +510,24 @@ msgstr ""
 
 #. TRANSLATORS: This is <percentage> (<hours>:<minutes> Remaining)
 #: src/plugins/battery/valent-battery-gadget.c:99
-#: src/plugins/battery/valent-battery-plugin.c:307
+#: src/plugins/battery/valent-battery-plugin.c:295
 #, c-format
 msgid "%g%% (%d∶%02d Remaining)"
 msgstr ""
 
 #. TRANSLATORS: This is <device name>: Fully Charged
-#: src/plugins/battery/valent-battery-plugin.c:276
+#: src/plugins/battery/valent-battery-plugin.c:264
 #, c-format
 msgid "%s: Fully Charged"
 msgstr ""
 
 #. TRANSLATORS: When the battery level is at maximum
-#: src/plugins/battery/valent-battery-plugin.c:278
+#: src/plugins/battery/valent-battery-plugin.c:266
 msgid "Battery Fully Charged"
 msgstr ""
 
 #. TRANSLATORS: This is <device name>: Battery Low
-#: src/plugins/battery/valent-battery-plugin.c:305
+#: src/plugins/battery/valent-battery-plugin.c:293
 #, c-format
 msgid "%s: Battery Low"
 msgstr ""
@@ -511,16 +540,16 @@ msgstr ""
 msgid "Notify when the remote battery is full"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:15
-#: src/plugins/battery/valent-battery-preferences.ui:39
+#: src/plugins/battery/valent-battery-preferences.ui:16
+#: src/plugins/battery/valent-battery-preferences.ui:42
 msgid "Level Threshold"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:34
+#: src/plugins/battery/valent-battery-preferences.ui:36
 msgid "Low Battery Notification"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:35
+#: src/plugins/battery/valent-battery-preferences.ui:37
 msgid "Notify when the remote battery is low"
 msgstr ""
 
@@ -536,11 +565,11 @@ msgstr ""
 msgid "Copy changes to the local clipboard"
 msgstr ""
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:22
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
 msgid "Local Clipboard"
 msgstr ""
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:24
 msgid "Report changes to the remote device"
 msgstr ""
 
@@ -553,34 +582,34 @@ msgid "Monitor mobile connectivity status"
 msgstr ""
 
 #. TRANSLATORS: When the mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:173
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:162
 msgid "Mobile Network"
 msgstr ""
 
 #. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:175
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:164
 #, c-format
 msgid "Signal Strength %f%%"
 msgstr ""
 
 #. TRANSLATORS: When no mobile service is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:181
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:188
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:170
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:177
 msgid "No Service"
 msgstr ""
 
 #. TRANSLATORS: When no mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:183
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
 msgid "No mobile network service"
 msgstr ""
 
 #. TRANSLATORS: When the device is missing a SIM card
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:190
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:179
 msgid "No SIM"
 msgstr ""
 
 #. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:321
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:310
 #, c-format
 msgid "%s: %s"
 msgstr ""
@@ -589,15 +618,15 @@ msgstr ""
 msgid "Local Connectivity"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:11
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12
 msgid "Send updates to the remote device"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:22
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
 msgid "Remote Connectivity"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:24
 msgid "Notify if the remote device loses connectivity"
 msgstr ""
 
@@ -613,11 +642,11 @@ msgstr ""
 msgid "Import contacts from the remote device"
 msgstr ""
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:22
+#: src/plugins/contacts/valent-contacts-preferences.ui:23
 msgid "Local Contacts"
 msgstr ""
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:23
+#: src/plugins/contacts/valent-contacts-preferences.ui:24
 msgid "Share contacts with the remote device"
 msgstr ""
 
@@ -686,52 +715,12 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:579
-msgid "Remote Input"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:8
-msgid "Input Remote"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:142
-msgid "Drag one finger to move"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:151
-msgid "Drag two fingers to scroll"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:160
-msgid "Tap one finger to click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:170
-msgid "Tap two fingers to right click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:179
-msgid "Tap three fingers to middle click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:188
-msgid "Hold one finger to grab"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:198
-msgid "Tap one finger to ungrab"
-msgstr ""
-
 #: src/plugins/mpris/mpris.plugin.desktop.in:7
 msgid "MPRIS"
 msgstr ""
 
 #: src/plugins/mpris/mpris.plugin.desktop.in:8
 msgid "Share control of MPRISv2 players"
-msgstr ""
-
-#: src/plugins/mpris/valent-mpris-plugin.c:484
-msgid "Unknown"
 msgstr ""
 
 #: src/plugins/notification/notification.plugin.desktop.in:8
@@ -754,6 +743,7 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:150
 #: src/plugins/share/valent-share-text-dialog.ui:53
+#: src/plugins/sms/valent-sms-window.ui:352
 msgid "Close"
 msgstr ""
 
@@ -769,27 +759,27 @@ msgstr ""
 msgid "Forward notifications to the remote device"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:15
+#: src/plugins/notification/valent-notification-preferences.ui:16
 msgid "Intelligent Sync"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:16
+#: src/plugins/notification/valent-notification-preferences.ui:17
 msgid "Notifications follow the active device"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:28
+#: src/plugins/notification/valent-notification-preferences.ui:30
 msgid "Filter by Application"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:64
+#: src/plugins/notification/valent-notification-preferences.ui:67
 msgid "Applications"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:85
+#: src/plugins/notification/valent-notification-preferences.ui:88
 msgid "Search"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:132
+#: src/plugins/notification/valent-notification-preferences.ui:135
 msgid "No Applications"
 msgstr ""
 
@@ -891,7 +881,7 @@ msgid "Execute commands remotely"
 msgstr ""
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#: src/plugins/runcommand/valent-runcommand-preferences.c:85
 msgid "Edit Command"
 msgstr ""
 
@@ -956,15 +946,15 @@ msgstr ""
 msgid "Mount shared folders when the device connects"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:22
+#: src/plugins/sftp/valent-sftp-preferences.ui:23
 msgid "Local Files"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:23
+#: src/plugins/sftp/valent-sftp-preferences.ui:24
 msgid "Share local files and directories"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:27
+#: src/plugins/sftp/valent-sftp-preferences.ui:29
 msgid "Port"
 msgstr ""
 
@@ -1091,7 +1081,7 @@ msgstr ""
 msgid "Searching…"
 msgstr ""
 
-#: src/plugins/share/valent-share-target-chooser.ui:127
+#: src/plugins/share/valent-share-target-chooser.ui:128
 msgid "Always use this device"
 msgstr ""
 
@@ -1265,7 +1255,7 @@ msgid "Incoming call"
 msgstr ""
 
 #: src/plugins/telephony/valent-telephony-plugin.c:311
-#: src/plugins/telephony/valent-telephony-preferences.ui:79
+#: src/plugins/telephony/valent-telephony-preferences.ui:86
 msgid "Mute"
 msgstr ""
 
@@ -1281,28 +1271,28 @@ msgstr ""
 msgid "What to do when the phone rings"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:24
-#: src/plugins/telephony/valent-telephony-preferences.ui:63
+#: src/plugins/telephony/valent-telephony-preferences.ui:26
+#: src/plugins/telephony/valent-telephony-preferences.ui:69
 msgid "Pause Media"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:39
+#: src/plugins/telephony/valent-telephony-preferences.ui:42
 msgid "Ongoing Calls"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:40
+#: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "What to do when the phone is answered"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:52
+#: src/plugins/telephony/valent-telephony-preferences.ui:57
 msgid "Mute Microphone"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:77
+#: src/plugins/telephony/valent-telephony-preferences.ui:84
 msgid "Nothing"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:78
+#: src/plugins/telephony/valent-telephony-preferences.ui:85
 msgid "Lower"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-06-03 12:35-0700\n"
+"POT-Creation-Date: 2023-07-04 17:27-0700\n"
 "PO-Revision-Date: 2023-03-04 17:28+0100\n"
 "Last-Translator: Valérie Roux <vxlerieuwu@unixgirl.xyz>\n"
 "Language-Team: French <vxlerieuwu@unixgirl.xyz>\n"
@@ -48,7 +48,7 @@ msgstr "Si l'extension est activée ou non"
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:51
 msgid "Valent"
 msgstr "Valent"
 
@@ -121,57 +121,58 @@ msgid "Pairing request from %s"
 msgstr "Demande de liaison de %s"
 
 #: src/libvalent/device/valent-device.c:523
-#: src/libvalent/ui/valent-device-page.ui:143
+#: src/libvalent/ui/valent-device-page.ui:161
 msgid "Reject"
 msgstr "Refuser"
 
 #: src/libvalent/device/valent-device.c:529
-#: src/libvalent/ui/valent-device-page.ui:156
+#: src/libvalent/ui/valent-device-page.ui:174
 msgid "Accept"
 msgstr "Accepter"
 
 #: src/libvalent/ui/valent-device-page.c:175
-#: src/libvalent/ui/valent-device-page.ui:113
+#: src/libvalent/ui/valent-device-page.ui:131
 msgid "Unavailable"
 msgstr "Indisponible"
 
-#: src/libvalent/ui/valent-device-page.ui:21
+#: src/libvalent/ui/valent-device-page.ui:38
 #: src/libvalent/ui/valent-media-remote.ui:239
 #: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr "Précédent"
 
-#: src/libvalent/ui/valent-device-page.ui:31
+#: src/libvalent/ui/valent-device-page.ui:49
 #, fuzzy
 msgid "Device Menu"
 msgstr "Nom de l'appareil"
 
-#: src/libvalent/ui/valent-device-page.ui:105
+#: src/libvalent/ui/valent-device-page.ui:123
 msgid "Verification Key"
 msgstr "Clé de vérification"
 
-#: src/libvalent/ui/valent-device-page.ui:134
+#: src/libvalent/ui/valent-device-page.ui:152
 msgid "Request Pairing"
 msgstr "Demande de liaison"
 
-#: src/libvalent/ui/valent-device-page.ui:229
+#: src/libvalent/ui/valent-device-page.ui:247
 #: src/libvalent/ui/valent-window.c:191
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: src/libvalent/ui/valent-device-page.ui:259
-#, fuzzy
-msgid "_Preferences"
+#: src/libvalent/ui/valent-device-page.ui:277
+#: src/libvalent/ui/valent-window.ui:135
+msgid "Preferences"
 msgstr "Paramètres"
 
-#: src/libvalent/ui/valent-device-page.ui:265
-msgid "P_air"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-page.ui:270
+#: src/libvalent/ui/valent-device-page.ui:283
 #, fuzzy
-msgid "_Unpair"
+msgid "Pair"
+msgstr "Lié"
+
+#: src/libvalent/ui/valent-device-page.ui:288
+#, fuzzy
+msgid "Unpair"
 msgstr "Non associé"
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:15
@@ -198,6 +199,39 @@ msgstr "Extensions"
 #: src/libvalent/ui/valent-preferences-window.ui:39
 msgid "No Plugins"
 msgstr "Pas d'extensions"
+
+#: src/libvalent/ui/valent-input-remote.ui:8
+#: src/libvalent/ui/valent-window.ui:125
+msgid "Input Remote"
+msgstr "Télécommande"
+
+#: src/libvalent/ui/valent-input-remote.ui:153
+msgid "Drag one finger to move"
+msgstr "Glisser un doigt pour déplacer"
+
+#: src/libvalent/ui/valent-input-remote.ui:162
+msgid "Drag two fingers to scroll"
+msgstr "Glisser deux doigts pour faire défiler"
+
+#: src/libvalent/ui/valent-input-remote.ui:171
+msgid "Tap one finger to click"
+msgstr "Tapoter avec un doigt pour cliquer"
+
+#: src/libvalent/ui/valent-input-remote.ui:181
+msgid "Tap two fingers to right click"
+msgstr "Tapoter avec deux doigts pour un clic droit"
+
+#: src/libvalent/ui/valent-input-remote.ui:190
+msgid "Tap three fingers to middle click"
+msgstr "Tapoter avec deux doigts pour un clic de la molette"
+
+#: src/libvalent/ui/valent-input-remote.ui:199
+msgid "Hold one finger to grab"
+msgstr "Maintenir un doigt pour saisir"
+
+#: src/libvalent/ui/valent-input-remote.ui:209
+msgid "Tap one finger to ungrab"
+msgstr "Tapoter avec un doigt pour relâcher"
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
@@ -232,13 +266,13 @@ msgid "Play"
 msgstr "Jouer"
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:113
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Media Remote"
 msgstr "Télécommande média"
 
 #: src/libvalent/ui/valent-media-remote.ui:219
-#: src/plugins/telephony/valent-telephony-preferences.ui:15
-#: src/plugins/telephony/valent-telephony-preferences.ui:43
+#: src/plugins/telephony/valent-telephony-preferences.ui:16
+#: src/plugins/telephony/valent-telephony-preferences.ui:47
 msgid "Volume"
 msgstr "Volume"
 
@@ -273,44 +307,44 @@ msgstr "Aléatoire"
 msgid "No Actions"
 msgstr "Aucune action"
 
-#: src/libvalent/ui/valent-preferences-window.c:375
+#: src/libvalent/ui/valent-preferences-window.c:377
 msgid "Global"
 msgstr "Global"
 
-#: src/libvalent/ui/valent-preferences-window.c:382
+#: src/libvalent/ui/valent-preferences-window.c:384
 msgid "Device Connections"
 msgstr "Connexions"
 
-#: src/libvalent/ui/valent-preferences-window.c:389
+#: src/libvalent/ui/valent-preferences-window.c:391
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr "Presse-papiers"
 
-#: src/libvalent/ui/valent-preferences-window.c:396
+#: src/libvalent/ui/valent-preferences-window.c:398
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr "Contacts"
 
-#: src/libvalent/ui/valent-preferences-window.c:403
+#: src/libvalent/ui/valent-preferences-window.c:405
 msgid "Mouse and Keyboard"
 msgstr "Souris et clavier"
 
-#: src/libvalent/ui/valent-preferences-window.c:410
+#: src/libvalent/ui/valent-preferences-window.c:412
 msgid "Media Players"
 msgstr "Lecteurs média"
 
-#: src/libvalent/ui/valent-preferences-window.c:417
+#: src/libvalent/ui/valent-preferences-window.c:419
 msgid "Volume Control"
 msgstr "Contrôle du volume"
 
-#: src/libvalent/ui/valent-preferences-window.c:424
+#: src/libvalent/ui/valent-preferences-window.c:426
 #: src/plugins/notification/notification.plugin.desktop.in:7
-#: src/plugins/notification/valent-notification-preferences.ui:63
+#: src/plugins/notification/valent-notification-preferences.ui:66
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/libvalent/ui/valent-preferences-window.c:431
+#: src/libvalent/ui/valent-preferences-window.c:433
 msgid "Session Manager"
 msgstr "Gestion de session"
 
@@ -439,34 +473,29 @@ msgstr "Valérie Roux <vxlerieuwu@unixgirl.xyz>"
 msgid "Sponsors"
 msgstr "Sponsors"
 
-#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#: src/libvalent/ui/valent-window.ui:70 src/libvalent/ui/valent-window.ui:73
 #, fuzzy
 msgid "Main Menu"
 msgstr "Nom de l'appareil"
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:91
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr "Appareils"
 
-#: src/libvalent/ui/valent-window.ui:87
+#: src/libvalent/ui/valent-window.ui:99
 msgid "Searching for devices…"
 msgstr "Recherche d'appareils"
 
-#: src/libvalent/ui/valent-window.ui:119
-msgid "Preferences"
-msgstr "Paramètres"
-
-#: src/libvalent/ui/valent-window.ui:123
-#: src/plugins/sms/valent-sms-window.ui:350
+#: src/libvalent/ui/valent-window.ui:139
 msgid "About Valent"
 msgstr "À propos de Valent"
 
-#: src/libvalent/ui/valent-window.ui:129
+#: src/libvalent/ui/valent-window.ui:145
 msgid "Quit"
 msgstr "Quitter"
 
@@ -497,24 +526,24 @@ msgstr "%g%% (%d∶%02d jusqu'à charge complète)"
 
 #. TRANSLATORS: This is <percentage> (<hours>:<minutes> Remaining)
 #: src/plugins/battery/valent-battery-gadget.c:99
-#: src/plugins/battery/valent-battery-plugin.c:307
+#: src/plugins/battery/valent-battery-plugin.c:295
 #, c-format
 msgid "%g%% (%d∶%02d Remaining)"
 msgstr "%g%% (%d∶%02d restants)"
 
 #. TRANSLATORS: This is <device name>: Fully Charged
-#: src/plugins/battery/valent-battery-plugin.c:276
+#: src/plugins/battery/valent-battery-plugin.c:264
 #, c-format
 msgid "%s: Fully Charged"
 msgstr "%s: Batterie pleine"
 
 #. TRANSLATORS: When the battery level is at maximum
-#: src/plugins/battery/valent-battery-plugin.c:278
+#: src/plugins/battery/valent-battery-plugin.c:266
 msgid "Battery Fully Charged"
 msgstr "Batterie pleine"
 
 #. TRANSLATORS: This is <device name>: Battery Low
-#: src/plugins/battery/valent-battery-plugin.c:305
+#: src/plugins/battery/valent-battery-plugin.c:293
 #, c-format
 msgid "%s: Battery Low"
 msgstr "%s: Batterie faible"
@@ -528,16 +557,16 @@ msgstr "Notification de batterie pleine"
 msgid "Notify when the remote battery is full"
 msgstr "Avertir lorsque la batterie est pleine"
 
-#: src/plugins/battery/valent-battery-preferences.ui:15
-#: src/plugins/battery/valent-battery-preferences.ui:39
+#: src/plugins/battery/valent-battery-preferences.ui:16
+#: src/plugins/battery/valent-battery-preferences.ui:42
 msgid "Level Threshold"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:34
+#: src/plugins/battery/valent-battery-preferences.ui:36
 msgid "Low Battery Notification"
 msgstr "Notification de batterie faible"
 
-#: src/plugins/battery/valent-battery-preferences.ui:35
+#: src/plugins/battery/valent-battery-preferences.ui:37
 #, fuzzy
 msgid "Notify when the remote battery is low"
 msgstr "Avertir lorsque la batterie est faible"
@@ -559,12 +588,12 @@ msgstr "Changements distants du presse-papiers"
 msgid "Copy changes to the local clipboard"
 msgstr "Copier vers le presse-papiers local"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:22
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
 #, fuzzy
 msgid "Local Clipboard"
 msgstr "Changements locaux du presse-papiers"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:24
 #, fuzzy
 msgid "Report changes to the remote device"
 msgstr "Prendre une photo avec l'appareil distant"
@@ -580,34 +609,34 @@ msgid "Monitor mobile connectivity status"
 msgstr "Synchroniser l'état du réseau"
 
 #. TRANSLATORS: When the mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:173
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:162
 msgid "Mobile Network"
 msgstr "Réseau mobile"
 
 #. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:175
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:164
 #, c-format
 msgid "Signal Strength %f%%"
 msgstr "Force du signal %f%%"
 
 #. TRANSLATORS: When no mobile service is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:181
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:188
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:170
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:177
 msgid "No Service"
 msgstr "Aucun service"
 
 #. TRANSLATORS: When no mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:183
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
 msgid "No mobile network service"
 msgstr "Aucun service mobile"
 
 #. TRANSLATORS: When the device is missing a SIM card
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:190
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:179
 msgid "No SIM"
 msgstr "Pas de SIM"
 
 #. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:321
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:310
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
@@ -616,16 +645,16 @@ msgstr "%s: %s"
 msgid "Local Connectivity"
 msgstr "Connectivité locale"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:11
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12
 #, fuzzy
 msgid "Send updates to the remote device"
 msgstr "Prendre une photo avec l'appareil distant"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:22
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
 msgid "Remote Connectivity"
 msgstr "Connectivité distante"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:24
 msgid "Notify if the remote device loses connectivity"
 msgstr ""
 
@@ -643,11 +672,11 @@ msgstr "Contacts distants"
 msgid "Import contacts from the remote device"
 msgstr "Télécharger les contacts de l'appareil distant"
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:22
+#: src/plugins/contacts/valent-contacts-preferences.ui:23
 msgid "Local Contacts"
 msgstr "Contacts locaux"
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:23
+#: src/plugins/contacts/valent-contacts-preferences.ui:24
 #, fuzzy
 msgid "Share contacts with the remote device"
 msgstr "Prendre une photo avec l'appareil distant"
@@ -717,42 +746,6 @@ msgstr "Tapis de souris"
 msgid "Control the mouse and keyboard"
 msgstr "Contrôler la souris et le clavier"
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:579
-msgid "Remote Input"
-msgstr "Entrée distante"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:8
-msgid "Input Remote"
-msgstr "Télécommande"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:142
-msgid "Drag one finger to move"
-msgstr "Glisser un doigt pour déplacer"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:151
-msgid "Drag two fingers to scroll"
-msgstr "Glisser deux doigts pour faire défiler"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:160
-msgid "Tap one finger to click"
-msgstr "Tapoter avec un doigt pour cliquer"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:170
-msgid "Tap two fingers to right click"
-msgstr "Tapoter avec deux doigts pour un clic droit"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:179
-msgid "Tap three fingers to middle click"
-msgstr "Tapoter avec deux doigts pour un clic de la molette"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:188
-msgid "Hold one finger to grab"
-msgstr "Maintenir un doigt pour saisir"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:198
-msgid "Tap one finger to ungrab"
-msgstr "Tapoter avec un doigt pour relâcher"
-
 #: src/plugins/mpris/mpris.plugin.desktop.in:7
 msgid "MPRIS"
 msgstr "MPRIS"
@@ -760,10 +753,6 @@ msgstr "MPRIS"
 #: src/plugins/mpris/mpris.plugin.desktop.in:8
 msgid "Share control of MPRISv2 players"
 msgstr "Partager la gestion des lecteurs MPRISv2"
-
-#: src/plugins/mpris/valent-mpris-plugin.c:484
-msgid "Unknown"
-msgstr "Inconnu"
 
 #: src/plugins/notification/notification.plugin.desktop.in:8
 msgid "Sync notifications"
@@ -785,6 +774,7 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:150
 #: src/plugins/share/valent-share-text-dialog.ui:53
+#: src/plugins/sms/valent-sms-window.ui:352
 msgid "Close"
 msgstr "Fermer"
 
@@ -803,30 +793,30 @@ msgstr "Notifications"
 msgid "Forward notifications to the remote device"
 msgstr "Téléverser les contacts vers l'appareil distant."
 
-#: src/plugins/notification/valent-notification-preferences.ui:15
+#: src/plugins/notification/valent-notification-preferences.ui:16
 msgid "Intelligent Sync"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:16
+#: src/plugins/notification/valent-notification-preferences.ui:17
 #, fuzzy
 msgid "Notifications follow the active device"
 msgstr "Envoyer les notifications lorsque la session est active."
 
-#: src/plugins/notification/valent-notification-preferences.ui:28
+#: src/plugins/notification/valent-notification-preferences.ui:30
 #, fuzzy
 msgid "Filter by Application"
 msgstr "Aucune application"
 
-#: src/plugins/notification/valent-notification-preferences.ui:64
+#: src/plugins/notification/valent-notification-preferences.ui:67
 msgid "Applications"
 msgstr "Applications"
 
-#: src/plugins/notification/valent-notification-preferences.ui:85
+#: src/plugins/notification/valent-notification-preferences.ui:88
 #, fuzzy
 msgid "Search"
 msgstr "Recherche..."
 
-#: src/plugins/notification/valent-notification-preferences.ui:132
+#: src/plugins/notification/valent-notification-preferences.ui:135
 msgid "No Applications"
 msgstr "Aucune application"
 
@@ -928,7 +918,7 @@ msgid "Execute commands remotely"
 msgstr "Exécuter des commandes à distance"
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#: src/plugins/runcommand/valent-runcommand-preferences.c:85
 #, fuzzy
 msgid "Edit Command"
 msgstr "Commandes"
@@ -1004,17 +994,17 @@ msgstr ""
 "Tenter de monter le système de fichiers distant lorsque l'appareil se "
 "connecte."
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:22
+#: src/plugins/sftp/valent-sftp-preferences.ui:23
 #, fuzzy
 msgid "Local Files"
 msgstr "Système de fichiers local"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:23
+#: src/plugins/sftp/valent-sftp-preferences.ui:24
 #, fuzzy
 msgid "Share local files and directories"
 msgstr "Parcourir les fichiers et dossiers"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:27
+#: src/plugins/sftp/valent-sftp-preferences.ui:29
 msgid "Port"
 msgstr "Port"
 
@@ -1143,7 +1133,7 @@ msgstr "Choisissez un appareil auquel partager les fichiers seléctionnés."
 msgid "Searching…"
 msgstr "Recherche..."
 
-#: src/plugins/share/valent-share-target-chooser.ui:127
+#: src/plugins/share/valent-share-target-chooser.ui:128
 msgid "Always use this device"
 msgstr "Toujours utiliser cet appareil"
 
@@ -1317,7 +1307,7 @@ msgid "Incoming call"
 msgstr "Appel entrant"
 
 #: src/plugins/telephony/valent-telephony-plugin.c:311
-#: src/plugins/telephony/valent-telephony-preferences.ui:79
+#: src/plugins/telephony/valent-telephony-preferences.ui:86
 msgid "Mute"
 msgstr "Sourdine"
 
@@ -1334,29 +1324,29 @@ msgstr "Appels entrants"
 msgid "What to do when the phone rings"
 msgstr "Que faire lorsque le téléphone sonne."
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:24
-#: src/plugins/telephony/valent-telephony-preferences.ui:63
+#: src/plugins/telephony/valent-telephony-preferences.ui:26
+#: src/plugins/telephony/valent-telephony-preferences.ui:69
 msgid "Pause Media"
 msgstr "Mettre le média en pause"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:39
+#: src/plugins/telephony/valent-telephony-preferences.ui:42
 msgid "Ongoing Calls"
 msgstr "Appels en cours"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:40
+#: src/plugins/telephony/valent-telephony-preferences.ui:43
 #, fuzzy
 msgid "What to do when the phone is answered"
 msgstr "Que faire lorsque le téléphone est décroché."
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:52
+#: src/plugins/telephony/valent-telephony-preferences.ui:57
 msgid "Mute Microphone"
 msgstr "Mettre le microphone en sourdine"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:77
+#: src/plugins/telephony/valent-telephony-preferences.ui:84
 msgid "Nothing"
 msgstr "Rien"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:78
+#: src/plugins/telephony/valent-telephony-preferences.ui:85
 msgid "Lower"
 msgstr "Baisser"
 
@@ -1371,6 +1361,16 @@ msgstr "Portails"
 #: src/plugins/xdp/xdp.plugin.desktop.in:8
 msgid "Integration with desktop portals"
 msgstr "Intégration avec les portails de bureau"
+
+#, fuzzy
+#~ msgid "_Preferences"
+#~ msgstr "Paramètres"
+
+#~ msgid "Remote Input"
+#~ msgstr "Entrée distante"
+
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
 
 #~ msgid "Send"
 #~ msgstr "Envoyer"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-06-03 12:35-0700\n"
+"POT-Creation-Date: 2023-07-04 17:27-0700\n"
 "PO-Revision-Date: 2022-09-12 19:59+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -45,7 +45,7 @@ msgstr "Of de plug-in is ingeschakeld."
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:51
 msgid "Valent"
 msgstr "Valent"
 
@@ -116,57 +116,58 @@ msgid "Pairing request from %s"
 msgstr "Koppelverzoek van %s"
 
 #: src/libvalent/device/valent-device.c:523
-#: src/libvalent/ui/valent-device-page.ui:143
+#: src/libvalent/ui/valent-device-page.ui:161
 msgid "Reject"
 msgstr "Afwijzen"
 
 #: src/libvalent/device/valent-device.c:529
-#: src/libvalent/ui/valent-device-page.ui:156
+#: src/libvalent/ui/valent-device-page.ui:174
 msgid "Accept"
 msgstr "Goedkeuren"
 
 #: src/libvalent/ui/valent-device-page.c:175
-#: src/libvalent/ui/valent-device-page.ui:113
+#: src/libvalent/ui/valent-device-page.ui:131
 msgid "Unavailable"
 msgstr "Niet beschikbaar"
 
-#: src/libvalent/ui/valent-device-page.ui:21
+#: src/libvalent/ui/valent-device-page.ui:38
 #: src/libvalent/ui/valent-media-remote.ui:239
 #: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr "Vorige"
 
-#: src/libvalent/ui/valent-device-page.ui:31
+#: src/libvalent/ui/valent-device-page.ui:49
 #, fuzzy
 msgid "Device Menu"
 msgstr "Apparaatnaam"
 
-#: src/libvalent/ui/valent-device-page.ui:105
+#: src/libvalent/ui/valent-device-page.ui:123
 msgid "Verification Key"
 msgstr "Verificatiesleutel"
 
-#: src/libvalent/ui/valent-device-page.ui:134
+#: src/libvalent/ui/valent-device-page.ui:152
 msgid "Request Pairing"
 msgstr "Koppelverzoek versturen"
 
-#: src/libvalent/ui/valent-device-page.ui:229
+#: src/libvalent/ui/valent-device-page.ui:247
 #: src/libvalent/ui/valent-window.c:191
 msgid "Disconnected"
 msgstr "Niet verbonden"
 
-#: src/libvalent/ui/valent-device-page.ui:259
-#, fuzzy
-msgid "_Preferences"
+#: src/libvalent/ui/valent-device-page.ui:277
+#: src/libvalent/ui/valent-window.ui:135
+msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/libvalent/ui/valent-device-page.ui:265
-msgid "P_air"
-msgstr ""
-
-#: src/libvalent/ui/valent-device-page.ui:270
+#: src/libvalent/ui/valent-device-page.ui:283
 #, fuzzy
-msgid "_Unpair"
+msgid "Pair"
+msgstr "Gekoppeld"
+
+#: src/libvalent/ui/valent-device-page.ui:288
+#, fuzzy
+msgid "Unpair"
 msgstr "Niet gekoppeld"
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:15
@@ -193,6 +194,39 @@ msgstr "Plug-ins"
 #: src/libvalent/ui/valent-preferences-window.ui:39
 msgid "No Plugins"
 msgstr "Er zijn geen plug-ins."
+
+#: src/libvalent/ui/valent-input-remote.ui:8
+#: src/libvalent/ui/valent-window.ui:125
+msgid "Input Remote"
+msgstr "Afstandsbediening"
+
+#: src/libvalent/ui/valent-input-remote.ui:153
+msgid "Drag one finger to move"
+msgstr "Veeg met één vinger om de cursor te verplaatsen"
+
+#: src/libvalent/ui/valent-input-remote.ui:162
+msgid "Drag two fingers to scroll"
+msgstr "Veeg met twee vingers om te scrollen"
+
+#: src/libvalent/ui/valent-input-remote.ui:171
+msgid "Tap one finger to click"
+msgstr "Tik met één vinger om te klikken"
+
+#: src/libvalent/ui/valent-input-remote.ui:181
+msgid "Tap two fingers to right click"
+msgstr "Tik met twee vingers om het rechtermuisknopmenu te openen"
+
+#: src/libvalent/ui/valent-input-remote.ui:190
+msgid "Tap three fingers to middle click"
+msgstr "Tik met drie vingers om te middelklikken"
+
+#: src/libvalent/ui/valent-input-remote.ui:199
+msgid "Hold one finger to grab"
+msgstr "Houd met één vinger ingedrukt om te verslepen"
+
+#: src/libvalent/ui/valent-input-remote.ui:209
+msgid "Tap one finger to ungrab"
+msgstr "Tik met één vinger om te stoppen met verslepen"
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
@@ -225,13 +259,13 @@ msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:113
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Media Remote"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:219
-#: src/plugins/telephony/valent-telephony-preferences.ui:15
-#: src/plugins/telephony/valent-telephony-preferences.ui:43
+#: src/plugins/telephony/valent-telephony-preferences.ui:16
+#: src/plugins/telephony/valent-telephony-preferences.ui:47
 msgid "Volume"
 msgstr "Volume"
 
@@ -267,44 +301,44 @@ msgstr ""
 msgid "No Actions"
 msgstr "Er zijn geen acties."
 
-#: src/libvalent/ui/valent-preferences-window.c:375
+#: src/libvalent/ui/valent-preferences-window.c:377
 msgid "Global"
 msgstr "Algemeen"
 
-#: src/libvalent/ui/valent-preferences-window.c:382
+#: src/libvalent/ui/valent-preferences-window.c:384
 msgid "Device Connections"
 msgstr "Verbonden apparaten"
 
-#: src/libvalent/ui/valent-preferences-window.c:389
+#: src/libvalent/ui/valent-preferences-window.c:391
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr "Klembord"
 
-#: src/libvalent/ui/valent-preferences-window.c:396
+#: src/libvalent/ui/valent-preferences-window.c:398
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr "Contactpersonen"
 
-#: src/libvalent/ui/valent-preferences-window.c:403
+#: src/libvalent/ui/valent-preferences-window.c:405
 msgid "Mouse and Keyboard"
 msgstr "Muis en toetsenbord"
 
-#: src/libvalent/ui/valent-preferences-window.c:410
+#: src/libvalent/ui/valent-preferences-window.c:412
 msgid "Media Players"
 msgstr "Mediaspelers"
 
-#: src/libvalent/ui/valent-preferences-window.c:417
+#: src/libvalent/ui/valent-preferences-window.c:419
 msgid "Volume Control"
 msgstr "Volumeregeling"
 
-#: src/libvalent/ui/valent-preferences-window.c:424
+#: src/libvalent/ui/valent-preferences-window.c:426
 #: src/plugins/notification/notification.plugin.desktop.in:7
-#: src/plugins/notification/valent-notification-preferences.ui:63
+#: src/plugins/notification/valent-notification-preferences.ui:66
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/libvalent/ui/valent-preferences-window.c:431
+#: src/libvalent/ui/valent-preferences-window.c:433
 msgid "Session Manager"
 msgstr "Sessiebeheer"
 
@@ -433,34 +467,29 @@ msgstr "Heimen Stoffels <vistausss@fastmail.com>"
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
 msgid "Refresh"
 msgstr "Herladen"
 
-#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#: src/libvalent/ui/valent-window.ui:70 src/libvalent/ui/valent-window.ui:73
 #, fuzzy
 msgid "Main Menu"
 msgstr "Apparaatnaam"
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:91
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr "Apparaten"
 
-#: src/libvalent/ui/valent-window.ui:87
+#: src/libvalent/ui/valent-window.ui:99
 msgid "Searching for devices…"
 msgstr "Bezig met zoeken naar apparaten…"
 
-#: src/libvalent/ui/valent-window.ui:119
-msgid "Preferences"
-msgstr "Voorkeuren"
-
-#: src/libvalent/ui/valent-window.ui:123
-#: src/plugins/sms/valent-sms-window.ui:350
+#: src/libvalent/ui/valent-window.ui:139
 msgid "About Valent"
 msgstr "Over Valent"
 
-#: src/libvalent/ui/valent-window.ui:129
+#: src/libvalent/ui/valent-window.ui:145
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -491,24 +520,24 @@ msgstr "%g%% (volledig opgeladen over %d∶%02d)"
 
 #. TRANSLATORS: This is <percentage> (<hours>:<minutes> Remaining)
 #: src/plugins/battery/valent-battery-gadget.c:99
-#: src/plugins/battery/valent-battery-plugin.c:307
+#: src/plugins/battery/valent-battery-plugin.c:295
 #, c-format
 msgid "%g%% (%d∶%02d Remaining)"
 msgstr "%g%% (%d∶%02d resterend)"
 
 #. TRANSLATORS: This is <device name>: Fully Charged
-#: src/plugins/battery/valent-battery-plugin.c:276
+#: src/plugins/battery/valent-battery-plugin.c:264
 #, c-format
 msgid "%s: Fully Charged"
 msgstr "%s: volledig opgeladen"
 
 #. TRANSLATORS: When the battery level is at maximum
-#: src/plugins/battery/valent-battery-plugin.c:278
+#: src/plugins/battery/valent-battery-plugin.c:266
 msgid "Battery Fully Charged"
 msgstr "De accu is volledig opgeladen"
 
 #. TRANSLATORS: This is <device name>: Battery Low
-#: src/plugins/battery/valent-battery-plugin.c:305
+#: src/plugins/battery/valent-battery-plugin.c:293
 #, c-format
 msgid "%s: Battery Low"
 msgstr "%s: laag accuniveau"
@@ -522,16 +551,16 @@ msgstr "Volledig opgeladen"
 msgid "Notify when the remote battery is full"
 msgstr "Toon een melding als de accu volledig is opgeladen"
 
-#: src/plugins/battery/valent-battery-preferences.ui:15
-#: src/plugins/battery/valent-battery-preferences.ui:39
+#: src/plugins/battery/valent-battery-preferences.ui:16
+#: src/plugins/battery/valent-battery-preferences.ui:42
 msgid "Level Threshold"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:34
+#: src/plugins/battery/valent-battery-preferences.ui:36
 msgid "Low Battery Notification"
 msgstr "Laag accuniveau"
 
-#: src/plugins/battery/valent-battery-preferences.ui:35
+#: src/plugins/battery/valent-battery-preferences.ui:37
 #, fuzzy
 msgid "Notify when the remote battery is low"
 msgstr "Toon een melding als de accu bijna leeg is."
@@ -553,12 +582,12 @@ msgstr "Externe klembordwijzigingen"
 msgid "Copy changes to the local clipboard"
 msgstr "Kopiëren naar lokaal klembord"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:22
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
 #, fuzzy
 msgid "Local Clipboard"
 msgstr "Lokale klembordwijzigingen"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:24
 #, fuzzy
 msgid "Report changes to the remote device"
 msgstr "Maak een foto met het externe apparaat"
@@ -574,34 +603,34 @@ msgid "Monitor mobile connectivity status"
 msgstr "Verbindingsstatus synchroniseren"
 
 #. TRANSLATORS: When the mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:173
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:162
 msgid "Mobile Network"
 msgstr "Mobiel internet"
 
 #. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:175
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:164
 #, c-format
 msgid "Signal Strength %f%%"
 msgstr "Bereik: %f%%"
 
 #. TRANSLATORS: When no mobile service is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:181
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:188
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:170
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:177
 msgid "No Service"
 msgstr "Geen bereik"
 
 #. TRANSLATORS: When no mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:183
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
 msgid "No mobile network service"
 msgstr "Geen netwerkverbinding"
 
 #. TRANSLATORS: When the device is missing a SIM card
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:190
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:179
 msgid "No SIM"
 msgstr "Geen simkaart"
 
 #. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:321
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:310
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
@@ -610,16 +639,16 @@ msgstr "%s: %s"
 msgid "Local Connectivity"
 msgstr "Lokale verbinding"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:11
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12
 #, fuzzy
 msgid "Send updates to the remote device"
 msgstr "Maak een foto met het externe apparaat"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:22
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
 msgid "Remote Connectivity"
 msgstr "Externe verbinding"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:24
 msgid "Notify if the remote device loses connectivity"
 msgstr ""
 
@@ -637,11 +666,11 @@ msgstr "Externe contactpersonen"
 msgid "Import contacts from the remote device"
 msgstr "Haal de lijst met contactpersonen van het externe apparaat op."
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:22
+#: src/plugins/contacts/valent-contacts-preferences.ui:23
 msgid "Local Contacts"
 msgstr "Lokale contactpersonen"
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:23
+#: src/plugins/contacts/valent-contacts-preferences.ui:24
 #, fuzzy
 msgid "Share contacts with the remote device"
 msgstr "Maak een foto met het externe apparaat"
@@ -711,42 +740,6 @@ msgstr "Touchpad"
 msgid "Control the mouse and keyboard"
 msgstr "Bedien de muis en het toetsenbord"
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:579
-msgid "Remote Input"
-msgstr "Externe invoer"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:8
-msgid "Input Remote"
-msgstr "Afstandsbediening"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:142
-msgid "Drag one finger to move"
-msgstr "Veeg met één vinger om de cursor te verplaatsen"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:151
-msgid "Drag two fingers to scroll"
-msgstr "Veeg met twee vingers om te scrollen"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:160
-msgid "Tap one finger to click"
-msgstr "Tik met één vinger om te klikken"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:170
-msgid "Tap two fingers to right click"
-msgstr "Tik met twee vingers om het rechtermuisknopmenu te openen"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:179
-msgid "Tap three fingers to middle click"
-msgstr "Tik met drie vingers om te middelklikken"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:188
-msgid "Hold one finger to grab"
-msgstr "Houd met één vinger ingedrukt om te verslepen"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:198
-msgid "Tap one finger to ungrab"
-msgstr "Tik met één vinger om te stoppen met verslepen"
-
 #: src/plugins/mpris/mpris.plugin.desktop.in:7
 msgid "MPRIS"
 msgstr "MPRIS"
@@ -754,10 +747,6 @@ msgstr "MPRIS"
 #: src/plugins/mpris/mpris.plugin.desktop.in:8
 msgid "Share control of MPRISv2 players"
 msgstr "Bedien met MPRISv2 compatibele mediaspelers"
-
-#: src/plugins/mpris/valent-mpris-plugin.c:484
-msgid "Unknown"
-msgstr "Onbekend"
 
 #: src/plugins/notification/notification.plugin.desktop.in:8
 msgid "Sync notifications"
@@ -779,6 +768,7 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:150
 #: src/plugins/share/valent-share-text-dialog.ui:53
+#: src/plugins/sms/valent-sms-window.ui:352
 msgid "Close"
 msgstr ""
 
@@ -797,30 +787,30 @@ msgstr "Meldingen"
 msgid "Forward notifications to the remote device"
 msgstr "Verstuur de lijst met contactpersonen naar het externe apparaat."
 
-#: src/plugins/notification/valent-notification-preferences.ui:15
+#: src/plugins/notification/valent-notification-preferences.ui:16
 msgid "Intelligent Sync"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:16
+#: src/plugins/notification/valent-notification-preferences.ui:17
 #, fuzzy
 msgid "Notifications follow the active device"
 msgstr "Toon een melding als de verbinding verbroken is."
 
-#: src/plugins/notification/valent-notification-preferences.ui:28
+#: src/plugins/notification/valent-notification-preferences.ui:30
 #, fuzzy
 msgid "Filter by Application"
 msgstr "Geen toepassingen"
 
-#: src/plugins/notification/valent-notification-preferences.ui:64
+#: src/plugins/notification/valent-notification-preferences.ui:67
 msgid "Applications"
 msgstr "Toepassingen"
 
-#: src/plugins/notification/valent-notification-preferences.ui:85
+#: src/plugins/notification/valent-notification-preferences.ui:88
 #, fuzzy
 msgid "Search"
 msgstr "Bezig met zoeken naar apparaten…"
 
-#: src/plugins/notification/valent-notification-preferences.ui:132
+#: src/plugins/notification/valent-notification-preferences.ui:135
 msgid "No Applications"
 msgstr "Geen toepassingen"
 
@@ -922,7 +912,7 @@ msgid "Execute commands remotely"
 msgstr "Voer externe opdrachten uit"
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#: src/plugins/runcommand/valent-runcommand-preferences.c:85
 #, fuzzy
 msgid "Edit Command"
 msgstr "Opdrachten"
@@ -999,17 +989,17 @@ msgstr ""
 "Probeer het bestandssysteem automatisch aan te koppelen zodra het apparaat "
 "verbonden is."
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:22
+#: src/plugins/sftp/valent-sftp-preferences.ui:23
 #, fuzzy
 msgid "Local Files"
 msgstr "Lokaal bestandssysteem"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:23
+#: src/plugins/sftp/valent-sftp-preferences.ui:24
 #, fuzzy
 msgid "Share local files and directories"
 msgstr "Mappen en bestanden verkennen"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:27
+#: src/plugins/sftp/valent-sftp-preferences.ui:29
 msgid "Port"
 msgstr "Poort"
 
@@ -1140,7 +1130,7 @@ msgstr ""
 msgid "Searching…"
 msgstr "Bezig met zoeken naar apparaten…"
 
-#: src/plugins/share/valent-share-target-chooser.ui:127
+#: src/plugins/share/valent-share-target-chooser.ui:128
 msgid "Always use this device"
 msgstr ""
 
@@ -1315,7 +1305,7 @@ msgid "Incoming call"
 msgstr "Inkomende oproep"
 
 #: src/plugins/telephony/valent-telephony-plugin.c:311
-#: src/plugins/telephony/valent-telephony-preferences.ui:79
+#: src/plugins/telephony/valent-telephony-preferences.ui:86
 msgid "Mute"
 msgstr "Dempen"
 
@@ -1332,30 +1322,30 @@ msgstr "Inkomende oproepen"
 msgid "What to do when the phone rings"
 msgstr "Welke actie er dient te worden genomen als de telefoon overgaat."
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:24
-#: src/plugins/telephony/valent-telephony-preferences.ui:63
+#: src/plugins/telephony/valent-telephony-preferences.ui:26
+#: src/plugins/telephony/valent-telephony-preferences.ui:69
 msgid "Pause Media"
 msgstr "Media onderbreken"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:39
+#: src/plugins/telephony/valent-telephony-preferences.ui:42
 msgid "Ongoing Calls"
 msgstr "Actieve gesprekken"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:40
+#: src/plugins/telephony/valent-telephony-preferences.ui:43
 #, fuzzy
 msgid "What to do when the phone is answered"
 msgstr ""
 "Welke actie er dient te worden genomen als de telefoon wordt beantwoord."
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:52
+#: src/plugins/telephony/valent-telephony-preferences.ui:57
 msgid "Mute Microphone"
 msgstr "Microfoon dempen"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:77
+#: src/plugins/telephony/valent-telephony-preferences.ui:84
 msgid "Nothing"
 msgstr "Niets doen"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:78
+#: src/plugins/telephony/valent-telephony-preferences.ui:85
 msgid "Lower"
 msgstr "Verlagen"
 
@@ -1370,6 +1360,16 @@ msgstr "Portalen"
 #: src/plugins/xdp/xdp.plugin.desktop.in:8
 msgid "Integration with desktop portals"
 msgstr "Integratie met bureaubladportalen"
+
+#, fuzzy
+#~ msgid "_Preferences"
+#~ msgstr "Voorkeuren"
+
+#~ msgid "Remote Input"
+#~ msgstr "Externe invoer"
+
+#~ msgid "Unknown"
+#~ msgstr "Onbekend"
 
 #~ msgid "Send"
 #~ msgstr "Versturen"

--- a/po/valent.pot
+++ b/po/valent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-06-03 12:35-0700\n"
+"POT-Creation-Date: 2023-07-04 17:27-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,7 +46,7 @@ msgstr ""
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:51
 msgid "Valent"
 msgstr ""
 
@@ -113,54 +113,55 @@ msgid "Pairing request from %s"
 msgstr ""
 
 #: src/libvalent/device/valent-device.c:523
-#: src/libvalent/ui/valent-device-page.ui:143
+#: src/libvalent/ui/valent-device-page.ui:161
 msgid "Reject"
 msgstr ""
 
 #: src/libvalent/device/valent-device.c:529
-#: src/libvalent/ui/valent-device-page.ui:156
+#: src/libvalent/ui/valent-device-page.ui:174
 msgid "Accept"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-page.c:175
-#: src/libvalent/ui/valent-device-page.ui:113
+#: src/libvalent/ui/valent-device-page.ui:131
 msgid "Unavailable"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:21
+#: src/libvalent/ui/valent-device-page.ui:38
 #: src/libvalent/ui/valent-media-remote.ui:239
 #: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:31
+#: src/libvalent/ui/valent-device-page.ui:49
 msgid "Device Menu"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:105
+#: src/libvalent/ui/valent-device-page.ui:123
 msgid "Verification Key"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:134
+#: src/libvalent/ui/valent-device-page.ui:152
 msgid "Request Pairing"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:229
+#: src/libvalent/ui/valent-device-page.ui:247
 #: src/libvalent/ui/valent-window.c:191
 msgid "Disconnected"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:259
-msgid "_Preferences"
+#: src/libvalent/ui/valent-device-page.ui:277
+#: src/libvalent/ui/valent-window.ui:135
+msgid "Preferences"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:265
-msgid "P_air"
+#: src/libvalent/ui/valent-device-page.ui:283
+msgid "Pair"
 msgstr ""
 
-#: src/libvalent/ui/valent-device-page.ui:270
-msgid "_Unpair"
+#: src/libvalent/ui/valent-device-page.ui:288
+msgid "Unpair"
 msgstr ""
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:15
@@ -186,6 +187,39 @@ msgstr ""
 #: src/libvalent/ui/valent-device-preferences-window.ui:58
 #: src/libvalent/ui/valent-preferences-window.ui:39
 msgid "No Plugins"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:8
+#: src/libvalent/ui/valent-window.ui:125
+msgid "Input Remote"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:153
+msgid "Drag one finger to move"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:162
+msgid "Drag two fingers to scroll"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:171
+msgid "Tap one finger to click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:181
+msgid "Tap two fingers to right click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:190
+msgid "Tap three fingers to middle click"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:199
+msgid "Hold one finger to grab"
+msgstr ""
+
+#: src/libvalent/ui/valent-input-remote.ui:209
+msgid "Tap one finger to ungrab"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.c:250
@@ -218,13 +252,13 @@ msgid "Play"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:113
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Media Remote"
 msgstr ""
 
 #: src/libvalent/ui/valent-media-remote.ui:219
-#: src/plugins/telephony/valent-telephony-preferences.ui:15
-#: src/plugins/telephony/valent-telephony-preferences.ui:43
+#: src/plugins/telephony/valent-telephony-preferences.ui:16
+#: src/plugins/telephony/valent-telephony-preferences.ui:47
 msgid "Volume"
 msgstr ""
 
@@ -258,44 +292,44 @@ msgstr ""
 msgid "No Actions"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:375
+#: src/libvalent/ui/valent-preferences-window.c:377
 msgid "Global"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:382
+#: src/libvalent/ui/valent-preferences-window.c:384
 msgid "Device Connections"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:389
+#: src/libvalent/ui/valent-preferences-window.c:391
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:396
+#: src/libvalent/ui/valent-preferences-window.c:398
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:403
+#: src/libvalent/ui/valent-preferences-window.c:405
 msgid "Mouse and Keyboard"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:410
+#: src/libvalent/ui/valent-preferences-window.c:412
 msgid "Media Players"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:417
+#: src/libvalent/ui/valent-preferences-window.c:419
 msgid "Volume Control"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:424
+#: src/libvalent/ui/valent-preferences-window.c:426
 #: src/plugins/notification/notification.plugin.desktop.in:7
-#: src/plugins/notification/valent-notification-preferences.ui:63
+#: src/plugins/notification/valent-notification-preferences.ui:66
 msgid "Notifications"
 msgstr ""
 
-#: src/libvalent/ui/valent-preferences-window.c:431
+#: src/libvalent/ui/valent-preferences-window.c:433
 msgid "Session Manager"
 msgstr ""
 
@@ -424,33 +458,28 @@ msgstr ""
 msgid "Sponsors"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
 msgid "Refresh"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#: src/libvalent/ui/valent-window.ui:70 src/libvalent/ui/valent-window.ui:73
 msgid "Main Menu"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:91
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:87
+#: src/libvalent/ui/valent-window.ui:99
 msgid "Searching for devices…"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:119
-msgid "Preferences"
-msgstr ""
-
-#: src/libvalent/ui/valent-window.ui:123
-#: src/plugins/sms/valent-sms-window.ui:350
+#: src/libvalent/ui/valent-window.ui:139
 msgid "About Valent"
 msgstr ""
 
-#: src/libvalent/ui/valent-window.ui:129
+#: src/libvalent/ui/valent-window.ui:145
 msgid "Quit"
 msgstr ""
 
@@ -481,24 +510,24 @@ msgstr ""
 
 #. TRANSLATORS: This is <percentage> (<hours>:<minutes> Remaining)
 #: src/plugins/battery/valent-battery-gadget.c:99
-#: src/plugins/battery/valent-battery-plugin.c:307
+#: src/plugins/battery/valent-battery-plugin.c:295
 #, c-format
 msgid "%g%% (%d∶%02d Remaining)"
 msgstr ""
 
 #. TRANSLATORS: This is <device name>: Fully Charged
-#: src/plugins/battery/valent-battery-plugin.c:276
+#: src/plugins/battery/valent-battery-plugin.c:264
 #, c-format
 msgid "%s: Fully Charged"
 msgstr ""
 
 #. TRANSLATORS: When the battery level is at maximum
-#: src/plugins/battery/valent-battery-plugin.c:278
+#: src/plugins/battery/valent-battery-plugin.c:266
 msgid "Battery Fully Charged"
 msgstr ""
 
 #. TRANSLATORS: This is <device name>: Battery Low
-#: src/plugins/battery/valent-battery-plugin.c:305
+#: src/plugins/battery/valent-battery-plugin.c:293
 #, c-format
 msgid "%s: Battery Low"
 msgstr ""
@@ -511,16 +540,16 @@ msgstr ""
 msgid "Notify when the remote battery is full"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:15
-#: src/plugins/battery/valent-battery-preferences.ui:39
+#: src/plugins/battery/valent-battery-preferences.ui:16
+#: src/plugins/battery/valent-battery-preferences.ui:42
 msgid "Level Threshold"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:34
+#: src/plugins/battery/valent-battery-preferences.ui:36
 msgid "Low Battery Notification"
 msgstr ""
 
-#: src/plugins/battery/valent-battery-preferences.ui:35
+#: src/plugins/battery/valent-battery-preferences.ui:37
 msgid "Notify when the remote battery is low"
 msgstr ""
 
@@ -536,11 +565,11 @@ msgstr ""
 msgid "Copy changes to the local clipboard"
 msgstr ""
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:22
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
 msgid "Local Clipboard"
 msgstr ""
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:24
 msgid "Report changes to the remote device"
 msgstr ""
 
@@ -553,34 +582,34 @@ msgid "Monitor mobile connectivity status"
 msgstr ""
 
 #. TRANSLATORS: When the mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:173
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:162
 msgid "Mobile Network"
 msgstr ""
 
 #. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:175
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:164
 #, c-format
 msgid "Signal Strength %f%%"
 msgstr ""
 
 #. TRANSLATORS: When no mobile service is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:181
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:188
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:170
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:177
 msgid "No Service"
 msgstr ""
 
 #. TRANSLATORS: When no mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:183
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
 msgid "No mobile network service"
 msgstr ""
 
 #. TRANSLATORS: When the device is missing a SIM card
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:190
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:179
 msgid "No SIM"
 msgstr ""
 
 #. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:321
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:310
 #, c-format
 msgid "%s: %s"
 msgstr ""
@@ -589,15 +618,15 @@ msgstr ""
 msgid "Local Connectivity"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:11
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12
 msgid "Send updates to the remote device"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:22
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
 msgid "Remote Connectivity"
 msgstr ""
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:24
 msgid "Notify if the remote device loses connectivity"
 msgstr ""
 
@@ -613,11 +642,11 @@ msgstr ""
 msgid "Import contacts from the remote device"
 msgstr ""
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:22
+#: src/plugins/contacts/valent-contacts-preferences.ui:23
 msgid "Local Contacts"
 msgstr ""
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:23
+#: src/plugins/contacts/valent-contacts-preferences.ui:24
 msgid "Share contacts with the remote device"
 msgstr ""
 
@@ -686,52 +715,12 @@ msgstr ""
 msgid "Control the mouse and keyboard"
 msgstr ""
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:579
-msgid "Remote Input"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:8
-msgid "Input Remote"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:142
-msgid "Drag one finger to move"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:151
-msgid "Drag two fingers to scroll"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:160
-msgid "Tap one finger to click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:170
-msgid "Tap two fingers to right click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:179
-msgid "Tap three fingers to middle click"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:188
-msgid "Hold one finger to grab"
-msgstr ""
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:198
-msgid "Tap one finger to ungrab"
-msgstr ""
-
 #: src/plugins/mpris/mpris.plugin.desktop.in:7
 msgid "MPRIS"
 msgstr ""
 
 #: src/plugins/mpris/mpris.plugin.desktop.in:8
 msgid "Share control of MPRISv2 players"
-msgstr ""
-
-#: src/plugins/mpris/valent-mpris-plugin.c:484
-msgid "Unknown"
 msgstr ""
 
 #: src/plugins/notification/notification.plugin.desktop.in:8
@@ -754,6 +743,7 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:150
 #: src/plugins/share/valent-share-text-dialog.ui:53
+#: src/plugins/sms/valent-sms-window.ui:352
 msgid "Close"
 msgstr ""
 
@@ -769,27 +759,27 @@ msgstr ""
 msgid "Forward notifications to the remote device"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:15
+#: src/plugins/notification/valent-notification-preferences.ui:16
 msgid "Intelligent Sync"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:16
+#: src/plugins/notification/valent-notification-preferences.ui:17
 msgid "Notifications follow the active device"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:28
+#: src/plugins/notification/valent-notification-preferences.ui:30
 msgid "Filter by Application"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:64
+#: src/plugins/notification/valent-notification-preferences.ui:67
 msgid "Applications"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:85
+#: src/plugins/notification/valent-notification-preferences.ui:88
 msgid "Search"
 msgstr ""
 
-#: src/plugins/notification/valent-notification-preferences.ui:132
+#: src/plugins/notification/valent-notification-preferences.ui:135
 msgid "No Applications"
 msgstr ""
 
@@ -891,7 +881,7 @@ msgid "Execute commands remotely"
 msgstr ""
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#: src/plugins/runcommand/valent-runcommand-preferences.c:85
 msgid "Edit Command"
 msgstr ""
 
@@ -956,15 +946,15 @@ msgstr ""
 msgid "Mount shared folders when the device connects"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:22
+#: src/plugins/sftp/valent-sftp-preferences.ui:23
 msgid "Local Files"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:23
+#: src/plugins/sftp/valent-sftp-preferences.ui:24
 msgid "Share local files and directories"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:27
+#: src/plugins/sftp/valent-sftp-preferences.ui:29
 msgid "Port"
 msgstr ""
 
@@ -1091,7 +1081,7 @@ msgstr ""
 msgid "Searching…"
 msgstr ""
 
-#: src/plugins/share/valent-share-target-chooser.ui:127
+#: src/plugins/share/valent-share-target-chooser.ui:128
 msgid "Always use this device"
 msgstr ""
 
@@ -1265,7 +1255,7 @@ msgid "Incoming call"
 msgstr ""
 
 #: src/plugins/telephony/valent-telephony-plugin.c:311
-#: src/plugins/telephony/valent-telephony-preferences.ui:79
+#: src/plugins/telephony/valent-telephony-preferences.ui:86
 msgid "Mute"
 msgstr ""
 
@@ -1281,28 +1271,28 @@ msgstr ""
 msgid "What to do when the phone rings"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:24
-#: src/plugins/telephony/valent-telephony-preferences.ui:63
+#: src/plugins/telephony/valent-telephony-preferences.ui:26
+#: src/plugins/telephony/valent-telephony-preferences.ui:69
 msgid "Pause Media"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:39
+#: src/plugins/telephony/valent-telephony-preferences.ui:42
 msgid "Ongoing Calls"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:40
+#: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "What to do when the phone is answered"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:52
+#: src/plugins/telephony/valent-telephony-preferences.ui:57
 msgid "Mute Microphone"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:77
+#: src/plugins/telephony/valent-telephony-preferences.ui:84
 msgid "Nothing"
 msgstr ""
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:78
+#: src/plugins/telephony/valent-telephony-preferences.ui:85
 msgid "Lower"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2023-06-03 12:35-0700\n"
+"POT-Creation-Date: 2023-07-04 17:27-0700\n"
 "PO-Revision-Date: 2023-07-03 19:05+0800\n"
 "Last-Translator: sky96111 <sky96111@outlook.com>\n"
 "Language-Team: Chinese Simplified\n"
@@ -46,7 +46,7 @@ msgstr "插件是否已启用。"
 #: data/metainfo/ca.andyholmes.Valent.metainfo.xml.in.in:11
 #: data/ca.andyholmes.Valent.desktop.in.in:3
 #: src/libvalent/ui/valent-preferences-window.ui:12
-#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:39
+#: src/libvalent/ui/valent-window.c:336 src/libvalent/ui/valent-window.ui:51
 msgid "Valent"
 msgstr ""
 
@@ -114,55 +114,58 @@ msgid "Pairing request from %s"
 msgstr "来自 %s 的配对请求"
 
 #: src/libvalent/device/valent-device.c:523
-#: src/libvalent/ui/valent-device-page.ui:143
+#: src/libvalent/ui/valent-device-page.ui:161
 msgid "Reject"
 msgstr "拒绝"
 
 #: src/libvalent/device/valent-device.c:529
-#: src/libvalent/ui/valent-device-page.ui:156
+#: src/libvalent/ui/valent-device-page.ui:174
 msgid "Accept"
 msgstr "接受"
 
 #: src/libvalent/ui/valent-device-page.c:175
-#: src/libvalent/ui/valent-device-page.ui:113
+#: src/libvalent/ui/valent-device-page.ui:131
 msgid "Unavailable"
 msgstr "不可用"
 
-#: src/libvalent/ui/valent-device-page.ui:21
+#: src/libvalent/ui/valent-device-page.ui:38
 #: src/libvalent/ui/valent-media-remote.ui:239
 #: src/libvalent/ui/valent-menu-list.c:664
 #: src/plugins/presenter/valent-presenter-remote.ui:126
 msgid "Previous"
 msgstr "上一首"
 
-#: src/libvalent/ui/valent-device-page.ui:31
+#: src/libvalent/ui/valent-device-page.ui:49
 msgid "Device Menu"
 msgstr "设备菜单"
 
-#: src/libvalent/ui/valent-device-page.ui:105
+#: src/libvalent/ui/valent-device-page.ui:123
 msgid "Verification Key"
 msgstr "验证密钥"
 
-#: src/libvalent/ui/valent-device-page.ui:134
+#: src/libvalent/ui/valent-device-page.ui:152
 msgid "Request Pairing"
 msgstr "请求配对"
 
-#: src/libvalent/ui/valent-device-page.ui:229
+#: src/libvalent/ui/valent-device-page.ui:247
 #: src/libvalent/ui/valent-window.c:191
 msgid "Disconnected"
 msgstr "已断开连接"
 
-#: src/libvalent/ui/valent-device-page.ui:259
-msgid "_Preferences"
-msgstr ""
+#: src/libvalent/ui/valent-device-page.ui:277
+#: src/libvalent/ui/valent-window.ui:135
+msgid "Preferences"
+msgstr "首选项"
 
-#: src/libvalent/ui/valent-device-page.ui:265
-msgid "P_air"
-msgstr ""
+#: src/libvalent/ui/valent-device-page.ui:283
+#, fuzzy
+msgid "Pair"
+msgstr "已配对"
 
-#: src/libvalent/ui/valent-device-page.ui:270
-msgid "_Unpair"
-msgstr ""
+#: src/libvalent/ui/valent-device-page.ui:288
+#, fuzzy
+msgid "Unpair"
+msgstr "未配对"
 
 #: src/libvalent/ui/valent-device-preferences-window.ui:15
 msgid "Status"
@@ -188,6 +191,39 @@ msgstr "插件"
 #: src/libvalent/ui/valent-preferences-window.ui:39
 msgid "No Plugins"
 msgstr "无插件"
+
+#: src/libvalent/ui/valent-input-remote.ui:8
+#: src/libvalent/ui/valent-window.ui:125
+msgid "Input Remote"
+msgstr "远程输入"
+
+#: src/libvalent/ui/valent-input-remote.ui:153
+msgid "Drag one finger to move"
+msgstr "单指拖动以移动"
+
+#: src/libvalent/ui/valent-input-remote.ui:162
+msgid "Drag two fingers to scroll"
+msgstr "双指拖动以滚动"
+
+#: src/libvalent/ui/valent-input-remote.ui:171
+msgid "Tap one finger to click"
+msgstr "单指轻触以左键单击"
+
+#: src/libvalent/ui/valent-input-remote.ui:181
+msgid "Tap two fingers to right click"
+msgstr "双指轻触以右键单击"
+
+#: src/libvalent/ui/valent-input-remote.ui:190
+msgid "Tap three fingers to middle click"
+msgstr "三指轻触以中键单击"
+
+#: src/libvalent/ui/valent-input-remote.ui:199
+msgid "Hold one finger to grab"
+msgstr "单指按住以拖动"
+
+#: src/libvalent/ui/valent-input-remote.ui:209
+msgid "Tap one finger to ungrab"
+msgstr "再单指轻触以松开"
 
 #: src/libvalent/ui/valent-media-remote.c:250
 #: src/libvalent/ui/valent-media-remote.c:252
@@ -219,13 +255,13 @@ msgid "Play"
 msgstr "播放"
 
 #: src/libvalent/ui/valent-media-remote.ui:8
-#: src/libvalent/ui/valent-window.ui:113
+#: src/libvalent/ui/valent-window.ui:129
 msgid "Media Remote"
 msgstr "远程媒体控制"
 
 #: src/libvalent/ui/valent-media-remote.ui:219
-#: src/plugins/telephony/valent-telephony-preferences.ui:15
-#: src/plugins/telephony/valent-telephony-preferences.ui:43
+#: src/plugins/telephony/valent-telephony-preferences.ui:16
+#: src/plugins/telephony/valent-telephony-preferences.ui:47
 msgid "Volume"
 msgstr "音量"
 
@@ -259,44 +295,44 @@ msgstr "随机"
 msgid "No Actions"
 msgstr "无动作"
 
-#: src/libvalent/ui/valent-preferences-window.c:375
+#: src/libvalent/ui/valent-preferences-window.c:377
 msgid "Global"
 msgstr "全局"
 
-#: src/libvalent/ui/valent-preferences-window.c:382
+#: src/libvalent/ui/valent-preferences-window.c:384
 msgid "Device Connections"
 msgstr "设备连接"
 
-#: src/libvalent/ui/valent-preferences-window.c:389
+#: src/libvalent/ui/valent-preferences-window.c:391
 #: src/plugins/clipboard/clipboard.plugin.desktop.in:7
 msgid "Clipboard"
 msgstr "剪切板"
 
-#: src/libvalent/ui/valent-preferences-window.c:396
+#: src/libvalent/ui/valent-preferences-window.c:398
 #: src/plugins/contacts/contacts.plugin.desktop.in:7
 #: src/plugins/sms/valent-contact-row.c:253
 msgid "Contacts"
 msgstr "联系人"
 
-#: src/libvalent/ui/valent-preferences-window.c:403
+#: src/libvalent/ui/valent-preferences-window.c:405
 msgid "Mouse and Keyboard"
 msgstr "鼠标和键盘"
 
-#: src/libvalent/ui/valent-preferences-window.c:410
+#: src/libvalent/ui/valent-preferences-window.c:412
 msgid "Media Players"
 msgstr "媒体播放器"
 
-#: src/libvalent/ui/valent-preferences-window.c:417
+#: src/libvalent/ui/valent-preferences-window.c:419
 msgid "Volume Control"
 msgstr "音量控制"
 
-#: src/libvalent/ui/valent-preferences-window.c:424
+#: src/libvalent/ui/valent-preferences-window.c:426
 #: src/plugins/notification/notification.plugin.desktop.in:7
-#: src/plugins/notification/valent-notification-preferences.ui:63
+#: src/plugins/notification/valent-notification-preferences.ui:66
 msgid "Notifications"
 msgstr "通知"
 
-#: src/libvalent/ui/valent-preferences-window.c:431
+#: src/libvalent/ui/valent-preferences-window.c:433
 msgid "Session Manager"
 msgstr "会话管理"
 
@@ -425,33 +461,28 @@ msgstr "sky96111"
 msgid "Sponsors"
 msgstr "赞助者"
 
-#: src/libvalent/ui/valent-window.ui:46 src/libvalent/ui/valent-window.ui:49
+#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
 msgid "Refresh"
 msgstr "刷新"
 
-#: src/libvalent/ui/valent-window.ui:58 src/libvalent/ui/valent-window.ui:61
+#: src/libvalent/ui/valent-window.ui:70 src/libvalent/ui/valent-window.ui:73
 msgid "Main Menu"
 msgstr "主菜单"
 
-#: src/libvalent/ui/valent-window.ui:79
+#: src/libvalent/ui/valent-window.ui:91
 #: src/plugins/share/valent-share-target-chooser.ui:68
 msgid "Devices"
 msgstr "设备"
 
-#: src/libvalent/ui/valent-window.ui:87
+#: src/libvalent/ui/valent-window.ui:99
 msgid "Searching for devices…"
 msgstr "正在搜索设备…"
 
-#: src/libvalent/ui/valent-window.ui:119
-msgid "Preferences"
-msgstr "首选项"
-
-#: src/libvalent/ui/valent-window.ui:123
-#: src/plugins/sms/valent-sms-window.ui:350
+#: src/libvalent/ui/valent-window.ui:139
 msgid "About Valent"
 msgstr "关于"
 
-#: src/libvalent/ui/valent-window.ui:129
+#: src/libvalent/ui/valent-window.ui:145
 msgid "Quit"
 msgstr "退出"
 
@@ -482,24 +513,24 @@ msgstr "%g%% (充满还需 %d∶%02d)"
 
 #. TRANSLATORS: This is <percentage> (<hours>:<minutes> Remaining)
 #: src/plugins/battery/valent-battery-gadget.c:99
-#: src/plugins/battery/valent-battery-plugin.c:307
+#: src/plugins/battery/valent-battery-plugin.c:295
 #, c-format
 msgid "%g%% (%d∶%02d Remaining)"
 msgstr "%g%% (剩余 %d∶%02d)"
 
 #. TRANSLATORS: This is <device name>: Fully Charged
-#: src/plugins/battery/valent-battery-plugin.c:276
+#: src/plugins/battery/valent-battery-plugin.c:264
 #, c-format
 msgid "%s: Fully Charged"
 msgstr "%s: 电量满"
 
 #. TRANSLATORS: When the battery level is at maximum
-#: src/plugins/battery/valent-battery-plugin.c:278
+#: src/plugins/battery/valent-battery-plugin.c:266
 msgid "Battery Fully Charged"
 msgstr "电池电量满"
 
 #. TRANSLATORS: This is <device name>: Battery Low
-#: src/plugins/battery/valent-battery-plugin.c:305
+#: src/plugins/battery/valent-battery-plugin.c:293
 #, c-format
 msgid "%s: Battery Low"
 msgstr "%s: 电量低"
@@ -512,16 +543,16 @@ msgstr "电量充满通知"
 msgid "Notify when the remote battery is full"
 msgstr "远程设备电量充满时通知"
 
-#: src/plugins/battery/valent-battery-preferences.ui:15
-#: src/plugins/battery/valent-battery-preferences.ui:39
+#: src/plugins/battery/valent-battery-preferences.ui:16
+#: src/plugins/battery/valent-battery-preferences.ui:42
 msgid "Level Threshold"
 msgstr "提醒阈值"
 
-#: src/plugins/battery/valent-battery-preferences.ui:34
+#: src/plugins/battery/valent-battery-preferences.ui:36
 msgid "Low Battery Notification"
 msgstr "低电量通知"
 
-#: src/plugins/battery/valent-battery-preferences.ui:35
+#: src/plugins/battery/valent-battery-preferences.ui:37
 msgid "Notify when the remote battery is low"
 msgstr "远程设备电量不足时通知"
 
@@ -537,11 +568,11 @@ msgstr "远程剪贴板"
 msgid "Copy changes to the local clipboard"
 msgstr "将远程设备剪切板变化同步到本地"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:22
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
 msgid "Local Clipboard"
 msgstr "本地剪贴板"
 
-#: src/plugins/clipboard/valent-clipboard-preferences.ui:23
+#: src/plugins/clipboard/valent-clipboard-preferences.ui:24
 msgid "Report changes to the remote device"
 msgstr "向远程设备报告本地剪切板变化"
 
@@ -554,34 +585,34 @@ msgid "Monitor mobile connectivity status"
 msgstr "监测手机信号状态"
 
 #. TRANSLATORS: When the mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:173
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:162
 msgid "Mobile Network"
 msgstr "移动网络"
 
 #. TRANSLATORS: The mobile network signal strength (e.g. "Signal Strength (25%)")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:175
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:164
 #, c-format
 msgid "Signal Strength %f%%"
 msgstr "信号强度 %f%%"
 
 #. TRANSLATORS: When no mobile service is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:181
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:188
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:170
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:177
 msgid "No Service"
 msgstr "无服务"
 
 #. TRANSLATORS: When no mobile network signal is available
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:183
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:172
 msgid "No mobile network service"
 msgstr "无移动网络服务"
 
 #. TRANSLATORS: When the device is missing a SIM card
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:190
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:179
 msgid "No SIM"
 msgstr "无SIM卡"
 
 #. TRANSLATORS: The connectivity notification title (e.g. "PinePhone: No Service")
-#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:321
+#: src/plugins/connectivity_report/valent-connectivity_report-plugin.c:310
 #, c-format
 msgid "%s: %s"
 msgstr ""
@@ -590,15 +621,15 @@ msgstr ""
 msgid "Local Connectivity"
 msgstr "本机连接性"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:11
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:12
 msgid "Send updates to the remote device"
 msgstr "向远程设备发送连接性更新信息"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:22
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
 msgid "Remote Connectivity"
 msgstr "远程设备连接性"
 
-#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:23
+#: src/plugins/connectivity_report/valent-connectivity_report-preferences.ui:24
 msgid "Notify if the remote device loses connectivity"
 msgstr "远程设备失去连接时发出通知"
 
@@ -614,11 +645,11 @@ msgstr "远程联系人"
 msgid "Import contacts from the remote device"
 msgstr "从远程设备导入联系人"
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:22
+#: src/plugins/contacts/valent-contacts-preferences.ui:23
 msgid "Local Contacts"
 msgstr "本地联系人"
 
-#: src/plugins/contacts/valent-contacts-preferences.ui:23
+#: src/plugins/contacts/valent-contacts-preferences.ui:24
 msgid "Share contacts with the remote device"
 msgstr "与远程设备共享联系人"
 
@@ -687,42 +718,6 @@ msgstr "键鼠"
 msgid "Control the mouse and keyboard"
 msgstr "控制鼠标和键盘"
 
-#: src/plugins/mousepad/valent-mousepad-plugin.c:579
-msgid "Remote Input"
-msgstr "远程输入"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:8
-msgid "Input Remote"
-msgstr "远程输入"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:142
-msgid "Drag one finger to move"
-msgstr "单指拖动以移动"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:151
-msgid "Drag two fingers to scroll"
-msgstr "双指拖动以滚动"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:160
-msgid "Tap one finger to click"
-msgstr "单指轻触以左键单击"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:170
-msgid "Tap two fingers to right click"
-msgstr "双指轻触以右键单击"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:179
-msgid "Tap three fingers to middle click"
-msgstr "三指轻触以中键单击"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:188
-msgid "Hold one finger to grab"
-msgstr "单指按住以拖动"
-
-#: src/plugins/mousepad/valent-mousepad-remote.ui:198
-msgid "Tap one finger to ungrab"
-msgstr "再单指轻触以松开"
-
 #: src/plugins/mpris/mpris.plugin.desktop.in:7
 msgid "MPRIS"
 msgstr "MPRIS"
@@ -730,10 +725,6 @@ msgstr "MPRIS"
 #: src/plugins/mpris/mpris.plugin.desktop.in:8
 msgid "Share control of MPRISv2 players"
 msgstr "共享 MPRISv2 播放器的控制权"
-
-#: src/plugins/mpris/valent-mpris-plugin.c:484
-msgid "Unknown"
-msgstr "未知"
 
 #: src/plugins/notification/notification.plugin.desktop.in:8
 msgid "Sync notifications"
@@ -755,6 +746,7 @@ msgstr ""
 
 #: src/plugins/notification/valent-notification-dialog.ui:150
 #: src/plugins/share/valent-share-text-dialog.ui:53
+#: src/plugins/sms/valent-sms-window.ui:352
 msgid "Close"
 msgstr "关闭"
 
@@ -770,27 +762,27 @@ msgstr "本地通知"
 msgid "Forward notifications to the remote device"
 msgstr "转发通知到远程设备"
 
-#: src/plugins/notification/valent-notification-preferences.ui:15
+#: src/plugins/notification/valent-notification-preferences.ui:16
 msgid "Intelligent Sync"
 msgstr "智能同步"
 
-#: src/plugins/notification/valent-notification-preferences.ui:16
+#: src/plugins/notification/valent-notification-preferences.ui:17
 msgid "Notifications follow the active device"
 msgstr "通知跟随活动的设备"
 
-#: src/plugins/notification/valent-notification-preferences.ui:28
+#: src/plugins/notification/valent-notification-preferences.ui:30
 msgid "Filter by Application"
 msgstr "按应用过滤"
 
-#: src/plugins/notification/valent-notification-preferences.ui:64
+#: src/plugins/notification/valent-notification-preferences.ui:67
 msgid "Applications"
 msgstr "应用"
 
-#: src/plugins/notification/valent-notification-preferences.ui:85
+#: src/plugins/notification/valent-notification-preferences.ui:88
 msgid "Search"
 msgstr "搜索"
 
-#: src/plugins/notification/valent-notification-preferences.ui:132
+#: src/plugins/notification/valent-notification-preferences.ui:135
 msgid "No Applications"
 msgstr "无应用"
 
@@ -892,7 +884,7 @@ msgid "Execute commands remotely"
 msgstr "远程设备执行命令"
 
 #: src/plugins/runcommand/valent-runcommand-editor.ui:8
-#: src/plugins/runcommand/valent-runcommand-preferences.c:84
+#: src/plugins/runcommand/valent-runcommand-preferences.c:85
 msgid "Edit Command"
 msgstr "编辑命令"
 
@@ -957,15 +949,15 @@ msgstr "自动挂载"
 msgid "Mount shared folders when the device connects"
 msgstr "设备连接时挂载共享文件夹"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:22
+#: src/plugins/sftp/valent-sftp-preferences.ui:23
 msgid "Local Files"
 msgstr "本地文件"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:23
+#: src/plugins/sftp/valent-sftp-preferences.ui:24
 msgid "Share local files and directories"
 msgstr "共享本地文件和目录"
 
-#: src/plugins/sftp/valent-sftp-preferences.ui:27
+#: src/plugins/sftp/valent-sftp-preferences.ui:29
 msgid "Port"
 msgstr "端口"
 
@@ -1088,7 +1080,7 @@ msgstr "选择一个设备来分享所选文件。"
 msgid "Searching…"
 msgstr "搜索中..."
 
-#: src/plugins/share/valent-share-target-chooser.ui:127
+#: src/plugins/share/valent-share-target-chooser.ui:128
 msgid "Always use this device"
 msgstr "始终使用这个装置"
 
@@ -1259,7 +1251,7 @@ msgid "Incoming call"
 msgstr "来电"
 
 #: src/plugins/telephony/valent-telephony-plugin.c:311
-#: src/plugins/telephony/valent-telephony-preferences.ui:79
+#: src/plugins/telephony/valent-telephony-preferences.ui:86
 msgid "Mute"
 msgstr "静音"
 
@@ -1275,28 +1267,28 @@ msgstr "来电"
 msgid "What to do when the phone rings"
 msgstr "当电话响起时"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:24
-#: src/plugins/telephony/valent-telephony-preferences.ui:63
+#: src/plugins/telephony/valent-telephony-preferences.ui:26
+#: src/plugins/telephony/valent-telephony-preferences.ui:69
 msgid "Pause Media"
 msgstr "暂停媒体"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:39
+#: src/plugins/telephony/valent-telephony-preferences.ui:42
 msgid "Ongoing Calls"
 msgstr "正在进行呼叫"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:40
+#: src/plugins/telephony/valent-telephony-preferences.ui:43
 msgid "What to do when the phone is answered"
 msgstr "当电话接通时"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:52
+#: src/plugins/telephony/valent-telephony-preferences.ui:57
 msgid "Mute Microphone"
 msgstr "麦克风静音"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:77
+#: src/plugins/telephony/valent-telephony-preferences.ui:84
 msgid "Nothing"
 msgstr "无"
 
-#: src/plugins/telephony/valent-telephony-preferences.ui:78
+#: src/plugins/telephony/valent-telephony-preferences.ui:85
 msgid "Lower"
 msgstr "降低"
 
@@ -1311,3 +1303,9 @@ msgstr "桌面环境"
 #: src/plugins/xdp/xdp.plugin.desktop.in:8
 msgid "Integration with desktop portals"
 msgstr "与桌面环境集成"
+
+#~ msgid "Remote Input"
+#~ msgstr "远程输入"
+
+#~ msgid "Unknown"
+#~ msgstr "未知"

--- a/src/libvalent/ui/valent-device-page.ui
+++ b/src/libvalent/ui/valent-device-page.ui
@@ -7,6 +7,23 @@
   <template class="ValentDevicePage" parent="GtkBox">
     <property name="orientation">vertical</property>
     <child>
+      <object class="GtkShortcutController">
+        <property name="scope">local</property>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">&lt;Control&gt;comma</property>
+            <property name="action">action(page.preferences)</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">Escape</property>
+            <property name="action">action(win.previous)</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
       <object class="GtkHeaderBar">
         <property name="title-widget">
           <object class="AdwWindowTitle" id="title"/>
@@ -26,6 +43,7 @@
           <object class="GtkMenuButton">
             <property name="valign">center</property>
             <property name="menu-model">secondary_menu</property>
+            <property name="primary">1</property>
             <property name="icon-name">view-more-symbolic</property>
             <accessibility>
               <property name="label" translatable="yes">Device Menu</property>
@@ -256,18 +274,18 @@
   <menu id="secondary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">_Preferences</attribute>
+        <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">page.preferences</attribute>
       </item>
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">P_air</attribute>
+        <attribute name="label" translatable="yes">Pair</attribute>
         <attribute name="action">page.pair</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_Unpair</attribute>
+        <attribute name="label" translatable="yes">Unpair</attribute>
         <attribute name="action">page.unpair</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>

--- a/src/libvalent/ui/valent-window.ui
+++ b/src/libvalent/ui/valent-window.ui
@@ -21,6 +21,18 @@
             <property name="action">action(win.refresh)</property>
           </object>
         </child>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">&lt;Control&gt;w</property>
+            <property name="action">action(window.close)</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcut">
+            <property name="trigger">&lt;Control&gt;q</property>
+            <property name="action">action(app.quit)</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/src/plugins/battery/meson.build
+++ b/src/plugins/battery/meson.build
@@ -19,6 +19,7 @@ plugin_battery_include_directories = [include_directories('.')]
 
 # Resources
 plugin_battery_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'battery.plugin.desktop.in',
   output: 'battery.plugin',
   po_dir: po_dir,

--- a/src/plugins/bluez/meson.build
+++ b/src/plugins/bluez/meson.build
@@ -23,6 +23,7 @@ plugin_bluez_include_directories = [include_directories('.')]
 
 # Resources
 plugin_bluez_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'bluez.plugin.desktop.in',
   output: 'bluez.plugin',
   po_dir: po_dir,

--- a/src/plugins/clipboard/meson.build
+++ b/src/plugins/clipboard/meson.build
@@ -17,6 +17,7 @@ plugin_clipboard_include_directories = [include_directories('.')]
 
 # Resources
 plugin_clipboard_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'clipboard.plugin.desktop.in',
   output: 'clipboard.plugin',
   po_dir: po_dir,

--- a/src/plugins/connectivity_report/meson.build
+++ b/src/plugins/connectivity_report/meson.build
@@ -19,6 +19,7 @@ plugin_connectivity_report_include_directories = [include_directories('.')]
 
 # Resources
 plugin_connectivity_report_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'connectivity_report.plugin.desktop.in',
   output: 'connectivity_report.plugin',
   po_dir: po_dir,

--- a/src/plugins/contacts/meson.build
+++ b/src/plugins/contacts/meson.build
@@ -17,6 +17,7 @@ plugin_contacts_include_directories = [include_directories('.')]
 
 # Resources
 plugin_contacts_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'contacts.plugin.desktop.in',
   output: 'contacts.plugin',
   po_dir: po_dir,

--- a/src/plugins/eds/meson.build
+++ b/src/plugins/eds/meson.build
@@ -20,6 +20,7 @@ plugin_eds_include_directories = include_directories('.')
 
 # Resources
 plugin_eds_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'eds.plugin.desktop.in',
   output: 'eds.plugin',
   po_dir: po_dir,

--- a/src/plugins/fdo/meson.build
+++ b/src/plugins/fdo/meson.build
@@ -26,6 +26,7 @@ plugin_fdo_include_directories = [include_directories('.')]
 
 # Resources
 plugin_fdo_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'fdo.plugin.desktop.in',
   output: 'fdo.plugin',
   po_dir: po_dir,

--- a/src/plugins/findmyphone/meson.build
+++ b/src/plugins/findmyphone/meson.build
@@ -26,6 +26,7 @@ plugin_findmyphone_include_directories = [include_directories('.')]
 
 # Resources
 plugin_findmyphone_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'findmyphone.plugin.desktop.in',
   output: 'findmyphone.plugin',
   po_dir: po_dir,

--- a/src/plugins/gnome/meson.build
+++ b/src/plugins/gnome/meson.build
@@ -17,6 +17,7 @@ plugin_gnome_include_directories = [include_directories('.')]
 
 # Resources
 plugin_gnome_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'gnome.plugin.desktop.in',
   output: 'gnome.plugin',
   po_dir: po_dir,

--- a/src/plugins/gtk/meson.build
+++ b/src/plugins/gtk/meson.build
@@ -19,6 +19,7 @@ plugin_gtk_include_directories = [include_directories('.')]
 
 # Resources
 plugin_gtk_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'gtk.plugin.desktop.in',
   output: 'gtk.plugin',
   po_dir: po_dir,

--- a/src/plugins/lan/meson.build
+++ b/src/plugins/lan/meson.build
@@ -18,6 +18,7 @@ plugin_lan_include_directories = [include_directories('.')]
 
 # Resources
 plugin_lan_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'lan.plugin.desktop.in',
   output: 'lan.plugin',
   po_dir: po_dir,

--- a/src/plugins/lock/meson.build
+++ b/src/plugins/lock/meson.build
@@ -17,6 +17,7 @@ plugin_lock_include_directories = [include_directories('.')]
 
 # Resources
 plugin_lock_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'lock.plugin.desktop.in',
   output: 'lock.plugin',
   po_dir: po_dir,

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -6,6 +6,12 @@ plugins_c_args = []
 plugins_link_args = []
 plugins_static = []
 
+# NOTE: Pass to `i18n.merge_file()` for `.plugin` files
+plugins_po_args = [
+    '--keyword=Name',
+    '--keyword=Description'
+]
+
 # Peas Plugins
 plugins = [
   'battery',

--- a/src/plugins/mousepad/meson.build
+++ b/src/plugins/mousepad/meson.build
@@ -17,6 +17,7 @@ plugin_mousepad_include_directories = [include_directories('.')]
 
 # Resources
 plugin_mousepad_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'mousepad.plugin.desktop.in',
   output: 'mousepad.plugin',
   po_dir: po_dir,

--- a/src/plugins/mpris/meson.build
+++ b/src/plugins/mpris/meson.build
@@ -21,6 +21,7 @@ plugin_mpris_include_directories = [include_directories('.')]
 
 # Resources
 plugin_mpris_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'mpris.plugin.desktop.in',
   output: 'mpris.plugin',
   po_dir: po_dir,

--- a/src/plugins/notification/meson.build
+++ b/src/plugins/notification/meson.build
@@ -19,6 +19,7 @@ plugin_notification_include_directories = [include_directories('.')]
 
 # Resources
 plugin_notification_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'notification.plugin.desktop.in',
   output: 'notification.plugin',
   po_dir: po_dir,

--- a/src/plugins/photo/meson.build
+++ b/src/plugins/photo/meson.build
@@ -24,6 +24,7 @@ plugin_photo_include_directories = [include_directories('.')]
 
 # Resources
 plugin_photo_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'photo.plugin.desktop.in',
   output: 'photo.plugin',
   po_dir: po_dir,

--- a/src/plugins/ping/meson.build
+++ b/src/plugins/ping/meson.build
@@ -16,6 +16,7 @@ plugin_ping_include_directories = [include_directories('.')]
 
 # Resources
 plugin_ping_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'ping.plugin.desktop.in',
   output: 'ping.plugin',
   po_dir: po_dir,

--- a/src/plugins/presenter/meson.build
+++ b/src/plugins/presenter/meson.build
@@ -17,6 +17,7 @@ plugin_presenter_include_directories = [include_directories('.')]
 
 # Resources
 plugin_presenter_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'presenter.plugin.desktop.in',
   output: 'presenter.plugin',
   po_dir: po_dir,

--- a/src/plugins/pulseaudio/meson.build
+++ b/src/plugins/pulseaudio/meson.build
@@ -33,6 +33,7 @@ plugin_pulseaudio_include_directories = [include_directories('.')]
 
 # Resources
 plugin_pulseaudio_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'pulseaudio.plugin.desktop.in',
   output: 'pulseaudio.plugin',
   po_dir: po_dir,

--- a/src/plugins/runcommand/meson.build
+++ b/src/plugins/runcommand/meson.build
@@ -19,6 +19,7 @@ plugin_runcommand_include_directories = [include_directories('.')]
 
 # Resources
 plugin_runcommand_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'runcommand.plugin.desktop.in',
   output: 'runcommand.plugin',
   po_dir: po_dir,

--- a/src/plugins/sftp/meson.build
+++ b/src/plugins/sftp/meson.build
@@ -17,6 +17,7 @@ plugin_sftp_include_directories = [include_directories('.')]
 
 # Resources
 plugin_sftp_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'sftp.plugin.desktop.in',
   output: 'sftp.plugin',
   po_dir: po_dir,

--- a/src/plugins/share/meson.build
+++ b/src/plugins/share/meson.build
@@ -22,6 +22,7 @@ plugin_share_include_directories = [include_directories('.')]
 
 # Resources
 plugin_share_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'share.plugin.desktop.in',
   output: 'share.plugin',
   po_dir: po_dir,

--- a/src/plugins/sms/meson.build
+++ b/src/plugins/sms/meson.build
@@ -29,6 +29,7 @@ plugin_sms_include_directories = [include_directories('.')]
 
 # Resources
 plugin_sms_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'sms.plugin.desktop.in',
   output: 'sms.plugin',
   po_dir: po_dir,

--- a/src/plugins/sms/valent-sms-window.ui
+++ b/src/plugins/sms/valent-sms-window.ui
@@ -346,9 +346,11 @@
         <attribute name="action">app.wiki</attribute>
         <attribute name="target">Help</attribute>
       </item>
+    </section>
+    <section>
       <item>
-        <attribute name="label" translatable="yes">About Valent</attribute>
-        <attribute name="action">app.about</attribute>
+        <attribute name="label" translatable="yes">Close</attribute>
+        <attribute name="action">window.close</attribute>
       </item>
     </section>
   </menu>

--- a/src/plugins/systemvolume/meson.build
+++ b/src/plugins/systemvolume/meson.build
@@ -16,6 +16,7 @@ plugin_systemvolume_include_directories = [include_directories('.')]
 
 # Resources
 plugin_systemvolume_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'systemvolume.plugin.desktop.in',
   output: 'systemvolume.plugin',
   po_dir: po_dir,

--- a/src/plugins/telephony/meson.build
+++ b/src/plugins/telephony/meson.build
@@ -18,6 +18,7 @@ plugin_telephony_include_directories = [include_directories('.')]
 
 # Resources
 plugin_telephony_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'telephony.plugin.desktop.in',
   output: 'telephony.plugin',
   po_dir: po_dir,

--- a/src/plugins/xdp/meson.build
+++ b/src/plugins/xdp/meson.build
@@ -26,6 +26,7 @@ plugin_xdp_include_directories = [include_directories('.')]
 
 # Resources
 plugin_xdp_info = i18n.merge_file(
+    args: plugins_po_args,
    input: 'xdp.plugin.desktop.in',
   output: 'xdp.plugin',
   po_dir: po_dir,


### PR DESCRIPTION
Various translation fixes and related tweaks.

* [fix(translations): set proper args for `i18n.merge_file()`](https://github.com/andyholmes/valent/commit/fad1917e62d9f54689d34aed7d8ff56777c2231a)
* [fix(ui): remove keyboard mnemonics in menu, until revisited](https://github.com/andyholmes/valent/commit/90982b7731594073c16b06c703642f7d0d3e0b18)
* [chore(translations): update POT and PO files](https://github.com/andyholmes/valent/commit/307595ed799f95071619a115dc6a0e1d4dad31b9)

closes #518