### PR TITLE
ci: drop the coveralls.io check

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,14 +30,7 @@ jobs:
           test-coverage: true
           lcov-include: '${{ github.workspace }}/src/*'
 
-      - name: Report
-        continue-on-error: true
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.test.outputs.coverage }}
-
-      - name: Coverage
+      - name: Coverage Report
         continue-on-error: true
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,19 +213,12 @@ jobs:
           name: Tests (${{ matrix.compiler }}, ${{ matrix.suite }})
           path: ${{ steps.test.outputs.log }}
 
-      - name: Coverage (html)
+      - name: Coverage Report
         if: ${{ matrix.compiler == 'gcc' && matrix.suite == 'test' }}
         uses: actions/upload-artifact@v4
         with:
           name: Tests (coverage)
           path: ${{ steps.test.outputs.coverage-html }}
-
-      - name: Coverage (coveralls.io)
-        if: ${{ matrix.compiler == 'gcc' && matrix.suite == 'test' }}
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.test.outputs.coverage }}
 
   installed-tests:
     name: Tests (Installed)


### PR DESCRIPTION
This will keep failing and the coverage report is posted publicly, so just drop the dependency.