### PR TITLE
feat: adopt standardized KDE Connect device ID

### DIFF
--- a/doc/schemas/kdeconnect.identity.json
+++ b/doc/schemas/kdeconnect.identity.json
@@ -7,7 +7,7 @@
             "id": 0,
             "type": "kdeconnect.identity",
             "body": {
-                "deviceId": "abcdef0123456789",
+                "deviceId": "740bd4b9_b418_4ee4_97d6_caf1da8151be",
                 "deviceName": "FOSS Phone",
                 "deviceType": "phone",
                 "incomingCapabilities": [
@@ -48,8 +48,9 @@
             ],
             "properties": {
                 "deviceId": {
-                    "description": "A unique ID for the device.",
-                    "type": "string"
+                    "description": "A unique ID for the device, which should be a UUIDv4 string with hyphens (`-`) replaced with underscores (`_`), such as `740bd4b9_b418_4ee4_97d6_caf1da8151be`.\n\n    Note that older clients may report a device ID in a different format, and a compliant implementation must accept and respond with the device's reported ID. Implementations are responsible for any sanitization necessary for internal use.",
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{8}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{12}|.*$"
                 },
                 "deviceName": {
                     "description": "A human-readable label for the device.",
@@ -89,3 +90,4 @@
         }
     }
 }
+

--- a/src/libvalent/device/valent-certificate.c
+++ b/src/libvalent/device/valent-certificate.c
@@ -14,6 +14,7 @@
 
 #include <libvalent-core.h>
 #include "valent-certificate.h"
+#include "valent-device.h"
 
 #define DEFAULT_EXPIRATION (60L*60L*24L*10L*365L)
 #define DEFAULT_KEY_SIZE   4096
@@ -247,7 +248,7 @@ valent_certificate_new_finish (GAsyncResult  *result,
  *
  * If either one doesn't exist, a new certificate and private key pair will be
  * generated. The common name will be set to a string returned by
- * [func@GLib.uuid_string_random].
+ * [func@Valent.Device.generate_id].
  *
  * If either generating or loading the certificate fails, %NULL will be returned
  * with @error set.
@@ -274,7 +275,7 @@ valent_certificate_new_sync (const char  *path,
     {
       g_autofree char *cn = NULL;
 
-      cn = g_uuid_string_random ();
+      cn = valent_device_generate_id ();
 
       if (!valent_certificate_generate (cert_path, key_path, cn, error))
         return FALSE;

--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -891,7 +891,7 @@ valent_device_manager_constructed (GObject *object)
 
   if (self->id == NULL)
     {
-      self->id = g_uuid_string_random ();
+      self->id = valent_device_generate_id ();
       g_warning ("%s(): %s", G_STRFUNC, error->message);
     }
 

--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -1611,6 +1611,33 @@ valent_device_get_state (ValentDevice *device)
   return state;
 }
 
+/**
+ * valent_device_generate_id:
+ *
+ * Generate a new KDE Connect device ID.
+ *
+ * A compliant device ID is a UUIDv4 string with hyphens (`-`) replaced with
+ * underscores (`_`), although for backward compatibility strings of any length
+ * and content are accepted.
+ *
+ * Returns: (transfer full): a new KDE Connect device ID
+ *
+ * Since: 1.0
+ */
+char *
+valent_device_generate_id (void)
+{
+  char *id = g_uuid_string_random ();
+
+  for (uint_fast8_t i = 0; id[i] != '\0'; i++)
+    {
+      if G_UNLIKELY (id[i] == '-')
+        id[i] = '_';
+    }
+
+  return g_steal_pointer (&id);
+}
+
 /*< private >
  * valent_device_reload_plugins:
  * @device: a `ValentDevice`

--- a/src/libvalent/device/valent-device.h
+++ b/src/libvalent/device/valent-device.h
@@ -68,6 +68,8 @@ VALENT_AVAILABLE_IN_1_0
 gboolean            valent_device_send_packet_finish (ValentDevice         *device,
                                                       GAsyncResult         *result,
                                                       GError              **error);
+VALENT_AVAILABLE_IN_1_0
+char              * valent_device_generate_id        (void);
 
 G_END_DECLS
 

--- a/tests/plugins/lan/test-lan-plugin.c
+++ b/tests/plugins/lan/test-lan-plugin.c
@@ -82,7 +82,7 @@ lan_service_fixture_set_up (LanBackendFixture *fixture,
   JsonNode *identity;
   GError *error = NULL;
 
-  device_id = g_uuid_string_random ();
+  device_id = valent_device_generate_id ();
   context = valent_context_new (NULL, "network", device_id);
   plugin_info = peas_engine_get_plugin_info (valent_get_plugin_engine (), "lan");
   fixture->service = g_object_new (VALENT_TYPE_LAN_CHANNEL_SERVICE,


### PR DESCRIPTION
Add `valent_device_generate_id()` and adopt it for use throughout
Valent, including tests. Existing test vectors are left as-is for
now, although later tests should be added for generating compliant
IDs and accepting backward-compatible IDs.

closes #643