### PR TITLE
refactor(systemvolume): don't send `requestSinks` command at connect

### DIFF
--- a/src/plugins/systemvolume/valent-systemvolume-device.c
+++ b/src/plugins/systemvolume/valent-systemvolume-device.c
@@ -222,6 +222,26 @@ struct _ValentSystemvolumeDevice
 
 G_DEFINE_FINAL_TYPE (ValentSystemvolumeDevice, valent_systemvolume_device, VALENT_TYPE_MIXER_ADAPTER)
 
+#if 0
+static void
+valent_systemvolume_device_request_sinks (ValentSystemvolumeDevice *self)
+{
+  g_autoptr (JsonBuilder) builder = NULL;
+  g_autoptr (JsonNode) packet = NULL;
+
+  valent_packet_init (&builder, "kdeconnect.systemvolume.request");
+  json_builder_set_member_name (builder, "requestSinks");
+  json_builder_add_boolean_value (builder, TRUE);
+  packet = valent_packet_end (&builder);
+
+  valent_device_send_packet (self->device,
+                             packet,
+                             self->cancellable,
+                             (GAsyncReadyCallback) valent_device_send_packet_cb,
+                             NULL);
+}
+#endif
+
 /*
  * ValentMixerAdapter
  */
@@ -248,17 +268,6 @@ on_device_state_changed (ValentDevice             *device,
       cancellable = g_cancellable_new ();
       self->cancellable = valent_object_chain_cancellable (VALENT_OBJECT (self),
                                                            cancellable);
-
-      valent_packet_init (&builder, "kdeconnect.systemvolume.request");
-      json_builder_set_member_name (builder, "requestSinks");
-      json_builder_add_boolean_value (builder, TRUE);
-      packet = valent_packet_end (&builder);
-
-      valent_device_send_packet (self->device,
-                                 packet,
-                                 self->cancellable,
-                                 (GAsyncReadyCallback) valent_device_send_packet_cb,
-                                 NULL);
     }
   else
     {

--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -5,7 +5,7 @@
 preprocessorErrorDirective:src/libvalent/core/valent-global.c:35
 
 # src/libvalent/device/
-memleak:src/libvalent/device/valent-channel.c:325
+memleak:src/libvalent/device/valent-channel.c:315
 
 # src/libvalent/notifications/
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:89

--- a/tests/plugins/systemvolume/test-systemvolume-plugin.c
+++ b/tests/plugins/systemvolume/test-systemvolume-plugin.c
@@ -82,12 +82,6 @@ test_systemvolume_plugin_handle_request (ValentTestFixture *fixture,
   g_assert_cmpstr (json_object_get_string_member (sink_info, "name"), ==, "test_sink1");
   json_node_unref (packet);
 
-  VALENT_TEST_CHECK ("Plugin requests the sink list on connect");
-  packet = valent_test_fixture_expect_packet (fixture);
-  v_assert_packet_type (packet, "kdeconnect.systemvolume.request");
-  v_assert_packet_true (packet, "requestSinks");
-  json_node_unref (packet);
-
   VALENT_TEST_CHECK ("Plugin sends the sink list when requested");
   packet = valent_test_fixture_lookup_packet (fixture, "request-sinks");
   valent_test_fixture_handle_packet (fixture, packet);
@@ -248,12 +242,6 @@ test_systemvolume_plugin_handle_sinks (ValentTestFixture *fixture,
   v_assert_packet_field (packet, "sinkList");
   g_assert_true (valent_packet_get_array (packet, "sinkList", &sink_list));
   g_assert_cmpuint (json_array_get_length (sink_list), ==, 0);
-  json_node_unref (packet);
-
-  VALENT_TEST_CHECK ("Plugin requests the sink list on connect");
-  packet = valent_test_fixture_expect_packet (fixture);
-  v_assert_packet_type (packet, "kdeconnect.systemvolume.request");
-  v_assert_packet_true (packet, "requestSinks");
   json_node_unref (packet);
 
   VALENT_TEST_CHECK ("Plugin handles the sink list");


### PR DESCRIPTION
Sinks are sent at connect time and updated as necessary, so drop the request command.

See:
- https://invent.kde.org/network/kdeconnect-android/-/merge_requests/500
- https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/756
- https://github.com/GSConnect/gnome-shell-extension-gsconnect/pull/1890