### PR TITLE
refactor: various minor cleanups

### DIFF
--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -179,6 +179,7 @@ on_incoming_connection (ValentChannelService   *service,
   g_autoptr (GSocketAddress) s_addr = NULL;
   GInetAddress *i_addr = NULL;
   g_autofree char *host = NULL;
+  uint16_t port = VALENT_LAN_PROTOCOL_PORT;
   g_autoptr (JsonNode) identity = NULL;
   g_autoptr (JsonNode) peer_identity = NULL;
   const char *device_id;
@@ -236,6 +237,7 @@ on_incoming_connection (ValentChannelService   *service,
   /* NOTE: We're the client when accepting incoming connections */
   valent_object_lock (VALENT_OBJECT (self));
   certificate = g_object_ref (self->certificate);
+  port = self->port;
   valent_object_unlock (VALENT_OBJECT (self));
 
   tls_stream = valent_lan_encrypt_client_connection (connection,
@@ -270,7 +272,7 @@ on_incoming_connection (ValentChannelService   *service,
   channel = g_object_new (VALENT_TYPE_LAN_CHANNEL,
                           "base-stream",   tls_stream,
                           "host",          host,
-                          "port",          self->port,
+                          "port",          port,
                           "identity",      identity,
                           "peer-identity", peer_identity,
                           NULL);

--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -43,5 +43,5 @@ leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:117
 leakNoVarFunctionCall:tests/plugins/gtk/test-gtk-notifications.c:119
 
 # tests/plugins/lan/
-memleak:src/plugins/lan/valent-lan-channel-service.c:546
+memleak:src/plugins/lan/valent-lan-channel-service.c:548
 

--- a/tests/fixtures/valent-mock-channel.c
+++ b/tests/fixtures/valent-mock-channel.c
@@ -37,10 +37,6 @@ enum {
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
 
-/* HACK: ThreadSanitizer reports a data race in socketpair() */
-static GRecMutex socketpair_lock;
-
-
 /*
  * ValentChannel
  */
@@ -99,8 +95,9 @@ valent_mock_channel_upload (ValentChannel  *channel,
                             GCancellable   *cancellable,
                             GError        **error)
 {
-  JsonObject *info;
+  static GRecMutex socketpair_lock;
   g_autoptr (GSocket) socket = NULL;
+  JsonObject *info;
   int sv[2] = { 0, };
   char buf[1] = { 0, };
 


### PR DESCRIPTION
* fix(lan): stash port while holding the lock
* refactor: move a static lock into its function scope
* refactor: error if a `ValentObject` subclass overrides `dispose()` and remove a defunct critical