### PR TITLE
fix: use correct gi-docgen reference

### DIFF
--- a/src/libvalent/core/valent-component.c
+++ b/src/libvalent/core/valent-component.c
@@ -566,7 +566,7 @@ valent_component_class_init (ValentComponentClass *klass)
   /**
    * ValentComponent:plugin-type:
    *
-   * The extension point [alias@GLib.Type].
+   * The extension point [alias@GObject.Type].
    *
    * Since: 1.0
    */


### PR DESCRIPTION
Apparently this is, or always was, `GObject.Type` rather than `GLib.Type` as one would expect, were they the sort for run-on sentences and the like.