### PR TITLE
ci: add libpeas-2 to the Dockerfile

### DIFF
--- a/build-aux/docker/Dockerfile
+++ b/build-aux/docker/Dockerfile
@@ -24,6 +24,20 @@ RUN dnf install -y --enablerepo=fedora-debuginfo,updates-debuginfo \
         sqlite-devel                  sqlite-debuginfo && \
     dnf clean all && rm -rf /var/cache/dnf
 
+# Build libpeas-2, until it's available in Fedora
+RUN git clone https://gitlab.gnome.org/GNOME/libpeas.git \
+              --branch main \
+              --single-branch && \
+    cd libpeas && \
+    meson setup --prefix=/usr \
+                -Dgjs=false \
+                -Dlua51=false \
+                -Dpython3=false \
+                -Dintrospection=true \
+                -Dvapi=true \
+                _build && \
+    meson install -C _build
+
 # Build libwalbottle from source, since it's not available in most repositories
 RUN git clone https://gitlab.com/walbottle/walbottle.git \
               --branch main \


### PR DESCRIPTION
libpeas-2 is not available in `fedora:39`, and fussing with a subproject is not really worth the trouble at this point.

Add build and install the dependency in the CI, so test can be run until its available or someone reports it as a necessity.