### PR TITLE
fix(share): remove defunct property

### DIFF
--- a/src/libvalent/ui/valent-ui-manager.c
+++ b/src/libvalent/ui/valent-ui-manager.c
@@ -59,7 +59,7 @@ main_window_action (GSimpleAction *action,
                                       G_ACTION_GROUP (application));
     }
 
-  gtk_window_present_with_time (self->main_window, GDK_CURRENT_TIME);
+  gtk_window_present (self->main_window);
   gtk_widget_activate_action_variant (GTK_WIDGET (self->main_window),
                                       "win.page",
                                       parameter);
@@ -83,7 +83,7 @@ input_remote_action (GSimpleAction *action,
                                  (gpointer)&self->input_remote);
     }
 
-  gtk_window_present_with_time (self->input_remote, GDK_CURRENT_TIME);
+  gtk_window_present (self->input_remote);
 }
 
 static void
@@ -104,7 +104,7 @@ media_remote_action (GSimpleAction *action,
                                  (gpointer)&self->media_remote);
     }
 
-  gtk_window_present_with_time (self->media_remote, GDK_CURRENT_TIME);
+  gtk_window_present (self->media_remote);
 }
 
 static const GActionEntry app_actions[] = {

--- a/src/plugins/findmyphone/valent-findmyphone-ringer.c
+++ b/src/plugins/findmyphone/valent-findmyphone-ringer.c
@@ -221,7 +221,7 @@ valent_findmyphone_ringer_show (ValentFindmyphoneRinger *ringer)
                             ringer->dialog);
 
   /* Show the dialog */
-  gtk_window_present_with_time (ringer->dialog, GDK_CURRENT_TIME);
+  gtk_window_present (ringer->dialog);
 }
 
 /**

--- a/src/plugins/runcommand/valent-runcommand-preferences.c
+++ b/src/plugins/runcommand/valent-runcommand-preferences.c
@@ -213,7 +213,7 @@ runcommand_edit_action (GtkWidget  *widget,
                            G_CALLBACK (on_command_changed),
                            self, 0);
 
-  gtk_window_present_with_time (self->editor, GDK_CURRENT_TIME);
+  gtk_window_present (self->editor);
 }
 
 static void

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -670,7 +670,6 @@ share_chooser_action (GSimpleAction *action,
   dialog = g_object_new (GTK_TYPE_FILE_DIALOG,
                          "title",           _("Share Files"),
                          "accept-label",    _("Share"),
-                         "select-multiple", TRUE,
                          NULL);
 
   destroy = valent_object_ref_cancellable (VALENT_OBJECT (self));

--- a/src/plugins/share/valent-share-plugin.c
+++ b/src/plugins/share/valent-share-plugin.c
@@ -1115,7 +1115,7 @@ valent_share_plugin_handle_text (ValentSharePlugin *self,
                              G_CONNECT_SWAPPED);
       g_ptr_array_add (self->windows, window);
 
-      gtk_window_present_with_time (window, GDK_CURRENT_TIME);
+      gtk_window_present (window);
     }
 }
 

--- a/src/plugins/sms/valent-sms-plugin.c
+++ b/src/plugins/sms/valent-sms-plugin.c
@@ -408,7 +408,7 @@ messaging_action (GSimpleAction *action,
                                self, 0);
     }
 
-  gtk_window_present_with_time (GTK_WINDOW (self->window), GDK_CURRENT_TIME);
+  gtk_window_present (GTK_WINDOW (self->window));
 }
 
 static const GActionEntry actions[] = {


### PR DESCRIPTION
The `select-multiple` property was a carry-over from `GtkFileChooser`.