### PR TITLE
fix: private header includes

### DIFF
--- a/src/libvalent/device/valent-certificate.c
+++ b/src/libvalent/device/valent-certificate.c
@@ -12,7 +12,7 @@
 #include <gnutls/abstract.h>
 #include <gnutls/x509.h>
 
-#include "libvalent-core.h"
+#include <libvalent-core.h>
 #include "valent-certificate.h"
 
 #define DEFAULT_EXPIRATION (60L*60L*24L*10L*365L)

--- a/src/libvalent/device/valent-certificate.h
+++ b/src/libvalent/device/valent-certificate.h
@@ -9,21 +9,21 @@
 
 #include <gio/gio.h>
 
-#include "valent-version.h"
+#include "../core/valent-version.h"
 
 G_BEGIN_DECLS
 
 VALENT_AVAILABLE_IN_1_0
-void              valent_certificate_new             (const char           *path,
-                                                      GCancellable         *cancellable,
-                                                      GAsyncReadyCallback   callback,
-                                                      gpointer              user_data);
+void              valent_certificate_new             (const char             *path,
+                                                      GCancellable           *cancellable,
+                                                      GAsyncReadyCallback     callback,
+                                                      gpointer                user_data);
 VALENT_AVAILABLE_IN_1_0
-GTlsCertificate * valent_certificate_new_finish      (GAsyncResult         *result,
-                                                      GError              **error);
+GTlsCertificate * valent_certificate_new_finish      (GAsyncResult           *result,
+                                                      GError                **error);
 VALENT_AVAILABLE_IN_1_0
-GTlsCertificate * valent_certificate_new_sync        (const char           *path,
-                                                      GError              **error);
+GTlsCertificate * valent_certificate_new_sync        (const char             *path,
+                                                      GError                **error);
 VALENT_AVAILABLE_IN_1_0
 const char      * valent_certificate_get_common_name (GTlsCertificate  *certificate);
 VALENT_AVAILABLE_IN_1_0


### PR DESCRIPTION
There were some errant includes of built-time private headers causing external builds fail (e.g. plugins).