### PR TITLE
ci: stop building libpeas in the container

### DIFF
--- a/build-aux/docker/Dockerfile
+++ b/build-aux/docker/Dockerfile
@@ -26,20 +26,6 @@ RUN dnf install -y \
         sqlite-devel                  sqlite-debuginfo && \
     dnf clean all && rm -rf /var/cache/dnf
 
-# Build libpeas-2, until it's available in Fedora
-RUN git clone https://gitlab.gnome.org/GNOME/libpeas.git \
-              --branch main \
-              --single-branch && \
-    cd libpeas && \
-    meson setup --prefix=/usr \
-                -Dgjs=false \
-                -Dlua51=false \
-                -Dpython3=false \
-                -Dintrospection=true \
-                -Dvapi=true \
-                _build && \
-    meson install -C _build
-
 # Build libwalbottle from source, since it's not available in most repositories
 RUN git clone https://gitlab.com/walbottle/walbottle.git \
               --branch main \


### PR DESCRIPTION
libpeas-2 is now available in fedora-updates