### PR TITLE
build(deps): bump libportal to 0.7.1

### DIFF
--- a/build-aux/contrib/valent.spec
+++ b/build-aux/contrib/valent.spec
@@ -7,7 +7,7 @@
 %global libeds_version >= 3.34.0
 %global sqlite_version >= 3.24.0
 %global libadwaita_version >= 1.2.0
-%global libportal_version >= 0.5, pkgconfig(libportal) <= 0.6
+%global libportal_version >= 0.6, pkgconfig(libportal) <= 0.7.1
 
 Name:           valent
 Version:        1.0.0~alpha

--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -160,7 +160,6 @@
             "buildsystem" : "meson",
             "builddir" : true,
             "config-opts" : [
-                "-Dbackends=gtk4",
                 "-Ddocs=false",
                 "-Dintrospection=false",
                 "-Dvapi=false"
@@ -169,8 +168,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/libportal.git",
-                    "commit" : "13df0b887a7eb7b0f9b14069561a41f62e813155",
-                    "tag" : "0.6"
+                    "commit" : "e9ed3a50cdde321eaf42361212480a66eb94a57a",
+                    "tag" : "0.7.1"
                 }
             ]
         },

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -183,7 +183,6 @@
             "buildsystem" : "meson",
             "builddir" : true,
             "config-opts" : [
-                "-Dbackends=gtk4",
                 "-Ddocs=false",
                 "-Dintrospection=false",
                 "-Dvapi=false"
@@ -192,8 +191,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/libportal.git",
-                    "commit" : "13df0b887a7eb7b0f9b14069561a41f62e813155",
-                    "tag" : "0.6",
+                    "commit" : "e9ed3a50cdde321eaf42361212480a66eb94a57a",
+                    "tag" : "0.7.1",
                     "x-checker-data" : {
                         "type" : "anitya",
                         "project-id" : 230124,

--- a/meson.build
+++ b/meson.build
@@ -186,7 +186,7 @@ libpeas_version = '>= 1.22.0'
 eds_version = '>= 3.34'
 sqlite_version = '>= 3.24.0'
 libadwaita_version = '>= 1.2.0'
-libportal_version = ['>= 0.5', '<= 0.6']
+libportal_version = ['>= 0.6', '<= 0.7.1']
 
 libm_dep = cc.find_library('m', required: true)
 gio_dep = dependency('gio-2.0', version: glib_version)
@@ -206,7 +206,6 @@ if not libportal_dep.found()
             version: libportal_version,
            fallback: ['libportal', 'libportal_dep'],
     default_options: [
-      'backends=gtk4',
       'docs=false',
       'introspection=false',
       'vapi=false',

--- a/subprojects/libportal.wrap
+++ b/subprojects/libportal.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory=libportal
 url=https://github.com/flatpak/libportal.git
-revision=0.6
+revision=0.7.1
 depth=1
 


### PR DESCRIPTION
Raise the minimum version to 0.6, since that'll be around for awhile.

closes #560
closes #569