### PR TITLE
build(flatpak): remove sysprof from devel flatpak 

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -174,31 +174,6 @@
                 }
             ]
         },
-        {
-            "name" : "sysprof",
-            "buildsystem" : "meson",
-            "builddir" : true,
-            "config-opts" : [
-                "--buildtype=debugoptimized",
-                "--libdir=/app/lib",
-                "-Dgtk=false",
-                "-Dsysprofd=host"
-            ],
-            "cleanup" : [
-                "/bin/*",
-                "/libexec/sysprof",
-                "/share/appdata",
-                "/share/applications",
-                "/share/metainfo",
-                "/share/mime/packages"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/sysprof.git"
-                }
-            ]
-        },
         "ca.andyholmes.Valent.Tests.json",
         {
             "name" : "valent",


### PR DESCRIPTION
Both libdex and sysprof will be included in runtime soon (yay!), so
remove them now rather than chasing incremental commits in the upstream
build systems.