### PR TITLE
test: various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           glob_pattern: "**/*.py"
+          pylint_rc: tests/extra/setup.cfg
 
       - name: Mypy
         if: ${{ always() }}

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -76,6 +76,7 @@ valent_battery_plugin_watch_battery (ValentBatteryPlugin *self,
                                "changed",
                                G_CALLBACK (on_battery_changed),
                                self, 0);
+      on_battery_changed (self->battery, self);
       self->battery_watch = TRUE;
     }
   else

--- a/tests/plugins/battery/mock_upower.py
+++ b/tests/plugins/battery/mock_upower.py
@@ -41,7 +41,10 @@ class UPowerTestFixture(dbusmock.DBusTestCase):
             '/org/freedesktop/UPower/devices/DisplayDevice',
             {
                 'IsPresent': dbus.Boolean(True, variant_level=1),
-                'Type': dbus.UInt32(2, variant_level=1)
+                'Percentage': dbus.Double(100.0, variant_level=1),
+                'State': dbus.UInt32(0, variant_level=1),
+                'Type': dbus.UInt32(2, variant_level=1),
+                'WarningLevel': dbus.UInt32(0, variant_level=1),
             })
 
     def tearDown(self) -> None:

--- a/tests/plugins/battery/test-battery.c
+++ b/tests/plugins/battery/test-battery.c
@@ -83,7 +83,7 @@ test_battery_proxy (void)
   valent_test_await_signal (battery, "changed");
 
   VALENT_TEST_CHECK ("Initial property state is empty");
-  g_assert_cmpint (valent_battery_current_charge (battery), ==, 0);
+  g_assert_cmpint (valent_battery_current_charge (battery), ==, 100);
   g_assert_false (valent_battery_is_charging (battery));
   g_assert_true (valent_battery_is_present (battery));
   g_assert_cmpuint (valent_battery_threshold_event (battery), ==, 0);


### PR DESCRIPTION
* fix(battery): always send the battery status at connect-time
* fix(battery): fix timeouts in `test-battery-plugin`
* fix(ci): add pylintrc to pre-test options