### PR TITLE
refactor(ui): various UI cleanups

### DIFF
--- a/src/libvalent/ui/valent-window.ui
+++ b/src/libvalent/ui/valent-window.ui
@@ -47,14 +47,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkHeaderBar">
-                    <property name="title-widget">
-                      <object class="AdwWindowTitle">
-                        <property name="title"
-                                  bind-source="ValentWindow"
-                                  bind-property="title"
-                                  bind-flags="sync-create"/>
-                      </object>
-                    </property>
                     <child type="start">
                       <object class="GtkButton" id="refresh_button">
                         <property name="action-name">win.refresh</property>

--- a/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
+++ b/src/plugins/connectivity_report/valent-connectivity_report-preferences.c
@@ -18,11 +18,8 @@ struct _ValentConnectivityReportPreferences
   ValentDevicePreferencesGroup  parent_instance;
 
   /* template */
-  AdwActionRow                *share_state_row;
-  GtkSwitch                   *share_state;
-
-  AdwActionRow                *offline_notification_row;
-  GtkSwitch                   *offline_notification;
+  GtkSwitch                    *share_state;
+  GtkSwitch                    *offline_notification;
 };
 
 G_DEFINE_FINAL_TYPE (ValentConnectivityReportPreferences, valent_connectivity_report_preferences, VALENT_TYPE_DEVICE_PREFERENCES_GROUP)
@@ -42,7 +39,6 @@ valent_connectivity_report_preferences_constructed (GObject *object)
   g_settings_bind (settings,          "share-state",
                    self->share_state, "active",
                    G_SETTINGS_BIND_DEFAULT);
-
   g_settings_bind (settings,                   "offline-notification",
                    self->offline_notification, "active",
                    G_SETTINGS_BIND_DEFAULT);
@@ -70,9 +66,7 @@ valent_connectivity_report_preferences_class_init (ValentConnectivityReportPrefe
   object_class->dispose = valent_connectivity_report_preferences_dispose;
 
   gtk_widget_class_set_template_from_resource (widget_class, "/plugins/connectivity_report/valent-connectivity_report-preferences.ui");
-  gtk_widget_class_bind_template_child (widget_class, ValentConnectivityReportPreferences, share_state_row);
   gtk_widget_class_bind_template_child (widget_class, ValentConnectivityReportPreferences, share_state);
-  gtk_widget_class_bind_template_child (widget_class, ValentConnectivityReportPreferences, offline_notification_row);
   gtk_widget_class_bind_template_child (widget_class, ValentConnectivityReportPreferences, offline_notification);
 }
 

--- a/src/plugins/connectivity_report/valent-connectivity_report-preferences.ui
+++ b/src/plugins/connectivity_report/valent-connectivity_report-preferences.ui
@@ -6,7 +6,7 @@
 <interface domain="valent">
   <template class="ValentConnectivityReportPreferences" parent="ValentDevicePreferencesGroup">
     <child>
-      <object class="AdwActionRow" id="share_state_row">
+      <object class="AdwActionRow">
         <property name="title" translatable="yes">Local Connectivity</property>
         <property name="selectable">0</property>
         <property name="subtitle" translatable="yes">Send updates to the remote device</property>
@@ -19,7 +19,7 @@
       </object>
     </child>
     <child>
-      <object class="AdwActionRow" id="offline_notification_row">
+      <object class="AdwActionRow">
         <property name="title" translatable="yes">Remote Connectivity</property>
         <property name="subtitle" translatable="yes">Notify if the remote device loses connectivity</property>
         <property name="selectable">0</property>

--- a/src/plugins/notification/valent-notification-preferences.ui
+++ b/src/plugins/notification/valent-notification-preferences.ui
@@ -112,33 +112,11 @@
                               bind-property="enable-expansion"
                               bind-flags="sync-create"/>
                     <child type="placeholder">
-                      <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">12</property>
-                        <property name="margin-start">12</property>
-                        <property name="margin-end">12</property>
-                        <property name="spacing">12</property>
-                        <property name="valign">center</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="halign">center</property>
-                            <property name="hexpand">1</property>
-                            <property name="icon-name">preferences-system-notifications-symbolic</property>
-                            <property name="pixel-size">64</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="halign">center</property>
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">No Applications</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                        </child>
+                      <object class="AdwStatusPage">
+                        <property name="icon-name">preferences-system-notifications-symbolic</property>
+                        <property name="title" translatable="yes">No Applications</property>
                         <style>
+                          <class name="compact"/>
                           <class name="dim-label"/>
                         </style>
                       </object>

--- a/src/plugins/sms/valent-sms-window.ui
+++ b/src/plugins/sms/valent-sms-window.ui
@@ -91,6 +91,7 @@
                             <property name="icon-name">view-list-symbolic</property>
                             <property name="title" translatable="yes">No Conversations</property>
                             <style>
+                              <class name="compact"/>
                               <class name="dim-label"/>
                             </style>
                           </object>

--- a/src/plugins/telephony/valent-telephony-preferences.ui
+++ b/src/plugins/telephony/valent-telephony-preferences.ui
@@ -7,7 +7,7 @@
   <template class="ValentTelephonyPreferences" parent="ValentDevicePreferencesGroup">
     <!-- Incoming Calls -->
     <child>
-      <object class="AdwExpanderRow" id="ringing_row">
+      <object class="AdwExpanderRow">
         <property name="title" translatable="yes">Incoming Calls</property>
         <property name="subtitle" translatable="yes">What to do when the phone rings</property>
         <property name="selectable">0</property>
@@ -38,7 +38,7 @@
 
     <!-- Ongoing Calls -->
     <child>
-      <object class="AdwExpanderRow" id="talking_row">
+      <object class="AdwExpanderRow">
         <property name="title" translatable="yes">Ongoing Calls</property>
         <property name="subtitle" translatable="yes">What to do when the phone is answered</property>
         <property name="selectable">0</property>


### PR DESCRIPTION
Cleanup a variety of minor UI elements, porting to `Adw.StatusPage`, removing unused template pointers, and other various tweaks.