### PR TITLE
fix(mpris): fix players self-disposing during initialization

### DIFF
--- a/src/libvalent/media/valent-media-player.h
+++ b/src/libvalent/media/valent-media-player.h
@@ -122,15 +122,15 @@ GVariant           * valent_media_player_get_metadata (ValentMediaPlayer *player
 VALENT_AVAILABLE_IN_1_0
 const char         * valent_media_player_get_name     (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
-ValentMediaRepeat    valent_media_player_get_repeat   (ValentMediaPlayer *player);
-VALENT_AVAILABLE_IN_1_0
-void                 valent_media_player_set_repeat   (ValentMediaPlayer *player,
-                                                       ValentMediaRepeat  repeat);
-VALENT_AVAILABLE_IN_1_0
 double               valent_media_player_get_position (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0
 void                 valent_media_player_set_position (ValentMediaPlayer *player,
                                                        double             position);
+VALENT_AVAILABLE_IN_1_0
+ValentMediaRepeat    valent_media_player_get_repeat   (ValentMediaPlayer *player);
+VALENT_AVAILABLE_IN_1_0
+void                 valent_media_player_set_repeat   (ValentMediaPlayer *player,
+                                                       ValentMediaRepeat  repeat);
 VALENT_AVAILABLE_IN_1_0
 gboolean             valent_media_player_get_shuffle  (ValentMediaPlayer *player);
 VALENT_AVAILABLE_IN_1_0

--- a/src/plugins/mpris/valent-mpris-player.c
+++ b/src/plugins/mpris/valent-mpris-player.c
@@ -610,16 +610,11 @@ valent_mpris_player_init_async (GAsyncInitable      *initable,
 {
   ValentMPRISPlayer *self = VALENT_MPRIS_PLAYER (initable);
   g_autoptr (GTask) task = NULL;
-  g_autoptr (GCancellable) destroy = NULL;
 
   g_assert (VALENT_IS_MPRIS_PLAYER (self));
   g_return_if_fail (self->bus_name != NULL);
 
-  /* Cancel initialization if the object is destroyed */
-  destroy = valent_object_chain_cancellable (VALENT_OBJECT (initable),
-                                             cancellable);
-
-  task = g_task_new (initable, destroy, callback, user_data);
+  task = g_task_new (initable, cancellable, callback, user_data);
   g_task_set_priority (task, io_priority);
   g_task_set_source_tag (task, valent_mpris_player_init_async);
 
@@ -629,7 +624,7 @@ valent_mpris_player_init_async (GAsyncInitable      *initable,
                             self->bus_name,
                             "/org/mpris/MediaPlayer2",
                             "org.mpris.MediaPlayer2",
-                            destroy,
+                            cancellable,
                             valent_mpris_player_init_application_cb,
                             g_steal_pointer (&task));
 }


### PR DESCRIPTION
It's not clear why chaining a cancellable would result in an object
self-disposing, or why it doesn't happen during the initial polling
of active players, but it's unnecessary here anyways.

closes #655