### PR TITLE
refactor: ignore packet IDs

### DIFF
--- a/src/libvalent/device/valent-packet.c
+++ b/src/libvalent/device/valent-packet.c
@@ -836,21 +836,6 @@ valent_packet_validate (JsonNode  *packet,
 
   root = json_node_get_object (packet);
 
-  /* TODO: kdeconnect-kde stringifies this in identity packets
-   *       https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/380 */
-  if G_UNLIKELY ((node = json_object_get_member (root, "id")) == NULL ||
-                 (json_node_get_value_type (node) != G_TYPE_INT64 &&
-                  json_node_get_value_type (node) != G_TYPE_STRING))
-    {
-      g_set_error_literal (error,
-                           VALENT_PACKET_ERROR,
-                           node == NULL
-                             ? VALENT_PACKET_ERROR_MISSING_FIELD
-                             : VALENT_PACKET_ERROR_INVALID_FIELD,
-                           "expected \"id\" field holding an integer or string");
-      return FALSE;
-    }
-
   if G_UNLIKELY ((node = json_object_get_member (root, "type")) == NULL ||
                  json_node_get_value_type (node) != G_TYPE_STRING)
     {

--- a/src/libvalent/device/valent-packet.h
+++ b/src/libvalent/device/valent-packet.h
@@ -61,13 +61,6 @@ valent_packet_is_valid (JsonNode *packet)
 
   root = json_node_get_object (packet);
 
-  /* TODO: kdeconnect-kde stringifies this in identity packets
-   *       https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/380 */
-  if G_UNLIKELY ((node = json_object_get_member (root, "id")) == NULL ||
-                 (json_node_get_value_type (node) != G_TYPE_INT64 &&
-                  json_node_get_value_type (node) != G_TYPE_STRING))
-    return FALSE;
-
   if G_UNLIKELY ((node = json_object_get_member (root, "type")) == NULL ||
                  json_node_get_value_type (node) != G_TYPE_STRING)
     return FALSE;

--- a/tests/fixtures/data/core-packet.json
+++ b/tests/fixtures/data/core-packet.json
@@ -2,17 +2,6 @@
   "invalid-data": null,
   "malformed": [
   ],
-  "missing-id": {
-    "type": "kdeconnect.test",
-    "body": {
-    }
-  },
-  "invalid-id": {
-    "id": [],
-    "type": "kdeconnect.test",
-    "body": {
-    }
-  },
   "missing-type": {
     "id": 0,
     "body": {


### PR DESCRIPTION
These are unused and skipping them saves a bit of time, especially given it's sometimes a string and sometimes an integer.