### PR TITLE
refactor(core): use a finalizer for `ValentObject`, like Builder

### DIFF
--- a/src/libvalent/core/valent-component.c
+++ b/src/libvalent/core/valent-component.c
@@ -397,6 +397,22 @@ valent_component_get_preferred (ValentComponent *self)
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_component_destroy (ValentObject *object)
+{
+  ValentComponent *self = VALENT_COMPONENT (object);
+  ValentComponentPrivate *priv = valent_component_get_instance_private (self);
+
+  g_signal_handlers_disconnect_by_func (priv->engine, on_load_plugin, self);
+  g_signal_handlers_disconnect_by_func (priv->engine, on_unload_plugin, self);
+  g_hash_table_remove_all (priv->plugins);
+
+  VALENT_OBJECT_CLASS (valent_component_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -444,19 +460,6 @@ valent_component_constructed (GObject *object)
                            0);
 
   G_OBJECT_CLASS (valent_component_parent_class)->constructed (object);
-}
-
-static void
-valent_component_dispose (GObject *object)
-{
-  ValentComponent *self = VALENT_COMPONENT (object);
-  ValentComponentPrivate *priv = valent_component_get_instance_private (self);
-
-  g_signal_handlers_disconnect_by_func (priv->engine, on_load_plugin, self);
-  g_signal_handlers_disconnect_by_func (priv->engine, on_unload_plugin, self);
-  g_hash_table_remove_all (priv->plugins);
-
-  G_OBJECT_CLASS (valent_component_parent_class)->dispose (object);
 }
 
 static void
@@ -525,12 +528,14 @@ static void
 valent_component_class_init (ValentComponentClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
   object_class->constructed = valent_component_constructed;
-  object_class->dispose = valent_component_dispose;
   object_class->finalize = valent_component_finalize;
   object_class->get_property = valent_component_get_property;
   object_class->set_property = valent_component_set_property;
+
+  vobject_class->destroy = valent_component_destroy;
 
   klass->bind_extension = valent_component_real_bind_extension;
   klass->unbind_extension = valent_component_real_unbind_extension;

--- a/src/libvalent/core/valent-extension.c
+++ b/src/libvalent/core/valent-extension.c
@@ -315,10 +315,10 @@ valent_extension_set_object (ValentExtension *self,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_extension_dispose (GObject *object)
+valent_extension_destroy (ValentObject *object)
 {
   ValentExtension *self = VALENT_EXTENSION (object);
   ValentExtensionPrivate *priv = valent_extension_get_instance_private (self);
@@ -337,9 +337,12 @@ valent_extension_dispose (GObject *object)
 
   valent_extension_plugin_state_changed (self, VALENT_PLUGIN_STATE_INACTIVE, NULL);
 
-  G_OBJECT_CLASS (valent_extension_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_extension_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_extension_finalize (GObject *object)
 {
@@ -423,11 +426,13 @@ static void
 valent_extension_class_init (ValentExtensionClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
-  object_class->dispose = valent_extension_dispose;
   object_class->finalize = valent_extension_finalize;
   object_class->get_property = valent_extension_get_property;
   object_class->set_property = valent_extension_set_property;
+
+  vobject_class->destroy = valent_extension_destroy;
 
   /**
    * ValentExtension:context: (getter get_context)

--- a/src/libvalent/input/valent-input.c
+++ b/src/libvalent/input/valent-input.c
@@ -160,18 +160,21 @@ valent_input_bind_preferred (ValentComponent *component,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_input_dispose (GObject *object)
+valent_input_destroy (ValentObject *object)
 {
   ValentInput *self = VALENT_INPUT (object);
 
   g_list_store_remove_all (G_LIST_STORE (self->exports));
 
-  G_OBJECT_CLASS (valent_input_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_input_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_input_finalize (GObject *object)
 {
@@ -188,10 +191,12 @@ static void
 valent_input_class_init (ValentInputClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentComponentClass *component_class = VALENT_COMPONENT_CLASS (klass);
 
-  object_class->dispose = valent_input_dispose;
   object_class->finalize = valent_input_finalize;
+
+  vobject_class->destroy = valent_input_destroy;
 
   component_class->bind_preferred = valent_input_bind_preferred;
 }

--- a/src/libvalent/media/valent-media.c
+++ b/src/libvalent/media/valent-media.c
@@ -198,18 +198,21 @@ valent_media_unbind_extension (ValentComponent *component,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_media_dispose (GObject *object)
+valent_media_destroy (ValentObject *object)
 {
   ValentMedia *self = VALENT_MEDIA (object);
 
   g_list_store_remove_all (G_LIST_STORE (self->exports));
 
-  G_OBJECT_CLASS (valent_media_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_media_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_media_finalize (GObject *object)
 {
@@ -227,10 +230,12 @@ static void
 valent_media_class_init (ValentMediaClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentComponentClass *component_class = VALENT_COMPONENT_CLASS (klass);
 
-  object_class->dispose = valent_media_dispose;
   object_class->finalize = valent_media_finalize;
+
+  vobject_class->destroy = valent_media_destroy;
 
   component_class->bind_extension = valent_media_bind_extension;
   component_class->unbind_extension = valent_media_unbind_extension;

--- a/src/libvalent/mixer/valent-mixer-adapter.c
+++ b/src/libvalent/mixer/valent-mixer-adapter.c
@@ -144,19 +144,22 @@ valent_mixer_adapter_real_set_default_output (ValentMixerAdapter *adapter,
 /* LCOV_EXCL_STOP */
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_mixer_adapter_dispose (GObject *object)
+valent_mixer_adapter_destroy (ValentObject *object)
 {
   ValentMixerAdapter *self = VALENT_MIXER_ADAPTER (object);
   ValentMixerAdapterPrivate *priv = valent_mixer_adapter_get_instance_private (self);
 
   g_clear_pointer (&priv->streams, g_ptr_array_unref);
 
-  G_OBJECT_CLASS (valent_mixer_adapter_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_mixer_adapter_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_mixer_adapter_get_property (GObject    *object,
                                    guint       prop_id,
@@ -207,10 +210,12 @@ static void
 valent_mixer_adapter_class_init (ValentMixerAdapterClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
-  object_class->dispose = valent_mixer_adapter_dispose;
   object_class->get_property = valent_mixer_adapter_get_property;
   object_class->set_property = valent_mixer_adapter_set_property;
+
+  vobject_class->destroy = valent_mixer_adapter_destroy;
 
   klass->get_default_input = valent_mixer_adapter_real_get_default_input;
   klass->set_default_input = valent_mixer_adapter_real_set_default_input;

--- a/src/plugins/battery/valent-battery-plugin.c
+++ b/src/plugins/battery/valent-battery-plugin.c
@@ -408,6 +408,19 @@ valent_battery_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_battery_plugin_destroy (ValentObject *object)
+{
+  ValentBatteryPlugin *self = VALENT_BATTERY_PLUGIN (object);
+
+  valent_battery_plugin_watch_battery (self, FALSE);
+
+  VALENT_OBJECT_CLASS (valent_battery_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -425,23 +438,15 @@ valent_battery_plugin_constructed (GObject *object)
 }
 
 static void
-valent_battery_plugin_dispose (GObject *object)
-{
-  ValentBatteryPlugin *self = VALENT_BATTERY_PLUGIN (object);
-
-  valent_battery_plugin_watch_battery (self, FALSE);
-
-  G_OBJECT_CLASS (valent_battery_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_battery_plugin_class_init (ValentBatteryPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_battery_plugin_constructed;
-  object_class->dispose = valent_battery_plugin_dispose;
+
+  vobject_class->destroy = valent_battery_plugin_destroy;
 
   plugin_class->handle_packet = valent_battery_plugin_handle_packet;
   plugin_class->update_state = valent_battery_plugin_update_state;

--- a/src/plugins/bluez/valent-bluez-channel-service.c
+++ b/src/plugins/bluez/valent-bluez-channel-service.c
@@ -453,10 +453,10 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_bluez_channel_service_dispose (GObject *object)
+valent_bluez_channel_service_destroy (ValentObject *object)
 {
   ValentBluezChannelService *self = VALENT_BLUEZ_CHANNEL_SERVICE (object);
 
@@ -472,9 +472,12 @@ valent_bluez_channel_service_dispose (GObject *object)
       valent_bluez_profile_unregister (self->profile);
     }
 
-  G_OBJECT_CLASS (valent_bluez_channel_service_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_bluez_channel_service_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_bluez_channel_service_finalize (GObject *object)
 {
@@ -495,10 +498,12 @@ static void
 valent_bluez_channel_service_class_init (ValentBluezChannelServiceClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentChannelServiceClass *service_class = VALENT_CHANNEL_SERVICE_CLASS (klass);
 
-  object_class->dispose = valent_bluez_channel_service_dispose;
   object_class->finalize = valent_bluez_channel_service_finalize;
+
+  vobject_class->destroy = valent_bluez_channel_service_destroy;
 
   service_class->identify = valent_bluez_channel_service_identify;
 }

--- a/src/plugins/bluez/valent-mux-connection.h
+++ b/src/plugins/bluez/valent-mux-connection.h
@@ -9,7 +9,7 @@ G_BEGIN_DECLS
 
 #define VALENT_TYPE_MUX_CONNECTION (valent_mux_connection_get_type())
 
-G_DECLARE_FINAL_TYPE (ValentMuxConnection, valent_mux_connection, VALENT, MUX_CONNECTION, GObject)
+G_DECLARE_FINAL_TYPE (ValentMuxConnection, valent_mux_connection, VALENT, MUX_CONNECTION, ValentObject)
 
 ValentMuxConnection * valent_mux_connection_new                  (GIOStream            *base_stream);
 ValentChannel       * valent_mux_connection_handshake            (ValentMuxConnection  *connection,

--- a/src/plugins/clipboard/valent-clipboard-plugin.c
+++ b/src/plugins/clipboard/valent-clipboard-plugin.c
@@ -425,6 +425,19 @@ valent_clipboard_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_clipboard_plugin_destroy (ValentObject *object)
+{
+  ValentClipboardPlugin *self = VALENT_CLIPBOARD_PLUGIN (object);
+
+  g_clear_signal_handler (&self->changed_id, self->clipboard);
+
+  VALENT_OBJECT_CLASS (valent_clipboard_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -459,16 +472,6 @@ valent_clipboard_plugin_constructed (GObject *object)
 }
 
 static void
-valent_clipboard_plugin_dispose (GObject *object)
-{
-  ValentClipboardPlugin *self = VALENT_CLIPBOARD_PLUGIN (object);
-
-  g_clear_signal_handler (&self->changed_id, self->clipboard);
-
-  G_OBJECT_CLASS (valent_clipboard_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_clipboard_plugin_finalize (GObject *object)
 {
   ValentClipboardPlugin *self = VALENT_CLIPBOARD_PLUGIN (object);
@@ -482,11 +485,13 @@ static void
 valent_clipboard_plugin_class_init (ValentClipboardPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_clipboard_plugin_constructed;
-  object_class->dispose = valent_clipboard_plugin_dispose;
   object_class->finalize = valent_clipboard_plugin_finalize;
+
+  vobject_class->destroy = valent_clipboard_plugin_destroy;
 
   plugin_class->handle_packet = valent_clipboard_plugin_handle_packet;
   plugin_class->update_state = valent_clipboard_plugin_update_state;

--- a/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-plugin.c
@@ -381,6 +381,19 @@ valent_connectivity_report_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_connectivity_report_plugin_destroy (ValentObject *object)
+{
+  ValentConnectivityReportPlugin *self = VALENT_CONNECTIVITY_REPORT_PLUGIN (object);
+
+  valent_connectivity_report_plugin_watch_telephony (self, FALSE);
+
+  VALENT_OBJECT_CLASS (valent_connectivity_report_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -397,23 +410,15 @@ valent_connectivity_report_plugin_constructed (GObject *object)
 }
 
 static void
-valent_connectivity_report_plugin_dispose (GObject *object)
-{
-  ValentConnectivityReportPlugin *self = VALENT_CONNECTIVITY_REPORT_PLUGIN (object);
-
-  valent_connectivity_report_plugin_watch_telephony (self, FALSE);
-
-  G_OBJECT_CLASS (valent_connectivity_report_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_connectivity_report_plugin_class_init (ValentConnectivityReportPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_connectivity_report_plugin_constructed;
-  object_class->dispose = valent_connectivity_report_plugin_dispose;
+
+  vobject_class->destroy = valent_connectivity_report_plugin_destroy;
 
   plugin_class->handle_packet = valent_connectivity_report_plugin_handle_packet;
   plugin_class->update_state = valent_connectivity_report_plugin_update_state;

--- a/src/plugins/connectivity_report/valent-telephony.c
+++ b/src/plugins/connectivity_report/valent-telephony.c
@@ -272,6 +272,20 @@ g_dbus_object_manager_client_new_for_bus_cb (GObject      *object,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_telephony_destroy (ValentObject *object)
+{
+  ValentTelephony *self = VALENT_TELEPHONY (object);
+
+  g_signal_handlers_disconnect_by_data (self->manager, self);
+  g_clear_object (&self->manager);
+
+  VALENT_OBJECT_CLASS (valent_telephony_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -292,17 +306,6 @@ valent_telephony_constructed (GObject *object)
 }
 
 static void
-valent_telephony_dispose (GObject *object)
-{
-  ValentTelephony *self = VALENT_TELEPHONY (object);
-
-  g_signal_handlers_disconnect_by_data (self->manager, self);
-  g_clear_object (&self->manager);
-
-  G_OBJECT_CLASS (valent_telephony_parent_class)->dispose (object);
-}
-
-static void
 valent_telephony_finalize (GObject *object)
 {
   ValentTelephony *self = VALENT_TELEPHONY (object);
@@ -316,10 +319,12 @@ static void
 valent_telephony_class_init (ValentTelephonyClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
   object_class->constructed = valent_telephony_constructed;
-  object_class->dispose = valent_telephony_dispose;
   object_class->finalize = valent_telephony_finalize;
+
+  vobject_class->destroy = valent_telephony_destroy;
 
   /**
    * ValentTelephony::changed:

--- a/src/plugins/contacts/valent-contacts-plugin.c
+++ b/src/plugins/contacts/valent-contacts-plugin.c
@@ -402,6 +402,23 @@ valent_contacts_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_contacts_plugin_destroy (ValentObject *object)
+{
+  ValentContactsPlugin *self = VALENT_CONTACTS_PLUGIN (object);
+
+  /* Cancel any pending operations and drop the address books */
+  g_cancellable_cancel (self->cancellable);
+  g_clear_object (&self->cancellable);
+  g_clear_object (&self->remote_store);
+  g_clear_object (&self->local_store);
+
+  VALENT_OBJECT_CLASS (valent_contacts_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -455,27 +472,15 @@ valent_contacts_plugin_constructed (GObject *object)
 }
 
 static void
-valent_contacts_plugin_dispose (GObject *object)
-{
-  ValentContactsPlugin *self = VALENT_CONTACTS_PLUGIN (object);
-
-  /* Cancel any pending operations and drop the address books */
-  g_cancellable_cancel (self->cancellable);
-  g_clear_object (&self->cancellable);
-  g_clear_object (&self->remote_store);
-  g_clear_object (&self->local_store);
-
-  G_OBJECT_CLASS (valent_contacts_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_contacts_plugin_class_init (ValentContactsPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_contacts_plugin_constructed;
-  object_class->dispose = valent_contacts_plugin_dispose;
+
+  vobject_class->destroy = valent_contacts_plugin_destroy;
 
   plugin_class->handle_packet = valent_contacts_plugin_handle_packet;
   plugin_class->update_state = valent_contacts_plugin_update_state;

--- a/src/plugins/eds/valent-ebook-adapter.c
+++ b/src/plugins/eds/valent-ebook-adapter.c
@@ -185,19 +185,22 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_ebook_adapter_dispose (GObject *object)
+valent_ebook_adapter_destroy (ValentObject *object)
 {
   ValentEBookAdapter *self = VALENT_EBOOK_ADAPTER (object);
 
   g_clear_object (&self->registry);
   g_hash_table_remove_all (self->stores);
 
-  G_OBJECT_CLASS (valent_ebook_adapter_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_ebook_adapter_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_ebook_adapter_finalize (GObject *object)
 {
@@ -212,9 +215,11 @@ static void
 valent_ebook_adapter_class_init (ValentEBookAdapterClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
-  object_class->dispose = valent_ebook_adapter_dispose;
   object_class->finalize = valent_ebook_adapter_finalize;
+
+  vobject_class->destroy = valent_ebook_adapter_destroy;
 }
 
 static void

--- a/src/plugins/eds/valent-ebook-store.c
+++ b/src/plugins/eds/valent-ebook-store.c
@@ -341,10 +341,10 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_ebook_store_dispose (GObject *object)
+valent_ebook_store_destroy (ValentObject *object)
 {
   ValentEBookStore *self = VALENT_EBOOK_STORE (object);
 
@@ -354,9 +354,12 @@ valent_ebook_store_dispose (GObject *object)
       g_clear_object (&self->view);
     }
 
-  G_OBJECT_CLASS (valent_ebook_store_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_ebook_store_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_ebook_store_finalize (GObject *object)
 {
@@ -372,10 +375,12 @@ static void
 valent_ebook_store_class_init (ValentEBookStoreClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentContactStoreClass *store_class = VALENT_CONTACT_STORE_CLASS (klass);
 
-  object_class->dispose = valent_ebook_store_dispose;
   object_class->finalize = valent_ebook_store_finalize;
+
+  vobject_class->destroy = valent_ebook_store_destroy;
 
   store_class->add_contacts = valent_ebook_store_add_contacts;
   store_class->remove_contacts = valent_ebook_store_remove_contacts;

--- a/src/plugins/fdo/valent-fdo-notifications.c
+++ b/src/plugins/fdo/valent-fdo-notifications.c
@@ -468,10 +468,10 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_fdo_notifications_dispose (GObject *object)
+valent_fdo_notifications_destroy (ValentObject *object)
 {
   ValentFdoNotifications *self = VALENT_FDO_NOTIFICATIONS (object);
 
@@ -496,9 +496,12 @@ valent_fdo_notifications_dispose (GObject *object)
   g_clear_object (&self->monitor);
   g_clear_object (&self->session);
 
-  G_OBJECT_CLASS (valent_fdo_notifications_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_fdo_notifications_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_fdo_notifications_finalize (GObject *object)
 {
@@ -513,9 +516,11 @@ static void
 valent_fdo_notifications_class_init (ValentFdoNotificationsClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
-  object_class->dispose = valent_fdo_notifications_dispose;
   object_class->finalize = valent_fdo_notifications_finalize;
+
+  vobject_class->destroy = valent_fdo_notifications_destroy;
 }
 
 static void

--- a/src/plugins/fdo/valent-fdo-session.c
+++ b/src/plugins/fdo/valent-fdo-session.c
@@ -297,25 +297,28 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_fdo_session_dispose (GObject *object)
+valent_fdo_session_destroy (ValentObject *object)
 {
   ValentFdoSession *self = VALENT_FDO_SESSION (object);
 
   g_clear_object (&self->proxy);
 
-  G_OBJECT_CLASS (valent_fdo_session_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_fdo_session_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_fdo_session_class_init (ValentFdoSessionClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentSessionAdapterClass *session_class = VALENT_SESSION_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_fdo_session_dispose;
+  vobject_class->destroy = valent_fdo_session_destroy;
 
   session_class->get_active = valent_fdo_session_get_active;
   session_class->get_locked = valent_fdo_session_get_locked;

--- a/src/plugins/findmyphone/valent-findmyphone-plugin.c
+++ b/src/plugins/findmyphone/valent-findmyphone-plugin.c
@@ -95,6 +95,24 @@ valent_findmyphone_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_findmyphone_plugin_destroy (ValentObject *object)
+{
+  ValentFindmyphonePlugin *self = VALENT_FINDMYPHONE_PLUGIN (object);
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  /* Release the ringer singleton */
+  g_clear_pointer (&self->ringer, valent_findmyphone_ringer_release);
+  self->session = NULL;
+
+  valent_device_plugin_set_menu_item (plugin, "device.findmyphone.ring", NULL);
+
+  VALENT_OBJECT_CLASS (valent_findmyphone_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -121,28 +139,15 @@ valent_findmyphone_plugin_constructed (GObject *object)
 }
 
 static void
-valent_findmyphone_plugin_dispose (GObject *object)
-{
-  ValentFindmyphonePlugin *self = VALENT_FINDMYPHONE_PLUGIN (object);
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  /* Release the ringer singleton */
-  g_clear_pointer (&self->ringer, valent_findmyphone_ringer_release);
-  self->session = NULL;
-
-  valent_device_plugin_set_menu_item (plugin, "device.findmyphone.ring", NULL);
-
-  G_OBJECT_CLASS (valent_findmyphone_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_findmyphone_plugin_class_init (ValentFindmyphonePluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_findmyphone_plugin_constructed;
-  object_class->dispose = valent_findmyphone_plugin_dispose;
+
+  vobject_class->destroy = valent_findmyphone_plugin_destroy;
 
   plugin_class->handle_packet = valent_findmyphone_plugin_handle_packet;
   plugin_class->update_state = valent_findmyphone_plugin_update_state;

--- a/src/plugins/gnome/valent-mutter-input.c
+++ b/src/plugins/gnome/valent-mutter-input.c
@@ -520,20 +520,22 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
   iface->init_async = valent_mutter_input_init_async;
 }
 
-
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_mutter_input_dispose (GObject *object)
+valent_mutter_input_destroy (ValentObject *object)
 {
   ValentMutterInput *self = VALENT_MUTTER_INPUT (object);
 
   valent_mutter_input_close (self);
 
-  G_OBJECT_CLASS (valent_mutter_input_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_mutter_input_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_mutter_input_finalize (GObject *object)
 {
@@ -549,10 +551,12 @@ static void
 valent_mutter_input_class_init (ValentMutterInputClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentInputAdapterClass *adapter_class = VALENT_INPUT_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_mutter_input_dispose;
   object_class->finalize = valent_mutter_input_finalize;
+
+  vobject_class->destroy = valent_mutter_input_destroy;
 
   adapter_class->keyboard_keysym = valent_mutter_input_keyboard_keysym;
   adapter_class->pointer_axis = valent_mutter_input_pointer_axis;

--- a/src/plugins/gtk/valent-gdk-clipboard.c
+++ b/src/plugins/gtk/valent-gdk-clipboard.c
@@ -256,6 +256,23 @@ valent_gdk_clipboard_write_bytes (ValentClipboardAdapter *adapter,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_gdk_clipboard_destroy (ValentObject *object)
+{
+  ValentGdkClipboard *self = VALENT_GDK_CLIPBOARD (object);
+
+  if (self->clipboard != NULL)
+    {
+      g_signal_handlers_disconnect_by_data (self->clipboard, self);
+      self->clipboard = NULL;
+    }
+
+  VALENT_OBJECT_CLASS (valent_gdk_clipboard_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -283,27 +300,15 @@ valent_gdk_clipboard_constructed (GObject *object)
 }
 
 static void
-valent_gdk_clipboard_dispose (GObject *object)
-{
-  ValentGdkClipboard *self = VALENT_GDK_CLIPBOARD (object);
-
-  if (self->clipboard != NULL)
-    {
-      g_signal_handlers_disconnect_by_data (self->clipboard, self);
-      self->clipboard = NULL;
-    }
-
-  G_OBJECT_CLASS (valent_gdk_clipboard_parent_class)->dispose (object);
-}
-
-static void
 valent_gdk_clipboard_class_init (ValentGdkClipboardClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentClipboardAdapterClass *clipboard_class = VALENT_CLIPBOARD_ADAPTER_CLASS (klass);
 
   object_class->constructed = valent_gdk_clipboard_constructed;
-  object_class->dispose = valent_gdk_clipboard_dispose;
+
+  vobject_class->destroy = valent_gdk_clipboard_destroy;
 
   clipboard_class->get_mimetypes = valent_gdk_clipboard_get_mimetypes;
   clipboard_class->get_timestamp = valent_gdk_clipboard_get_timestamp;

--- a/src/plugins/gtk/valent-gtk-notifications.c
+++ b/src/plugins/gtk/valent-gtk-notifications.c
@@ -334,10 +334,10 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_gtk_notifications_dispose (GObject *object)
+valent_gtk_notifications_destroy (ValentObject *object)
 {
   ValentGtkNotifications *self = VALENT_GTK_NOTIFICATIONS (object);
 
@@ -355,9 +355,12 @@ valent_gtk_notifications_dispose (GObject *object)
 
   g_clear_object (&self->monitor);
 
-  G_OBJECT_CLASS (valent_gtk_notifications_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_gtk_notifications_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_gtk_notifications_finalize (GObject *object)
 {
@@ -372,9 +375,11 @@ static void
 valent_gtk_notifications_class_init (ValentGtkNotificationsClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
-  object_class->dispose = valent_gtk_notifications_dispose;
   object_class->finalize = valent_gtk_notifications_finalize;
+
+  vobject_class->destroy = valent_gtk_notifications_destroy;
 }
 
 static void

--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -993,18 +993,16 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
   iface->init_async = valent_lan_channel_service_init_async;
 }
 
-
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_lan_channel_service_dispose (GObject *object)
+valent_lan_channel_service_destroy (ValentObject *object)
 {
   ValentLanChannelService *self = VALENT_LAN_CHANNEL_SERVICE (object);
 
   g_signal_handlers_disconnect_by_data (self->monitor, self);
 
-  valent_object_lock (VALENT_OBJECT (self));
   if (self->udp_context != NULL)
     {
       g_clear_object (&self->udp_socket4);
@@ -1019,11 +1017,13 @@ valent_lan_channel_service_dispose (GObject *object)
       g_socket_listener_close (G_SOCKET_LISTENER (self->listener));
       g_clear_object (&self->listener);
     }
-  valent_object_unlock (VALENT_OBJECT (self));
 
-  G_OBJECT_CLASS (valent_lan_channel_service_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_lan_channel_service_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_lan_channel_service_finalize (GObject *object)
 {
@@ -1090,12 +1090,14 @@ static void
 valent_lan_channel_service_class_init (ValentLanChannelServiceClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentChannelServiceClass *service_class = VALENT_CHANNEL_SERVICE_CLASS (klass);
 
-  object_class->dispose = valent_lan_channel_service_dispose;
   object_class->finalize = valent_lan_channel_service_finalize;
   object_class->get_property = valent_lan_channel_service_get_property;
   object_class->set_property = valent_lan_channel_service_set_property;
+
+  vobject_class->destroy = valent_lan_channel_service_destroy;
 
   service_class->build_identity = valent_lan_channel_service_build_identity;
   service_class->channel = valent_lan_channel_service_channel;

--- a/src/plugins/lock/valent-lock-plugin.c
+++ b/src/plugins/lock/valent-lock-plugin.c
@@ -25,8 +25,8 @@ struct _ValentLockPlugin
 
 G_DEFINE_FINAL_TYPE (ValentLockPlugin, valent_lock_plugin, VALENT_TYPE_DEVICE_PLUGIN)
 
-static void valent_lock_plugin_request_state (ValentLockPlugin *self);
-static void valent_lock_plugin_send_state    (ValentLockPlugin *self);
+static void   valent_lock_plugin_request_state (ValentLockPlugin *self);
+static void   valent_lock_plugin_send_state    (ValentLockPlugin *self);
 
 
 /*
@@ -201,6 +201,19 @@ valent_lock_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_lock_plugin_destroy (ValentObject *object)
+{
+  ValentLockPlugin *self = VALENT_LOCK_PLUGIN (object);
+
+  g_clear_signal_handler (&self->session_changed_id, self->session);
+
+  VALENT_OBJECT_CLASS (valent_lock_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -220,23 +233,15 @@ valent_lock_plugin_constructed (GObject *object)
 }
 
 static void
-valent_lock_plugin_dispose (GObject *object)
-{
-  ValentLockPlugin *self = VALENT_LOCK_PLUGIN (object);
-
-  g_clear_signal_handler (&self->session_changed_id, self->session);
-
-  G_OBJECT_CLASS (valent_lock_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_lock_plugin_class_init (ValentLockPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_lock_plugin_constructed;
-  object_class->dispose = valent_lock_plugin_dispose;
+
+  vobject_class->destroy = valent_lock_plugin_destroy;
 
   plugin_class->handle_packet = valent_lock_plugin_handle_packet;
   plugin_class->update_state = valent_lock_plugin_update_state;

--- a/src/plugins/mousepad/valent-mousepad-device.c
+++ b/src/plugins/mousepad/valent-mousepad-device.c
@@ -496,10 +496,10 @@ valent_mousepad_device_pointer_release (ValentInputRemote *self)
 #endif
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_mousepad_device_dispose (GObject *object)
+valent_mousepad_device_destroy (ValentObject *object)
 {
   ValentMousepadDevice *self = VALENT_MOUSEPAD_DEVICE (object);
 
@@ -512,9 +512,12 @@ valent_mousepad_device_dispose (GObject *object)
   valent_mousepad_device_keyboard_reset (self);
   valent_mousepad_device_pointer_reset (self);
 
-  G_OBJECT_CLASS (valent_mousepad_device_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_mousepad_device_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_mousepad_device_finalize (GObject *object)
 {
@@ -568,12 +571,13 @@ static void
 valent_mousepad_device_class_init (ValentMousepadDeviceClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentInputAdapterClass *input_class = VALENT_INPUT_ADAPTER_CLASS (klass);
-
-  object_class->dispose = valent_mousepad_device_dispose;
   object_class->finalize = valent_mousepad_device_finalize;
   object_class->get_property = valent_mousepad_device_get_property;
   object_class->set_property = valent_mousepad_device_set_property;
+
+  vobject_class->destroy = valent_mousepad_device_destroy;
 
   input_class->keyboard_keysym = valent_mousepad_device_keyboard_keysym;
   input_class->pointer_axis = valent_mousepad_device_pointer_axis;

--- a/src/plugins/mousepad/valent-mousepad-plugin.c
+++ b/src/plugins/mousepad/valent-mousepad-plugin.c
@@ -526,6 +526,24 @@ valent_mousepad_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_mousepad_plugin_destroy (ValentObject *object)
+{
+  ValentMousepadPlugin *self = VALENT_MOUSEPAD_PLUGIN (object);
+
+  if (self->controller != NULL)
+    {
+      valent_input_unexport_adapter (valent_input_get_default (),
+                                     VALENT_INPUT_ADAPTER (self->controller));
+      g_clear_object (&self->controller);
+    }
+
+  VALENT_OBJECT_CLASS (valent_mousepad_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -542,28 +560,15 @@ valent_mousepad_plugin_constructed (GObject *object)
 }
 
 static void
-valent_mousepad_plugin_dispose (GObject *object)
-{
-  ValentMousepadPlugin *self = VALENT_MOUSEPAD_PLUGIN (object);
-
-  if (self->controller != NULL)
-    {
-      valent_input_unexport_adapter (valent_input_get_default (),
-                                     VALENT_INPUT_ADAPTER (self->controller));
-      g_clear_object (&self->controller);
-    }
-
-  G_OBJECT_CLASS (valent_mousepad_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_mousepad_plugin_class_init (ValentMousepadPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_mousepad_plugin_constructed;
-  object_class->dispose = valent_mousepad_plugin_dispose;
+
+  vobject_class->destroy = valent_mousepad_plugin_destroy;
 
   plugin_class->handle_packet = valent_mousepad_plugin_handle_packet;
   plugin_class->update_state = valent_mousepad_plugin_update_state;

--- a/src/plugins/mpris/valent-mpris-adapter.c
+++ b/src/plugins/mpris/valent-mpris-adapter.c
@@ -420,10 +420,10 @@ valent_mpris_adapter_unexport (ValentMediaAdapter *adapter,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_mpris_adapter_dispose (GObject *object)
+valent_mpris_adapter_destroy (ValentObject *object)
 {
   ValentMPRISAdapter *self = VALENT_MPRIS_ADAPTER (object);
   GHashTableIter iter;
@@ -445,9 +445,12 @@ valent_mpris_adapter_dispose (GObject *object)
       g_hash_table_iter_remove (&iter);
     }
 
-  G_OBJECT_CLASS (valent_mpris_adapter_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_mpris_adapter_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_mpris_adapter_finalize (GObject *object)
 {
@@ -464,10 +467,12 @@ static void
 valent_mpris_adapter_class_init (ValentMPRISAdapterClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentMediaAdapterClass *adapter_class = VALENT_MEDIA_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_mpris_adapter_dispose;
   object_class->finalize = valent_mpris_adapter_finalize;
+
+  vobject_class->destroy = valent_mpris_adapter_destroy;
 
   adapter_class->export_player = valent_mpris_adapter_export;
   adapter_class->unexport_player = valent_mpris_adapter_unexport;

--- a/src/plugins/mpris/valent-mpris-plugin.c
+++ b/src/plugins/mpris/valent-mpris-plugin.c
@@ -855,6 +855,20 @@ valent_mpris_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_mpris_plugin_destroy (ValentObject *object)
+{
+  ValentMprisPlugin *self = VALENT_MPRIS_PLUGIN (object);
+
+  valent_mpris_plugin_watch_media (self, FALSE);
+  self->media = NULL;
+
+  VALENT_OBJECT_CLASS (valent_mpris_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -865,17 +879,6 @@ valent_mpris_plugin_constructed (GObject *object)
   self->media = valent_media_get_default ();
 
   G_OBJECT_CLASS (valent_mpris_plugin_parent_class)->constructed (object);
-}
-
-static void
-valent_mpris_plugin_dispose (GObject *object)
-{
-  ValentMprisPlugin *self = VALENT_MPRIS_PLUGIN (object);
-
-  valent_mpris_plugin_watch_media (self, FALSE);
-  self->media = NULL;
-
-  G_OBJECT_CLASS (valent_mpris_plugin_parent_class)->dispose (object);
 }
 
 static void
@@ -894,11 +897,13 @@ static void
 valent_mpris_plugin_class_init (ValentMprisPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_mpris_plugin_constructed;
-  object_class->dispose = valent_mpris_plugin_dispose;
   object_class->finalize = valent_mpris_plugin_finalize;
+
+  vobject_class->destroy = valent_mpris_plugin_destroy;
 
   plugin_class->handle_packet = valent_mpris_plugin_handle_packet;
   plugin_class->update_state = valent_mpris_plugin_update_state;

--- a/src/plugins/photo/valent-photo-plugin.c
+++ b/src/plugins/photo/valent-photo-plugin.c
@@ -172,6 +172,19 @@ valent_photo_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_photo_plugin_destroy (ValentObject *object)
+{
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  valent_device_plugin_set_menu_item (plugin, "device.photo.request", NULL);
+
+  VALENT_OBJECT_CLASS (valent_photo_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -192,23 +205,15 @@ valent_photo_plugin_constructed (GObject *object)
 }
 
 static void
-valent_photo_plugin_dispose (GObject *object)
-{
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  valent_device_plugin_set_menu_item (plugin, "device.photo.request", NULL);
-
-  G_OBJECT_CLASS (valent_photo_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_photo_plugin_class_init (ValentPhotoPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_photo_plugin_constructed;
-  object_class->dispose = valent_photo_plugin_dispose;
+
+  vobject_class->destroy = valent_photo_plugin_destroy;
 
   plugin_class->handle_packet = valent_photo_plugin_handle_packet;
   plugin_class->update_state = valent_photo_plugin_update_state;

--- a/src/plugins/ping/valent-ping-plugin.c
+++ b/src/plugins/ping/valent-ping-plugin.c
@@ -126,6 +126,19 @@ valent_ping_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_ping_plugin_destroy (ValentObject *object)
+{
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  valent_device_plugin_set_menu_item (plugin, "device.ping.ping", NULL);
+
+  VALENT_OBJECT_CLASS (valent_ping_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -146,23 +159,15 @@ valent_ping_plugin_constructed (GObject *object)
 }
 
 static void
-valent_ping_plugin_dispose (GObject *object)
-{
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  valent_device_plugin_set_menu_item (plugin, "device.ping.ping", NULL);
-
-  G_OBJECT_CLASS (valent_ping_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_ping_plugin_class_init (ValentPingPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_ping_plugin_constructed;
-  object_class->dispose = valent_ping_plugin_dispose;
+
+  vobject_class->destroy = valent_ping_plugin_destroy;
 
   plugin_class->handle_packet = valent_ping_plugin_handle_packet;
   plugin_class->update_state = valent_ping_plugin_update_state;

--- a/src/plugins/presenter/valent-presenter-plugin.c
+++ b/src/plugins/presenter/valent-presenter-plugin.c
@@ -197,6 +197,23 @@ valent_presenter_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_presenter_plugin_destroy (ValentObject *object)
+{
+  ValentPresenterPlugin *self = VALENT_PRESENTER_PLUGIN (object);
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  /* Destroy the presentation remote if necessary */
+  g_clear_pointer (&self->remote, gtk_window_destroy);
+
+  valent_device_plugin_set_menu_item (plugin, "device.presenter.remote", NULL);
+
+  VALENT_OBJECT_CLASS (valent_presenter_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -219,27 +236,15 @@ valent_presenter_plugin_constructed (GObject *object)
 }
 
 static void
-valent_presenter_plugin_dispose (GObject *object)
-{
-  ValentPresenterPlugin *self = VALENT_PRESENTER_PLUGIN (object);
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  /* Destroy the presentation remote if necessary */
-  g_clear_pointer (&self->remote, gtk_window_destroy);
-
-  valent_device_plugin_set_menu_item (plugin, "device.presenter.remote", NULL);
-
-  G_OBJECT_CLASS (valent_presenter_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_presenter_plugin_class_init (ValentPresenterPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_presenter_plugin_constructed;
-  object_class->dispose = valent_presenter_plugin_dispose;
+
+  vobject_class->destroy = valent_presenter_plugin_destroy;
 
   plugin_class->handle_packet = valent_presenter_plugin_handle_packet;
   plugin_class->update_state = valent_presenter_plugin_update_state;

--- a/src/plugins/pulseaudio/valent-pa-mixer.c
+++ b/src/plugins/pulseaudio/valent-pa-mixer.c
@@ -300,6 +300,21 @@ valent_pa_mixer_set_default_output (ValentMixerAdapter *adapter,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_pa_mixer_destroy (ValentObject *object)
+{
+  ValentPaMixer *self = VALENT_PA_MIXER (object);
+
+  g_signal_handlers_disconnect_by_data (self->control, self);
+  gvc_mixer_control_close (self->control);
+  g_hash_table_remove_all (self->streams);
+
+  VALENT_OBJECT_CLASS (valent_pa_mixer_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -319,18 +334,6 @@ valent_pa_mixer_constructed (GObject *object)
 }
 
 static void
-valent_pa_mixer_dispose (GObject *object)
-{
-  ValentPaMixer *self = VALENT_PA_MIXER (object);
-
-  g_signal_handlers_disconnect_by_data (self->control, self);
-  gvc_mixer_control_close (self->control);
-  g_hash_table_remove_all (self->streams);
-
-  G_OBJECT_CLASS (valent_pa_mixer_parent_class)->dispose (object);
-}
-
-static void
 valent_pa_mixer_finalize (GObject *object)
 {
   ValentPaMixer *self = VALENT_PA_MIXER (object);
@@ -345,11 +348,13 @@ static void
 valent_pa_mixer_class_init (ValentPaMixerClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentMixerAdapterClass *adapter_class = VALENT_MIXER_ADAPTER_CLASS (klass);
 
   object_class->constructed = valent_pa_mixer_constructed;
-  object_class->dispose = valent_pa_mixer_dispose;
   object_class->finalize = valent_pa_mixer_finalize;
+
+  vobject_class->destroy = valent_pa_mixer_destroy;
 
   adapter_class->get_default_input = valent_pa_mixer_get_default_input;
   adapter_class->set_default_input = valent_pa_mixer_set_default_input;

--- a/src/plugins/runcommand/valent-runcommand-plugin.c
+++ b/src/plugins/runcommand/valent-runcommand-plugin.c
@@ -471,6 +471,23 @@ valent_runcommand_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_runcommand_plugin_destroy (ValentObject *object)
+{
+  ValentRuncommandPlugin *self = VALENT_RUNCOMMAND_PLUGIN (object);
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+  GSettings *settings;
+
+  /* Stop watching for command changes */
+  settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
+  g_clear_signal_handler (&self->commands_changed_id, settings);
+
+  VALENT_OBJECT_CLASS (valent_runcommand_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -484,20 +501,6 @@ valent_runcommand_plugin_constructed (GObject *object)
                                    plugin);
 
   G_OBJECT_CLASS (valent_runcommand_plugin_parent_class)->constructed (object);
-}
-
-static void
-valent_runcommand_plugin_dispose (GObject *object)
-{
-  ValentRuncommandPlugin *self = VALENT_RUNCOMMAND_PLUGIN (object);
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-  GSettings *settings;
-
-  /* Stop watching for command changes */
-  settings = valent_extension_get_settings (VALENT_EXTENSION (plugin));
-  g_clear_signal_handler (&self->commands_changed_id, settings);
-
-  G_OBJECT_CLASS (valent_runcommand_plugin_parent_class)->dispose (object);
 }
 
 static void
@@ -515,11 +518,13 @@ static void
 valent_runcommand_plugin_class_init (ValentRuncommandPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_runcommand_plugin_constructed;
-  object_class->dispose = valent_runcommand_plugin_dispose;
   object_class->finalize = valent_runcommand_plugin_finalize;
+
+  vobject_class->destroy = valent_runcommand_plugin_destroy;
 
   plugin_class->handle_packet = valent_runcommand_plugin_handle_packet;
   plugin_class->update_state = valent_runcommand_plugin_update_state;

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -1205,25 +1205,10 @@ valent_share_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_share_plugin_constructed (GObject *object)
-{
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  g_action_map_add_action_entries (G_ACTION_MAP (plugin),
-                                   actions,
-                                   G_N_ELEMENTS (actions),
-                                   plugin);
-  valent_device_plugin_set_menu_action (plugin,
-                                        "device.share.chooser",
-                                        _("Send Files"),
-                                        "document-send-symbolic");
-}
-
-static void
-valent_share_plugin_dispose (GObject *object)
+valent_share_plugin_destroy (ValentObject *object)
 {
   ValentSharePlugin *self = VALENT_SHARE_PLUGIN (object);
   ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
@@ -1247,6 +1232,28 @@ valent_share_plugin_dispose (GObject *object)
   g_ptr_array_remove_range (self->windows, 0, self->windows->len);
 
   valent_device_plugin_set_menu_item (plugin, "device.share.chooser", NULL);
+
+  VALENT_OBJECT_CLASS (valent_share_plugin_parent_class)->destroy (object);
+}
+
+/*
+ * GObject
+ */
+static void
+valent_share_plugin_constructed (GObject *object)
+{
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  g_action_map_add_action_entries (G_ACTION_MAP (plugin),
+                                   actions,
+                                   G_N_ELEMENTS (actions),
+                                   plugin);
+  valent_device_plugin_set_menu_action (plugin,
+                                        "device.share.chooser",
+                                        _("Send Files"),
+                                        "document-send-symbolic");
+
+  G_OBJECT_CLASS (valent_share_plugin_parent_class)->constructed (object);
 }
 
 static void
@@ -1264,11 +1271,13 @@ static void
 valent_share_plugin_class_init (ValentSharePluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_share_plugin_constructed;
-  object_class->dispose = valent_share_plugin_dispose;
   object_class->finalize = valent_share_plugin_finalize;
+
+  vobject_class->destroy = valent_share_plugin_destroy;
 
   plugin_class->handle_packet = valent_share_plugin_handle_packet;
   plugin_class->update_state = valent_share_plugin_update_state;

--- a/src/plugins/share/valent-share-target.c
+++ b/src/plugins/share/valent-share-target.c
@@ -79,25 +79,28 @@ valent_share_target_open (ValentApplicationPlugin  *plugin,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_share_target_dispose (GObject *object)
+valent_share_target_destroy (ValentObject *object)
 {
   ValentShareTarget *self = VALENT_SHARE_TARGET (object);
 
   g_clear_pointer (&self->windows, g_ptr_array_unref);
 
-  G_OBJECT_CLASS (valent_share_target_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_share_target_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_share_target_class_init (ValentShareTargetClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentApplicationPluginClass *plugin_class = VALENT_APPLICATION_PLUGIN_CLASS (klass);
 
-  object_class->dispose = valent_share_target_dispose;
+  vobject_class->destroy = valent_share_target_destroy;
 
   plugin_class->open = valent_share_target_open;
 }

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -477,6 +477,24 @@ valent_sms_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_sms_plugin_destroy (ValentObject *object)
+{
+  ValentSmsPlugin *self = VALENT_SMS_PLUGIN (object);
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  /* Close message window and drop SMS Store */
+  g_clear_pointer (&self->window, gtk_window_destroy);
+  g_clear_object (&self->store);
+
+  valent_device_plugin_set_menu_item (plugin, "device.sms.messaging", NULL);
+
+  VALENT_OBJECT_CLASS (valent_sms_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -509,23 +527,6 @@ valent_sms_plugin_constructed (GObject *object)
 }
 
 static void
-valent_sms_plugin_dispose (GObject *object)
-{
-  ValentSmsPlugin *self = VALENT_SMS_PLUGIN (object);
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  g_assert (VALENT_IS_SMS_PLUGIN (plugin));
-
-  /* Close message window and drop SMS Store */
-  g_clear_pointer (&self->window, gtk_window_destroy);
-  g_clear_object (&self->store);
-
-  valent_device_plugin_set_menu_item (plugin, "device.sms.messaging", NULL);
-
-  G_OBJECT_CLASS (valent_sms_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_sms_plugin_finalize (GObject *object)
 {
   ValentSmsPlugin *self = VALENT_SMS_PLUGIN (object);
@@ -541,14 +542,16 @@ static void
 valent_sms_plugin_class_init (ValentSmsPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->finalize = valent_sms_plugin_finalize;
 
   object_class->constructed = valent_sms_plugin_constructed;
-  object_class->dispose = valent_sms_plugin_dispose;
   plugin_class->handle_packet = valent_sms_plugin_handle_packet;
   plugin_class->update_state = valent_sms_plugin_update_state;
+
+  vobject_class->destroy = valent_sms_plugin_destroy;
 }
 
 static void

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -401,6 +401,20 @@ valent_systemvolume_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_systemvolume_plugin_destroy (ValentObject *object)
+{
+  ValentSystemvolumePlugin *self = VALENT_SYSTEMVOLUME_PLUGIN (object);
+
+  valent_systemvolume_plugin_watch_mixer (self, FALSE);
+  g_clear_pointer (&self->states, g_ptr_array_unref);
+
+  VALENT_OBJECT_CLASS (valent_systemvolume_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -414,24 +428,15 @@ valent_systemvolume_plugin_constructed (GObject *object)
 }
 
 static void
-valent_systemvolume_plugin_dispose (GObject *object)
-{
-  ValentSystemvolumePlugin *self = VALENT_SYSTEMVOLUME_PLUGIN (object);
-
-  valent_systemvolume_plugin_watch_mixer (self, FALSE);
-  g_clear_pointer (&self->states, g_ptr_array_unref);
-
-  G_OBJECT_CLASS (valent_systemvolume_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_systemvolume_plugin_class_init (ValentSystemvolumePluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_systemvolume_plugin_constructed;
-  object_class->dispose = valent_systemvolume_plugin_dispose;
+
+  vobject_class->destroy = valent_systemvolume_plugin_destroy;
 
   plugin_class->handle_packet = valent_systemvolume_plugin_handle_packet;
   plugin_class->update_state = valent_systemvolume_plugin_update_state;

--- a/src/plugins/telephony/valent-telephony-plugin.c
+++ b/src/plugins/telephony/valent-telephony-plugin.c
@@ -398,6 +398,20 @@ valent_telephony_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_telephony_plugin_destroy (ValentObject *object)
+{
+  ValentTelephonyPlugin *self = VALENT_TELEPHONY_PLUGIN (object);
+
+  g_clear_pointer (&self->prev_output, stream_state_free);
+  g_clear_pointer (&self->prev_input, stream_state_free);
+
+  VALENT_OBJECT_CLASS (valent_telephony_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -414,24 +428,15 @@ valent_telephony_plugin_constructed (GObject *object)
 }
 
 static void
-valent_telephony_plugin_dispose (GObject *object)
-{
-  ValentTelephonyPlugin *self = VALENT_TELEPHONY_PLUGIN (object);
-
-  g_clear_pointer (&self->prev_output, stream_state_free);
-  g_clear_pointer (&self->prev_input, stream_state_free);
-
-  G_OBJECT_CLASS (valent_telephony_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_telephony_plugin_class_init (ValentTelephonyPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_telephony_plugin_constructed;
-  object_class->dispose = valent_telephony_plugin_dispose;
+
+  vobject_class->destroy = valent_telephony_plugin_destroy;
 
   plugin_class->handle_packet = valent_telephony_plugin_handle_packet;
   plugin_class->update_state = valent_telephony_plugin_update_state;

--- a/src/plugins/xdp/valent-xdp-background.c
+++ b/src/plugins/xdp/valent-xdp-background.c
@@ -174,26 +174,10 @@ on_autostart_changed (GSettings           *settings,
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_xdp_background_constructed (GObject *object)
-{
-  ValentXdpBackground *self = VALENT_XDP_BACKGROUND (object);
-
-  self->settings = g_settings_new ("ca.andyholmes.Valent.Plugin.xdp");
-  g_signal_connect (self->settings,
-                    "changed::autostart",
-                    G_CALLBACK (on_autostart_changed),
-                    self);
-
-  on_autostart_changed (self->settings, "autostart", self);
-
-  G_OBJECT_CLASS (valent_xdp_background_parent_class)->constructed (object);
-}
-
-static void
-valent_xdp_background_dispose (GObject *object)
+valent_xdp_background_destroy (ValentObject *object)
 {
   ValentXdpBackground *self = VALENT_XDP_BACKGROUND (object);
 
@@ -209,16 +193,37 @@ valent_xdp_background_dispose (GObject *object)
       valent_xdp_background_request (self);
     }
 
-  G_OBJECT_CLASS (valent_xdp_background_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_xdp_background_parent_class)->destroy (object);
+}
+
+/*
+ * GObject
+ */
+static void
+valent_xdp_background_constructed (GObject *object)
+{
+  ValentXdpBackground *self = VALENT_XDP_BACKGROUND (object);
+
+  self->settings = g_settings_new ("ca.andyholmes.Valent.Plugin.xdp");
+  g_signal_connect_object (self->settings,
+                           "changed::autostart",
+                           G_CALLBACK (on_autostart_changed),
+                           self, 0);
+
+  on_autostart_changed (self->settings, "autostart", self);
+
+  G_OBJECT_CLASS (valent_xdp_background_parent_class)->constructed (object);
 }
 
 static void
 valent_xdp_background_class_init (ValentXdpBackgroundClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
   object_class->constructed = valent_xdp_background_constructed;
-  object_class->dispose = valent_xdp_background_dispose;
+
+  vobject_class->destroy = valent_xdp_background_destroy;
 }
 
 static void

--- a/src/plugins/xdp/valent-xdp-input.c
+++ b/src/plugins/xdp/valent-xdp-input.c
@@ -323,10 +323,10 @@ valent_xdp_input_pointer_motion (ValentInputAdapter *adapter,
 
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_xdp_input_dispose (GObject *object)
+valent_xdp_input_destroy (ValentObject *object)
 {
   ValentXdpInput *self = VALENT_XDP_INPUT (object);
 
@@ -335,9 +335,12 @@ valent_xdp_input_dispose (GObject *object)
   if (self->session != NULL)
     xdp_session_close (self->session);
 
-  G_OBJECT_CLASS (valent_xdp_input_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_xdp_input_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_xdp_input_finalize (GObject *object)
 {
@@ -354,10 +357,12 @@ static void
 valent_xdp_input_class_init (ValentXdpInputClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentInputAdapterClass *adapter_class = VALENT_INPUT_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_xdp_input_dispose;
   object_class->finalize = valent_xdp_input_finalize;
+
+  vobject_class->destroy = valent_xdp_input_destroy;
 
   adapter_class->keyboard_keysym = valent_xdp_input_keyboard_keysym;
   adapter_class->pointer_axis = valent_xdp_input_pointer_axis;

--- a/src/plugins/xdp/valent-xdp-session.c
+++ b/src/plugins/xdp/valent-xdp-session.c
@@ -146,10 +146,10 @@ g_async_initable_iface_init (GAsyncInitableIface *iface)
 }
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_xdp_session_dispose (GObject *object)
+valent_xdp_session_destroy (ValentObject *object)
 {
   ValentXdpSession *self = VALENT_XDP_SESSION (object);
   XdpPortal *portal = valent_xdp_get_default ();
@@ -157,16 +157,19 @@ valent_xdp_session_dispose (GObject *object)
   g_signal_handlers_disconnect_by_data (portal, self);
   xdp_portal_session_monitor_stop (portal);
 
-  G_OBJECT_CLASS (valent_xdp_session_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_xdp_session_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_xdp_session_class_init (ValentXdpSessionClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentSessionAdapterClass *session_class = VALENT_SESSION_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_xdp_session_dispose;
+  vobject_class->destroy = valent_xdp_session_destroy;
 
   session_class->get_active = valent_xdp_session_get_active;
   session_class->get_locked = valent_xdp_session_get_locked;

--- a/tests/fixtures/packetless-plugin.c
+++ b/tests/fixtures/packetless-plugin.c
@@ -32,6 +32,19 @@ static const GActionEntry actions[] = {
 };
 
 /*
+ * ValentObject
+ */
+static void
+valent_packetless_plugin_destroy (ValentObject *object)
+{
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  valent_device_plugin_set_menu_item (plugin, "device.packetless.action", NULL);
+
+  VALENT_OBJECT_CLASS (valent_packetless_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -52,16 +65,6 @@ valent_packetless_plugin_constructed (GObject *object)
 }
 
 static void
-valent_packetless_plugin_dispose (GObject *object)
-{
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  valent_device_plugin_set_menu_item (plugin, "device.packetless.action", NULL);
-
-  G_OBJECT_CLASS (valent_packetless_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_packetless_plugin_class_finalize (ValentPacketlessPluginClass *klass)
 {
 }
@@ -70,9 +73,11 @@ static void
 valent_packetless_plugin_class_init (ValentPacketlessPluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
 
   object_class->constructed = valent_packetless_plugin_constructed;
-  object_class->dispose = valent_packetless_plugin_dispose;
+
+  vobject_class->destroy = valent_packetless_plugin_destroy;
 }
 
 static void

--- a/tests/fixtures/valent-mock-channel-service.c
+++ b/tests/fixtures/valent-mock-channel-service.c
@@ -104,10 +104,10 @@ valent_mock_channel_service_identify (ValentChannelService *service,
 
 
 /*
- * GObject
+ * ValentObject
  */
 static void
-valent_mock_channel_service_dispose (GObject *object)
+valent_mock_channel_service_destroy (ValentObject *object)
 {
   ValentMockChannelService *self = VALENT_MOCK_CHANNEL_SERVICE (object);
 
@@ -129,16 +129,19 @@ valent_mock_channel_service_dispose (GObject *object)
 
   g_cancellable_cancel (self->cancellable);
 
-  G_OBJECT_CLASS (valent_mock_channel_service_parent_class)->dispose (object);
+  VALENT_OBJECT_CLASS (valent_mock_channel_service_parent_class)->destroy (object);
 }
 
+/*
+ * GObject
+ */
 static void
 valent_mock_channel_service_class_init (ValentMockChannelServiceClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentChannelServiceClass *service_class = VALENT_CHANNEL_SERVICE_CLASS (klass);
 
-  object_class->dispose = valent_mock_channel_service_dispose;
+  vobject_class->destroy = valent_mock_channel_service_destroy;
 
   service_class->identify = valent_mock_channel_service_identify;
 }

--- a/tests/fixtures/valent-mock-device-plugin.c
+++ b/tests/fixtures/valent-mock-device-plugin.c
@@ -170,6 +170,19 @@ valent_mock_device_plugin_handle_packet (ValentDevicePlugin *plugin,
 }
 
 /*
+ * ValentObject
+ */
+static void
+valent_mock_device_plugin_destroy (ValentObject *object)
+{
+  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
+
+  valent_device_plugin_set_menu_item (plugin, "device.mock.transfer", NULL);
+
+  VALENT_OBJECT_CLASS (valent_mock_device_plugin_parent_class)->destroy (object);
+}
+
+/*
  * GObject
  */
 static void
@@ -190,23 +203,15 @@ valent_mock_device_plugin_constructed (GObject *object)
 }
 
 static void
-valent_mock_device_plugin_dispose (GObject *object)
-{
-  ValentDevicePlugin *plugin = VALENT_DEVICE_PLUGIN (object);
-
-  valent_device_plugin_set_menu_item (plugin, "device.mock.transfer", NULL);
-
-  G_OBJECT_CLASS (valent_mock_device_plugin_parent_class)->dispose (object);
-}
-
-static void
 valent_mock_device_plugin_class_init (ValentMockDevicePluginClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ValentObjectClass *vobject_class = VALENT_OBJECT_CLASS (klass);
   ValentDevicePluginClass *plugin_class = VALENT_DEVICE_PLUGIN_CLASS (klass);
 
   object_class->constructed = valent_mock_device_plugin_constructed;
-  object_class->dispose = valent_mock_device_plugin_dispose;
+
+  vobject_class->destroy = valent_mock_device_plugin_destroy;
 
   plugin_class->handle_packet = valent_mock_device_plugin_handle_packet;
   plugin_class->update_state = valent_mock_device_plugin_update_state;

--- a/tests/fixtures/valent-mock-mixer-adapter.c
+++ b/tests/fixtures/valent-mock-mixer-adapter.c
@@ -86,14 +86,14 @@ valent_mock_mixer_adapter_set_default_output (ValentMixerAdapter *adapter,
  * GObject
  */
 static void
-valent_mock_mixer_adapter_dispose (GObject *object)
+valent_mock_mixer_adapter_finalize (GObject *object)
 {
   ValentMockMixerAdapter *self = VALENT_MOCK_MIXER_ADAPTER (object);
 
   g_clear_object (&self->default_input);
   g_clear_object (&self->default_output);
 
-  G_OBJECT_CLASS (valent_mock_mixer_adapter_parent_class)->dispose (object);
+  G_OBJECT_CLASS (valent_mock_mixer_adapter_parent_class)->finalize (object);
 }
 
 static void
@@ -102,7 +102,7 @@ valent_mock_mixer_adapter_class_init (ValentMockMixerAdapterClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   ValentMixerAdapterClass *adapter_class = VALENT_MIXER_ADAPTER_CLASS (klass);
 
-  object_class->dispose = valent_mock_mixer_adapter_dispose;
+  object_class->finalize = valent_mock_mixer_adapter_finalize;
 
   adapter_class->get_default_input = valent_mock_mixer_adapter_get_default_input;
   adapter_class->set_default_input = valent_mock_mixer_adapter_set_default_input;


### PR DESCRIPTION
Use a locked queue on the main thread to finalize instances of `ValentObject`, and migrate existing classes to override `Valent.Object.destroy` instead of `GObject.Object.dispose`.

See: https://gitlab.gnome.org/GNOME/gnome-builder/commit/7ea0cc519fbdd26082c91c4ba1c0bb9e77494d03