### PR TITLE
refactor(device): stop exporting a private method

### DIFF
--- a/src/libvalent/device/valent-device-private.h
+++ b/src/libvalent/device/valent-device-private.h
@@ -11,9 +11,6 @@ _VALENT_EXTERN
 ValentDevice * valent_device_new_full      (JsonNode      *identity,
                                             ValentContext *context);
 _VALENT_EXTERN
-void           valent_device_handle_packet (ValentDevice  *device,
-                                            JsonNode      *packet);
-_VALENT_EXTERN
 void           valent_device_set_channel   (ValentDevice  *device,
                                             ValentChannel *channel);
 _VALENT_EXTERN

--- a/tests/fixtures/valent-test-utils.h
+++ b/tests/fixtures/valent-test-utils.h
@@ -34,6 +34,11 @@ void             valent_test_await_pointer (gpointer         *result);
 void             valent_test_await_nullptr (gpointer         *result);
 void             valent_test_await_signal  (gpointer          object,
                                             const char       *signal_name);
+void             valent_test_watch_signal  (gpointer          object,
+                                            const char       *signal_name,
+                                            gboolean         *watch);
+void             valent_test_watch_clear   (gpointer          object,
+                                            gboolean         *watch);
 void             valent_test_await_timeout (unsigned int      duration);
 JsonNode       * valent_test_load_json     (const char       *path);
 GSettings      * valent_test_mock_settings (const char       *domain);

--- a/tests/libvalent/clipboard/test-clipboard-component.c
+++ b/tests/libvalent/clipboard/test-clipboard-component.c
@@ -10,8 +10,6 @@ typedef struct
 {
   ValentClipboard        *clipboard;
   ValentClipboardAdapter *adapter;
-  GMainLoop              *loop;
-  gpointer                data;
 } ClipboardComponentFixture;
 
 static void
@@ -20,8 +18,6 @@ clipboard_component_fixture_set_up (ClipboardComponentFixture *fixture,
 {
   fixture->clipboard = valent_clipboard_get_default ();
   fixture->adapter = valent_test_await_adapter (fixture->clipboard);
-  fixture->loop = g_main_loop_new (NULL, FALSE);
-
   g_object_ref (fixture->adapter);
 }
 
@@ -31,114 +27,111 @@ clipboard_component_fixture_tear_down (ClipboardComponentFixture *fixture,
 {
   v_assert_finalize_object (fixture->clipboard);
   v_await_finalize_object (fixture->adapter);
-  g_clear_pointer (&fixture->loop, g_main_loop_unref);
 }
 
 static void
-on_changed (ValentClipboardAdapter    *adapter,
-            ClipboardComponentFixture *fixture)
+on_changed (ValentClipboardAdapter *adapter,
+            gboolean               *done)
 {
-  fixture->data = adapter;
+  if (done != NULL)
+    *done = TRUE;
 }
 
 static void
-valent_clipboard_adapter_read_bytes_cb (ValentClipboardAdapter    *adapter,
-                                        GAsyncResult              *result,
-                                        ClipboardComponentFixture *fixture)
-{
-  GError *error = NULL;
-
-  fixture->data = valent_clipboard_adapter_read_bytes_finish (adapter,
-                                                              result,
-                                                              &error);
-  g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
-}
-
-static void
-valent_clipboard_adapter_write_bytes_cb (ValentClipboardAdapter    *adapter,
-                                         GAsyncResult              *result,
-                                         ClipboardComponentFixture *fixture)
-{
-  gboolean ret;
-  GError *error = NULL;
-
-  ret = valent_clipboard_adapter_write_bytes_finish (adapter, result, &error);
-  g_assert_true (ret);
-  g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
-}
-
-static void
-valent_clipboard_read_bytes_cb (ValentClipboard           *clipboard,
-                                GAsyncResult              *result,
-                                ClipboardComponentFixture *fixture)
+valent_clipboard_adapter_read_bytes_cb (ValentClipboardAdapter  *adapter,
+                                        GAsyncResult            *result,
+                                        GBytes                 **bytes)
 {
   GError *error = NULL;
 
-  fixture->data = valent_clipboard_read_bytes_finish (clipboard, result, &error);
+  if (bytes != NULL)
+    *bytes = valent_clipboard_adapter_read_bytes_finish (adapter,
+                                                         result,
+                                                         &error);
+
   g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
 }
 
 static void
-valent_clipboard_write_bytes_cb (ValentClipboard           *clipboard,
-                                 GAsyncResult              *result,
-                                 ClipboardComponentFixture *fixture)
+valent_clipboard_adapter_write_bytes_cb (ValentClipboardAdapter *adapter,
+                                         GAsyncResult           *result,
+                                         gboolean               *done)
 {
-  gboolean ret;
   GError *error = NULL;
 
-  ret = valent_clipboard_write_bytes_finish (clipboard, result, &error);
-  g_assert_true (ret);
+  if (done != NULL)
+    *done = valent_clipboard_adapter_write_bytes_finish (adapter,
+                                                         result,
+                                                         &error);
+
   g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
 }
 
 static void
-valent_clipboard_read_text_cb (ValentClipboard           *clipboard,
-                               GAsyncResult              *result,
-                               ClipboardComponentFixture *fixture)
+valent_clipboard_read_bytes_cb (ValentClipboard  *clipboard,
+                                GAsyncResult     *result,
+                                GBytes          **bytes)
 {
   GError *error = NULL;
 
-  fixture->data = valent_clipboard_read_text_finish (clipboard, result, &error);
+  if (bytes != NULL)
+    *bytes = valent_clipboard_read_bytes_finish (clipboard, result, &error);
+
   g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
 }
 
 static void
-valent_clipboard_write_text_cb (ValentClipboard           *clipboard,
-                                GAsyncResult              *result,
-                                ClipboardComponentFixture *fixture)
+valent_clipboard_write_bytes_cb (ValentClipboard *clipboard,
+                                 GAsyncResult    *result,
+                                 gboolean        *done)
 {
-  gboolean ret;
   GError *error = NULL;
 
-  ret = valent_clipboard_write_text_finish (clipboard, result, &error);
-  g_assert_true (ret);
+  if (done != NULL)
+    *done = valent_clipboard_write_bytes_finish (clipboard, result, &error);
+
   g_assert_no_error (error);
-  g_main_loop_quit (fixture->loop);
+}
+
+static void
+valent_clipboard_read_text_cb (ValentClipboard  *clipboard,
+                               GAsyncResult     *result,
+                               char            **text)
+{
+  GError *error = NULL;
+
+  if (text != NULL)
+    *text = valent_clipboard_read_text_finish (clipboard, result, &error);
+
+  g_assert_no_error (error);
+}
+
+static void
+valent_clipboard_write_text_cb (ValentClipboard *clipboard,
+                                GAsyncResult    *result,
+                                gboolean        *done)
+{
+  GError *error = NULL;
+
+  if (done != NULL)
+    *done = valent_clipboard_write_text_finish (clipboard, result, &error);
+
+  g_assert_no_error (error);
 }
 
 static void
 test_clipboard_component_adapter (ClipboardComponentFixture *fixture,
                                   gconstpointer              user_data)
 {
-  PeasPluginInfo *info;
   g_autoptr (GBytes) bytes = NULL;
+  g_autoptr (GBytes) bytes_read = NULL;
   g_autofree char *text = NULL;
+  g_autofree char *text_read = NULL;
   g_auto (GStrv) mimetypes = NULL;
   int64_t timestamp = 0;
+  gboolean done = FALSE;
 
-  /* Adapter Properties */
-  g_object_get (fixture->adapter,
-                "plugin-info", &info,
-                NULL);
-  g_assert_nonnull (info);
-  g_boxed_free (PEAS_TYPE_PLUGIN_INFO, info);
-
-  /* Data can be written */
+  VALENT_TEST_CHECK ("Adapter handles bytes written to the clipboard");
   text = g_uuid_string_random ();
   bytes = g_bytes_new_take (text, strlen (text) + 1);
   text = NULL;
@@ -147,45 +140,75 @@ test_clipboard_component_adapter (ClipboardComponentFixture *fixture,
                                         bytes,
                                         NULL,
                                         (GAsyncReadyCallback)valent_clipboard_adapter_write_bytes_cb,
-                                        fixture);
-  g_main_loop_run (fixture->loop);
+                                        &done);
+  valent_test_await_boolean (&done);
 
-  /* Data can be read */
+  VALENT_TEST_CHECK ("Adapter handles bytes read from the clipboard");
   valent_clipboard_adapter_read_bytes (fixture->adapter,
                                        "text/plain;charset=utf-8",
                                        NULL,
                                        (GAsyncReadyCallback)valent_clipboard_adapter_read_bytes_cb,
-                                       fixture);
-  g_main_loop_run (fixture->loop);
+                                       &bytes_read);
+  valent_test_await_pointer (&bytes_read);
 
   g_assert_cmpmem (g_bytes_get_data (bytes, NULL),
                    g_bytes_get_size (bytes),
-                   g_bytes_get_data (fixture->data, NULL),
-                   g_bytes_get_size (fixture->data));
-  g_clear_pointer (&fixture->data, g_bytes_unref);
+                   g_bytes_get_data (bytes_read, NULL),
+                   g_bytes_get_size (bytes_read));
+  g_clear_pointer (&bytes_read, g_bytes_unref);
 
-  /* Timestamp is updated */
+  VALENT_TEST_CHECK ("Adapter updates the content timestamp");
   timestamp = valent_clipboard_adapter_get_timestamp (fixture->adapter);
   g_assert_cmpint (timestamp, !=, 0);
 
-  /* Mimetypes are updated */
+  VALENT_TEST_CHECK ("Adapter updates the content mime-types");
   mimetypes = valent_clipboard_adapter_get_mimetypes (fixture->adapter);
   g_assert_nonnull (mimetypes);
   g_assert_true (g_strv_contains ((const char * const *)mimetypes,
                                   "text/plain;charset=utf-8"));
   g_clear_pointer (&mimetypes, g_strfreev);
 
-  /* Signals are emitted from adapter */
+  VALENT_TEST_CHECK ("Adapter handles text written to the clipboard");
+  text = g_uuid_string_random ();
+  valent_clipboard_write_text (fixture->clipboard,
+                               text,
+                               NULL,
+                               (GAsyncReadyCallback)valent_clipboard_write_text_cb,
+                               &done);
+  valent_test_await_boolean (&done);
+
+  VALENT_TEST_CHECK ("Adapter handles text read from the clipboard");
+  valent_clipboard_read_text (fixture->clipboard,
+                              NULL,
+                              (GAsyncReadyCallback)valent_clipboard_read_text_cb,
+                              &text_read);
+  valent_test_await_pointer (&text_read);
+
+  g_assert_cmpstr (text_read, ==, text);
+  g_clear_pointer (&text_read, g_free);
+  g_clear_pointer (&text, g_free);
+
+  VALENT_TEST_CHECK ("Adapter updates the content timestamp");
+  timestamp = valent_clipboard_adapter_get_timestamp (fixture->adapter);
+  g_assert_cmpint (timestamp, !=, 0);
+
+  VALENT_TEST_CHECK ("Adapter updates the content mime-types");
+  mimetypes = valent_clipboard_adapter_get_mimetypes (fixture->adapter);
+  g_assert_nonnull (mimetypes);
+  g_assert_true (g_strv_contains ((const char * const *)mimetypes,
+                                  "text/plain;charset=utf-8"));
+  g_clear_pointer (&mimetypes, g_strfreev);
+
+  VALENT_TEST_CHECK ("Adapter emits `ValentClipboardAdapter::changed`");
   g_signal_connect (fixture->adapter,
                     "changed",
                     G_CALLBACK (on_changed),
-                    fixture);
+                    &done);
 
   valent_clipboard_adapter_changed (fixture->adapter);
-  g_assert_true (fixture->data == fixture->adapter);
-  fixture->data = NULL;
+  valent_test_await_boolean (&done);
 
-  g_signal_handlers_disconnect_by_data (fixture->adapter, fixture);
+  g_signal_handlers_disconnect_by_data (fixture->adapter, &done);
 }
 
 static void
@@ -193,11 +216,14 @@ test_clipboard_component_self (ClipboardComponentFixture *fixture,
                                gconstpointer              user_data)
 {
   g_autoptr (GBytes) bytes = NULL;
+  g_autoptr (GBytes) bytes_read = NULL;
   g_autofree char *text = NULL;
+  g_autofree char *text_read = NULL;
   g_auto (GStrv) mimetypes = NULL;
   int64_t timestamp = 0;
+  gboolean done = FALSE;
 
-  /* Data can be written */
+  VALENT_TEST_CHECK ("Clipboard handles bytes written to it");
   text = g_uuid_string_random ();
   bytes = g_bytes_new_take (text, strlen (text) + 1);
   text = NULL;
@@ -206,76 +232,75 @@ test_clipboard_component_self (ClipboardComponentFixture *fixture,
                                 bytes,
                                 NULL,
                                 (GAsyncReadyCallback)valent_clipboard_write_bytes_cb,
-                                fixture);
-  g_main_loop_run (fixture->loop);
+                                &done);
+  valent_test_await_boolean (&done);
 
-  /* Data can be read */
+  VALENT_TEST_CHECK ("Clipboard handles bytes read from it");
   valent_clipboard_read_bytes (fixture->clipboard,
                                "text/plain;charset=utf-8",
                                NULL,
                                (GAsyncReadyCallback)valent_clipboard_read_bytes_cb,
-                               fixture);
-  g_main_loop_run (fixture->loop);
+                               &bytes_read);
+  valent_test_await_pointer (&bytes_read);
 
   g_assert_cmpmem (g_bytes_get_data (bytes, NULL),
                    g_bytes_get_size (bytes),
-                   g_bytes_get_data (fixture->data, NULL),
-                   g_bytes_get_size (fixture->data));
-  g_clear_pointer (&fixture->data, g_bytes_unref);
+                   g_bytes_get_data (bytes_read, NULL),
+                   g_bytes_get_size (bytes_read));
+  g_clear_pointer (&bytes_read, g_bytes_unref);
 
-  /* Timestamp is updated */
+  VALENT_TEST_CHECK ("Clipboard updates the content timestamp");
   timestamp = valent_clipboard_get_timestamp (fixture->clipboard);
   g_assert_cmpint (timestamp, !=, 0);
 
-  /* Mimetypes are updated */
+  VALENT_TEST_CHECK ("Clipboard updates the content mime-types");
   mimetypes = valent_clipboard_get_mimetypes (fixture->clipboard);
   g_assert_nonnull (mimetypes);
   g_assert_true (g_strv_contains ((const char * const *)mimetypes,
                                   "text/plain;charset=utf-8"));
   g_clear_pointer (&mimetypes, g_strfreev);
 
-  /* Text can be written */
+  VALENT_TEST_CHECK ("Clipboard handles text written to the clipboard");
   text = g_uuid_string_random ();
   valent_clipboard_write_text (fixture->clipboard,
                                text,
                                NULL,
                                (GAsyncReadyCallback)valent_clipboard_write_text_cb,
-                               fixture);
-  g_main_loop_run (fixture->loop);
+                               &done);
+  valent_test_await_boolean (&done);
 
-  /* Text can be read */
+  VALENT_TEST_CHECK ("Clipboard handles text read from the clipboard");
   valent_clipboard_read_text (fixture->clipboard,
                               NULL,
                               (GAsyncReadyCallback)valent_clipboard_read_text_cb,
-                              fixture);
-  g_main_loop_run (fixture->loop);
+                              &text_read);
+  valent_test_await_pointer (&text_read);
 
-  g_assert_cmpstr (fixture->data, ==, text);
-  g_clear_pointer (&fixture->data, g_free);
+  g_assert_cmpstr (text_read, ==, text);
+  g_clear_pointer (&text_read, g_free);
   g_clear_pointer (&text, g_free);
 
-  /* Timestamp is updated */
+  VALENT_TEST_CHECK ("Clipboard updates the content timestamp");
   timestamp = valent_clipboard_get_timestamp (fixture->clipboard);
   g_assert_cmpint (timestamp, !=, 0);
 
-  /* Mimetypes are updated */
+  VALENT_TEST_CHECK ("Clipboard updates the content mime-types");
   mimetypes = valent_clipboard_get_mimetypes (fixture->clipboard);
   g_assert_nonnull (mimetypes);
   g_assert_true (g_strv_contains ((const char * const *)mimetypes,
                                   "text/plain;charset=utf-8"));
   g_clear_pointer (&mimetypes, g_strfreev);
 
-  /* Signals are propagated from adapter */
+  VALENT_TEST_CHECK ("Clipboard propagates `ValentClipboardAdapter::changed`");
   g_signal_connect (fixture->clipboard,
                     "changed",
                     G_CALLBACK (on_changed),
-                    fixture);
+                    &done);
 
   valent_clipboard_adapter_changed (fixture->adapter);
-  g_assert_true (fixture->data == fixture->clipboard);
-  fixture->data = NULL;
+  valent_test_await_boolean (&done);
 
-  g_signal_handlers_disconnect_by_data (fixture->clipboard, fixture);
+  g_signal_handlers_disconnect_by_data (fixture->clipboard, &done);
 }
 
 int

--- a/tests/plugins/battery/test-battery-plugin.c
+++ b/tests/plugins/battery/test-battery-plugin.c
@@ -98,6 +98,11 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   gboolean is_present;
   int64_t time_to_empty;
   int64_t time_to_full;
+  gboolean watch = FALSE;
+
+  valent_test_watch_signal (actions,
+                            "action-state-changed::battery.state",
+                            &watch);
 
   VALENT_TEST_CHECK ("Plugin action `battery.state` starts disabled");
   g_assert_false (g_action_group_get_action_enabled (actions, "battery.state"));
@@ -115,6 +120,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"empty\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "empty-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin action `battery.state` is enabled if a status "
                      "packet is received");
@@ -142,6 +148,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"caution\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "caution-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -165,6 +172,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"low\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "low-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -188,6 +196,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"good\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "good-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -211,6 +220,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"full\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "full-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -234,6 +244,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"charged\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "charged-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -257,6 +268,7 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles \"missing\" battery update");
   packet = valent_test_fixture_lookup_packet (fixture, "missing-battery");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   VALENT_TEST_CHECK ("Plugin updates `battery.state` action to expected value");
   state = g_action_group_get_action_state (actions, "battery.state");
@@ -274,6 +286,8 @@ test_battery_plugin_handle_update (ValentTestFixture *fixture,
   g_assert_false (is_present);
 
   g_clear_pointer (&state, g_variant_unref);
+
+  valent_test_watch_clear (actions, &watch);
 }
 
 static void

--- a/tests/plugins/clipboard/test-clipboard-plugin.c
+++ b/tests/plugins/clipboard/test-clipboard-plugin.c
@@ -7,14 +7,6 @@
 
 
 static void
-clipboard_plugin_fixture_tear_down (ValentTestFixture *fixture,
-                                    gconstpointer      user_data)
-{
-  g_clear_pointer (&fixture->data, g_free);
-  valent_test_fixture_clear (fixture, user_data);
-}
-
-static void
 valent_clipboard_read_text_cb (ValentClipboard *clipboard,
                                GAsyncResult    *result,
                                gpointer        *text)
@@ -49,6 +41,7 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
                                       gconstpointer      user_data)
 {
   JsonNode *packet;
+  char *content = NULL;
 
   g_settings_set_boolean (fixture->settings, "auto-pull", TRUE);
   g_settings_set_boolean (fixture->settings, "auto-push", TRUE);
@@ -67,11 +60,11 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   valent_clipboard_read_text (valent_clipboard_get_default (),
                               NULL,
                               (GAsyncReadyCallback)valent_clipboard_read_text_cb,
-                              &fixture->data);
-  valent_test_await_pointer (&fixture->data);
+                              &content);
+  valent_test_await_pointer (&content);
 
-  g_assert_cmpstr (fixture->data, ==, "clipboard-connect");
-  g_clear_pointer (&fixture->data, g_free);
+  g_assert_cmpstr (content, ==, "clipboard-connect");
+  g_clear_pointer (&content, g_free);
 
   VALENT_TEST_CHECK ("Plugin copies remote content to the local clipboard");
   packet = valent_test_fixture_lookup_packet (fixture, "clipboard-content");
@@ -80,11 +73,11 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   valent_clipboard_read_text (valent_clipboard_get_default (),
                               NULL,
                               (GAsyncReadyCallback)valent_clipboard_read_text_cb,
-                              &fixture->data);
-  valent_test_await_pointer (&fixture->data);
+                              &content);
+  valent_test_await_pointer (&content);
 
-  g_assert_cmpstr (fixture->data, ==, "clipboard-content");
-  g_clear_pointer (&fixture->data, g_free);
+  g_assert_cmpstr (content, ==, "clipboard-content");
+  g_clear_pointer (&content, g_free);
 
   VALENT_TEST_CHECK ("Plugin ignores connect-time content that is outdated");
   packet = valent_test_fixture_lookup_packet (fixture, "clipboard-connect");
@@ -95,11 +88,11 @@ test_clipboard_plugin_handle_content (ValentTestFixture *fixture,
   valent_clipboard_read_text (valent_clipboard_get_default (),
                               NULL,
                               (GAsyncReadyCallback)valent_clipboard_read_text_cb,
-                              &fixture->data);
-  valent_test_await_pointer (&fixture->data);
+                              &content);
+  valent_test_await_pointer (&content);
 
-  g_assert_cmpstr (fixture->data, ==, "clipboard-content");
-  g_clear_pointer (&fixture->data, g_free);
+  g_assert_cmpstr (content, ==, "clipboard-content");
+  g_clear_pointer (&content, g_free);
 }
 
 static void
@@ -137,6 +130,7 @@ test_clipboard_plugin_actions (ValentTestFixture *fixture,
 {
   GActionGroup *actions = G_ACTION_GROUP (fixture->device);
   JsonNode *packet;
+  char *content = NULL;
 
   /* NOTE: no connect-time packets with `auto-push` disabled */
   g_settings_set_boolean (fixture->settings, "auto-push", FALSE);
@@ -159,11 +153,11 @@ test_clipboard_plugin_actions (ValentTestFixture *fixture,
   valent_clipboard_read_text (valent_clipboard_get_default (),
                               NULL,
                               (GAsyncReadyCallback)valent_clipboard_read_text_cb,
-                              &fixture->data);
-  valent_test_await_pointer (&fixture->data);
+                              &content);
+  valent_test_await_pointer (&content);
 
-  g_assert_cmpstr (fixture->data, ==, "clipboard-content");
-  g_clear_pointer (&fixture->data, g_free);
+  g_assert_cmpstr (content, ==, "clipboard-content");
+  g_clear_pointer (&content, g_free);
 
   VALENT_TEST_CHECK ("Plugin action `clipboard.push` sends content to the device");
   valent_clipboard_write_text (valent_clipboard_get_default (),
@@ -208,25 +202,25 @@ main (int   argc,
               ValentTestFixture, path,
               valent_test_fixture_init,
               test_clipboard_plugin_connect,
-              clipboard_plugin_fixture_tear_down);
+              valent_test_fixture_clear);
 
   g_test_add ("/plugins/clipboard/handle-content",
               ValentTestFixture, path,
               valent_test_fixture_init,
               test_clipboard_plugin_handle_content,
-              clipboard_plugin_fixture_tear_down);
+              valent_test_fixture_clear);
 
   g_test_add ("/plugins/clipboard/send-content",
               ValentTestFixture, path,
               valent_test_fixture_init,
               test_clipboard_plugin_send_content,
-              clipboard_plugin_fixture_tear_down);
+              valent_test_fixture_clear);
 
   g_test_add ("/plugins/clipboard/actions",
               ValentTestFixture, path,
               valent_test_fixture_init,
               test_clipboard_plugin_actions,
-              clipboard_plugin_fixture_tear_down);
+              valent_test_fixture_clear);
 
   g_test_add ("/plugins/clipboard/fuzz",
               ValentTestFixture, path,

--- a/tests/plugins/lan/test-lan-dnssd.c
+++ b/tests/plugins/lan/test-lan-dnssd.c
@@ -12,7 +12,6 @@
 
 typedef struct
 {
-  GMainLoop  *loop;
   JsonNode   *packets;
   GListModel *dnssd;
 
@@ -26,7 +25,6 @@ lan_dnssd_fixture_set_up (LanDNSSDFixture *fixture,
 {
   JsonNode *identity;
 
-  fixture->loop = g_main_loop_new (NULL, FALSE);
   fixture->packets = valent_test_load_json ("plugin-lan.json");
 
   identity = json_object_get_member (json_node_get_object (fixture->packets),
@@ -44,7 +42,6 @@ lan_dnssd_fixture_tear_down (LanDNSSDFixture *fixture,
 {
   v_await_finalize_object (fixture->dnssd);
 
-  g_clear_pointer (&fixture->loop, g_main_loop_unref);
   g_clear_pointer (&fixture->packets, json_node_unref);
   g_clear_pointer (&fixture->data, g_ptr_array_unref);
 }

--- a/tests/plugins/telephony/test-telephony-plugin.c
+++ b/tests/plugins/telephony/test-telephony-plugin.c
@@ -83,12 +83,17 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
 {
   MixerInfo *info = fixture->data;
   JsonNode *packet;
+  gboolean watch = FALSE;
+
+  valent_test_watch_signal (info->speakers, "notify", &watch);
+  valent_test_watch_signal (info->microphone, "notify", &watch);
 
   valent_test_fixture_connect (fixture, TRUE);
 
   VALENT_TEST_CHECK ("Plugin handles a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "ringing");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -100,6 +105,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `isCancel` event, following a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "ringing-cancel");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 100);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -119,6 +125,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "ringing");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -130,6 +137,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `talking` event, following a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "talking");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, TRUE);
@@ -141,6 +149,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `isCancel` event, following a `talking` event");
   packet = valent_test_fixture_lookup_packet (fixture, "talking-cancel");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 100);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -162,6 +171,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "ringing");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -174,6 +184,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `talking` event, following a `ringing` event");
   packet = valent_test_fixture_lookup_packet (fixture, "talking");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -185,6 +196,7 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   VALENT_TEST_CHECK ("Plugin handles a `isCancel` event, following a `talking` event");
   packet = valent_test_fixture_lookup_packet (fixture, "talking-cancel");
   valent_test_fixture_handle_packet (fixture, packet);
+  valent_test_await_boolean (&watch);
 
   g_assert_cmpuint (valent_mixer_stream_get_level (info->speakers), ==, 15);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->speakers), ==, FALSE);
@@ -192,6 +204,9 @@ test_telephony_plugin_handle_event (ValentTestFixture *fixture,
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->microphone), ==, FALSE);
   g_assert_cmpuint (valent_mixer_stream_get_level (info->headphones), ==, 100);
   g_assert_cmpuint (valent_mixer_stream_get_muted (info->headphones), ==, FALSE);
+
+  valent_test_watch_clear (info->speakers, &watch);
+  valent_test_watch_clear (info->microphone, &watch);
 }
 
 static void


### PR DESCRIPTION
Remove `valent_device_handle_packet()` from the private header, in an effort to stop exposing private symbols to test fixtures.