### PR TITLE
refactor(device): move verification key generation to ValentDevice

### DIFF
--- a/src/libvalent/device/valent-channel.h
+++ b/src/libvalent/device/valent-channel.h
@@ -66,8 +66,6 @@ GTlsCertificate * valent_channel_get_peer_certificate (ValentChannel        *cha
 VALENT_AVAILABLE_IN_1_0
 JsonNode        * valent_channel_get_peer_identity    (ValentChannel        *channel);
 VALENT_AVAILABLE_IN_1_0
-const char      * valent_channel_get_verification_key (ValentChannel        *channel);
-VALENT_AVAILABLE_IN_1_0
 GIOStream       * valent_channel_download             (ValentChannel        *channel,
                                                        JsonNode             *packet,
                                                        GCancellable         *cancellable,

--- a/src/libvalent/device/valent-device.h
+++ b/src/libvalent/device/valent-device.h
@@ -42,39 +42,41 @@ VALENT_AVAILABLE_IN_1_0
 G_DECLARE_FINAL_TYPE (ValentDevice, valent_device, VALENT, DEVICE, ValentResource)
 
 VALENT_AVAILABLE_IN_1_0
-ValentDevice      * valent_device_new                (const char           *id);
+ValentDevice      * valent_device_new                  (const char           *id);
 VALENT_AVAILABLE_IN_1_0
-ValentChannel     * valent_device_ref_channel        (ValentDevice         *device);
+ValentChannel     * valent_device_ref_channel          (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-ValentContext     * valent_device_get_context        (ValentDevice         *device);
+ValentContext     * valent_device_get_context          (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-const char        * valent_device_get_icon_name      (ValentDevice         *device);
+const char        * valent_device_get_icon_name        (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-const char        * valent_device_get_id             (ValentDevice         *device);
+const char        * valent_device_get_id               (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-GMenuModel        * valent_device_get_menu           (ValentDevice         *device);
+GMenuModel        * valent_device_get_menu             (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-const char        * valent_device_get_name           (ValentDevice         *device);
+const char        * valent_device_get_name             (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-GStrv               valent_device_get_plugins        (ValentDevice         *device);
+GStrv               valent_device_get_plugins          (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-ValentDeviceState   valent_device_get_state          (ValentDevice         *device);
+ValentDeviceState   valent_device_get_state            (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-void                valent_device_send_packet        (ValentDevice         *device,
-                                                      JsonNode             *packet,
-                                                      GCancellable         *cancellable,
-                                                      GAsyncReadyCallback   callback,
-                                                      gpointer              user_data);
+char              * valent_device_get_verification_key (ValentDevice         *device);
 VALENT_AVAILABLE_IN_1_0
-gboolean            valent_device_send_packet_finish (ValentDevice         *device,
-                                                      GAsyncResult         *result,
-                                                      GError              **error);
+void                valent_device_send_packet          (ValentDevice         *device,
+                                                        JsonNode             *packet,
+                                                        GCancellable         *cancellable,
+                                                        GAsyncReadyCallback   callback,
+                                                        gpointer              user_data);
 VALENT_AVAILABLE_IN_1_0
-char              * valent_device_generate_id        (void);
+gboolean            valent_device_send_packet_finish   (ValentDevice         *device,
+                                                        GAsyncResult         *result,
+                                                        GError              **error);
 VALENT_AVAILABLE_IN_1_0
-gboolean            valent_device_validate_id        (const char           *id);
+char              * valent_device_generate_id          (void);
 VALENT_AVAILABLE_IN_1_0
-gboolean            valent_device_validate_name      (const char           *name);
+gboolean            valent_device_validate_id          (const char           *id);
+VALENT_AVAILABLE_IN_1_0
+gboolean            valent_device_validate_name        (const char           *name);
 
 G_END_DECLS
 

--- a/src/plugins/gnome/valent-device-page.c
+++ b/src/plugins/gnome/valent-device-page.c
@@ -75,9 +75,8 @@ on_state_changed (ValentDevice     *device,
     }
   else if (!paired)
     {
-      g_autoptr (ValentChannel) channel = NULL;
       g_autofree char *description = NULL;
-      const char *verification_key = NULL;
+      g_autofree char *verification_key = NULL;
       gboolean pair_incoming, pair_outgoing;
 
       description = g_strdup_printf (_("Please confirm the verification key "
@@ -86,10 +85,9 @@ on_state_changed (ValentDevice     *device,
       adw_status_page_set_description (self->pair_page, description);
 
       /* Get the channel verification key */
-      if ((channel = valent_device_ref_channel (self->device)) != NULL)
-        verification_key = valent_channel_get_verification_key (channel);
-      else
-        verification_key = _("Unavailable");
+      verification_key = valent_device_get_verification_key (self->device);
+      if (verification_key == NULL)
+        verification_key = g_strdup (_("Unavailable"));
 
       gtk_label_set_text (GTK_LABEL (self->verification_key), verification_key);
 

--- a/tests/extra/cppcheck.supp
+++ b/tests/extra/cppcheck.supp
@@ -5,7 +5,7 @@
 preprocessorErrorDirective:src/libvalent/core/valent-global.c:35
 
 # src/libvalent/device/
-memleak:src/libvalent/device/valent-channel.c:334
+memleak:src/libvalent/device/valent-channel.c:333
 
 # src/libvalent/notifications/
 leakNoVarFunctionCall:src/libvalent/notifications/valent-notification.c:85

--- a/tests/fixtures/data/core-state.json
+++ b/tests/fixtures/data/core-state.json
@@ -1,11 +1,10 @@
 {
-  "test-device": {
+  "00000000_0000_0000_0000_000000000001": {
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mock.echo",
@@ -15,6 +14,7 @@
         "kdeconnect.mock.echo",
         "kdeconnect.mock.transfer"
       ],
+      "protocolVersion": 7,
       "tcpPort": 1716
     }
   }

--- a/tests/fixtures/data/core.json
+++ b/tests/fixtures/data/core.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mock.echo",
@@ -15,6 +14,26 @@
         "kdeconnect.mock.echo",
         "kdeconnect.mock.transfer"
       ],
+      "protocolVersion": 7,
+      "tcpPort": 1716
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Test Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "protocolVersion": 7,
       "tcpPort": 1716
     }
   },

--- a/tests/fixtures/data/plugin-battery.json
+++ b/tests/fixtures/data/plugin-battery.json
@@ -3,15 +3,30 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
       ],
       "outgoingCapabilities": [
         "kdeconnect.battery"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.battery"
+      ],
+      "protocolVersion": 7
     }
   },
   "missing-battery": {

--- a/tests/fixtures/data/plugin-bluez.json
+++ b/tests/fixtures/data/plugin-bluez.json
@@ -5,7 +5,6 @@
     "body": {
       "deviceId": "endpoint",
       "deviceName": "Endpoint",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mock.echo",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.mock.echo",
         "kdeconnect.mock.transfer"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "protocolVersion": 7
     }
   },
   "transfer": {

--- a/tests/fixtures/data/plugin-clipboard.json
+++ b/tests/fixtures/data/plugin-clipboard.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.clipboard",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.clipboard",
         "kdeconnect.clipboard.connect"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.clipboard",
+        "kdeconnect.clipboard.connect"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.clipboard",
+        "kdeconnect.clipboard.connect"
+      ],
+      "protocolVersion": 7
     }
   },
   "clipboard-content": {

--- a/tests/fixtures/data/plugin-connectivity_report.json
+++ b/tests/fixtures/data/plugin-connectivity_report.json
@@ -3,16 +3,32 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.connectivity_report"
       ],
       "outgoingCapabilities": [
         "kdeconnect.connectivity_report"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.connectivity_report"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.connectivity_report"
+      ],
+      "protocolVersion": 7
     }
   },
   "modemless-report": {

--- a/tests/fixtures/data/plugin-contacts.json
+++ b/tests/fixtures/data/plugin-contacts.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.contacts.request_all_uids_timestamps",
@@ -18,7 +17,30 @@
         "kdeconnect.contacts.request_vcards_by_uid",
         "kdeconnect.contacts.response_uids_timestamps",
         "kdeconnect.contacts.response_vcards"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.contacts.request_all_uids_timestamps",
+        "kdeconnect.contacts.request_vcards_by_uid",
+        "kdeconnect.contacts.response_uids_timestamps",
+        "kdeconnect.contacts.response_vcards"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.contacts.request_all_uids_timestamps",
+        "kdeconnect.contacts.request_vcards_by_uid",
+        "kdeconnect.contacts.response_uids_timestamps",
+        "kdeconnect.contacts.response_vcards"
+      ],
+      "protocolVersion": 7
     }
   },
 

--- a/tests/fixtures/data/plugin-findmyphone.json
+++ b/tests/fixtures/data/plugin-findmyphone.json
@@ -3,16 +3,32 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.findmyphone.request"
       ],
       "outgoingCapabilities": [
         "kdeconnect.findmyphone.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.findmyphone.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.findmyphone.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "ring-request": {

--- a/tests/fixtures/data/plugin-lan.json
+++ b/tests/fixtures/data/plugin-lan.json
@@ -5,7 +5,6 @@
     "body": {
       "deviceId": "endpoint",
       "deviceName": "Endpoint",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mock.echo",
@@ -15,6 +14,26 @@
         "kdeconnect.mock.echo",
         "kdeconnect.mock.transfer"
       ],
+      "protocolVersion": 7,
+      "tcpPort": 1717
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mock.echo",
+        "kdeconnect.mock.transfer"
+      ],
+      "protocolVersion": 7,
       "tcpPort": 1717
     }
   },

--- a/tests/fixtures/data/plugin-lock.json
+++ b/tests/fixtures/data/plugin-lock.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.lock",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.lock",
         "kdeconnect.lock.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.lock",
+        "kdeconnect.lock.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.lock",
+        "kdeconnect.lock.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "is-locked": {

--- a/tests/fixtures/data/plugin-mock.json
+++ b/tests/fixtures/data/plugin-mock.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mock",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.mock",
         "kdeconnect.mock.transfer"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mock",
+        "kdeconnect.mock.transfer"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mock",
+        "kdeconnect.mock.transfer"
+      ],
+      "protocolVersion": 7
     }
   },
   "echo": {

--- a/tests/fixtures/data/plugin-mousepad.json
+++ b/tests/fixtures/data/plugin-mousepad.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mousepad.echo",
@@ -16,7 +15,28 @@
         "kdeconnect.mousepad.echo",
         "kdeconnect.mousepad.request",
         "kdeconnect.mousepad.keyboardstate"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mousepad.echo",
+        "kdeconnect.mousepad.request",
+        "kdeconnect.mousepad.keyboardstate"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mousepad.echo",
+        "kdeconnect.mousepad.request",
+        "kdeconnect.mousepad.keyboardstate"
+      ],
+      "protocolVersion": 7
     }
   },
   "echo": {

--- a/tests/fixtures/data/plugin-mpris.json
+++ b/tests/fixtures/data/plugin-mpris.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mpris",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.mpris",
         "kdeconnect.mpris.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mpris",
+        "kdeconnect.mpris.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mpris",
+        "kdeconnect.mpris.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "request-player-list": {

--- a/tests/fixtures/data/plugin-notification.json
+++ b/tests/fixtures/data/plugin-notification.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.notification",
@@ -16,7 +15,28 @@
       "outgoingCapabilities": [
         "kdeconnect.notification",
         "kdeconnect.notification.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.notification",
+        "kdeconnect.notification.action",
+        "kdeconnect.notification.reply",
+        "kdeconnect.notification.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.notification",
+        "kdeconnect.notification.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "notification-simple": {

--- a/tests/fixtures/data/plugin-ping.json
+++ b/tests/fixtures/data/plugin-ping.json
@@ -3,16 +3,32 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.ping"
       ],
       "outgoingCapabilities": [
         "kdeconnect.ping"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.ping"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.ping"
+      ],
+      "protocolVersion": 7
     }
   },
   "ping": {

--- a/tests/fixtures/data/plugin-presenter.json
+++ b/tests/fixtures/data/plugin-presenter.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.mousepad.request",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.mousepad.request",
         "kdeconnect.presenter"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.mousepad.request",
+        "kdeconnect.presenter"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.mousepad.request",
+        "kdeconnect.presenter"
+      ],
+      "protocolVersion": 7
     }
   },
   "presenter-motion1": {

--- a/tests/fixtures/data/plugin-runcommand.json
+++ b/tests/fixtures/data/plugin-runcommand.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.runcommand",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.runcommand",
         "kdeconnect.runcommand.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.runcommand",
+        "kdeconnect.runcommand.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.runcommand",
+        "kdeconnect.runcommand.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "command-list": {

--- a/tests/fixtures/data/plugin-sftp.json
+++ b/tests/fixtures/data/plugin-sftp.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.sftp",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.sftp",
         "kdeconnect.sftp.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.sftp",
+        "kdeconnect.sftp.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.sftp",
+        "kdeconnect.sftp.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "sftp-request": {

--- a/tests/fixtures/data/plugin-share.json
+++ b/tests/fixtures/data/plugin-share.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.share.request",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.share.request",
         "kdeconnect.share.request.update"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.share.request",
+        "kdeconnect.share.request.update"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.share.request",
+        "kdeconnect.share.request.update"
+      ],
+      "protocolVersion": 7
     }
   },
   "share-file": {

--- a/tests/fixtures/data/plugin-sms.json
+++ b/tests/fixtures/data/plugin-sms.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.sms.messages",
@@ -18,7 +17,30 @@
         "kdeconnect.sms.request",
         "kdeconnect.sms.request_conversation",
         "kdeconnect.sms.request_conversations"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.sms.messages",
+        "kdeconnect.sms.request",
+        "kdeconnect.sms.request_conversation",
+        "kdeconnect.sms.request_conversations"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.sms.messages",
+        "kdeconnect.sms.request",
+        "kdeconnect.sms.request_conversation",
+        "kdeconnect.sms.request_conversations"
+      ],
+      "protocolVersion": 7
     }
   },
   "connect-time-1": {

--- a/tests/fixtures/data/plugin-systemvolume.json
+++ b/tests/fixtures/data/plugin-systemvolume.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.systemvolume",
@@ -14,7 +13,26 @@
       "outgoingCapabilities": [
         "kdeconnect.systemvolume",
         "kdeconnect.systemvolume.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.systemvolume",
+        "kdeconnect.systemvolume.request"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.systemvolume",
+        "kdeconnect.systemvolume.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "request-sinks": {

--- a/tests/fixtures/data/plugin-telephony.json
+++ b/tests/fixtures/data/plugin-telephony.json
@@ -3,9 +3,8 @@
     "id": 0,
     "type": "kdeconnect.identity",
     "body": {
-      "deviceId": "test-device",
+      "deviceId": "00000000_0000_0000_0000_000000000001",
       "deviceName": "Test Device",
-      "protocolVersion": 7,
       "deviceType": "phone",
       "incomingCapabilities": [
         "kdeconnect.telephony",
@@ -13,7 +12,25 @@
       ],
       "outgoingCapabilities": [
         "kdeconnect.telephony.request"
-      ]
+      ],
+      "protocolVersion": 7
+    }
+  },
+  "peer-identity": {
+    "id": 0,
+    "type": "kdeconnect.identity",
+    "body": {
+      "deviceId": "00000000_0000_0000_0000_000000000002",
+      "deviceName": "Peer Device",
+      "deviceType": "phone",
+      "incomingCapabilities": [
+        "kdeconnect.telephony",
+        "kdeconnect.telephony.request_mute"
+      ],
+      "outgoingCapabilities": [
+        "kdeconnect.telephony.request"
+      ],
+      "protocolVersion": 7
     }
   },
   "ringing": {

--- a/tests/fixtures/valent-test-fixture.c
+++ b/tests/fixtures/valent-test-fixture.c
@@ -61,21 +61,21 @@ valent_test_fixture_init (ValentTestFixture *fixture,
   const char *path = (const char *)user_data;
   g_autofree ValentChannel **channels = NULL;
   g_auto (GStrv) plugins = NULL;
-  JsonNode *identity;
+  JsonNode *identity, *peer_identity;
 
   g_assert (path != NULL && *path != '\0');
 
   fixture->packets = valent_test_load_json (path);
-
-  /* Init device */
   identity = valent_test_fixture_lookup_packet (fixture, "identity");
-  fixture->device = valent_device_new_full (identity, NULL);
-  valent_device_set_paired (fixture->device, TRUE);
+  peer_identity = valent_test_fixture_lookup_packet (fixture, "peer-identity");
 
-  /* Init channels */
-  channels = valent_test_channel_pair (identity, identity);
-  fixture->channel = g_steal_pointer (&channels[0]);
-  fixture->endpoint = g_steal_pointer(&channels[1]);
+  /* Init channels & device */
+  valent_test_channel_pair (identity,
+                            peer_identity,
+                            &fixture->channel,
+                            &fixture->endpoint);
+  fixture->device = valent_device_new_full (peer_identity, NULL);
+  valent_device_set_paired (fixture->device, TRUE);
 
   /* Init settings */
   plugins = valent_device_get_plugins (fixture->device);

--- a/tests/fixtures/valent-test-utils.h
+++ b/tests/fixtures/valent-test-utils.h
@@ -42,8 +42,10 @@ void             valent_test_watch_clear   (gpointer          object,
 void             valent_test_await_timeout (unsigned int      duration);
 JsonNode       * valent_test_load_json     (const char       *path);
 GSettings      * valent_test_mock_settings (const char       *domain);
-ValentChannel ** valent_test_channel_pair  (JsonNode         *identity,
-                                            JsonNode         *peer_identity);
+void             valent_test_channel_pair  (JsonNode         *identity,
+                                            JsonNode         *peer_identity,
+                                            ValentChannel   **channel_out,
+                                            ValentChannel   **peer_channel_out);
 gboolean         valent_test_download      (ValentChannel    *channel,
                                             JsonNode         *packet,
                                             GError          **error);

--- a/tests/libvalent/device/test-channel-service.c
+++ b/tests/libvalent/device/test-channel-service.c
@@ -309,8 +309,6 @@ test_channel_service_channel (ChannelServiceFixture *fixture,
   g_autoptr (GIOStream) base_stream_out = NULL;
   g_autoptr (JsonNode) identity_out = NULL;
   g_autoptr (JsonNode) peer_identity_out = NULL;
-  const char *channel_verification;
-  const char *endpoint_verification;
   g_autoptr (GFile) file = NULL;
 
   g_signal_connect (fixture->service,
@@ -338,12 +336,6 @@ test_channel_service_channel (ChannelServiceFixture *fixture,
 
   g_assert_true (json_node_equal (valent_channel_get_identity (fixture->channel), identity_out));
   g_assert_true (json_node_equal (valent_channel_get_peer_identity (fixture->channel), peer_identity_out));
-
-  channel_verification = valent_channel_get_verification_key (fixture->channel);
-  endpoint_verification = valent_channel_get_verification_key (fixture->endpoint);
-  g_assert_null (channel_verification);
-  g_assert_null (endpoint_verification);
-  g_assert_cmpstr (channel_verification, ==, endpoint_verification);
 
   /* Packet Exchange */
   packet = json_object_get_member (json_node_get_object (fixture->packets),

--- a/tests/libvalent/device/test-channel-service.c
+++ b/tests/libvalent/device/test-channel-service.c
@@ -309,6 +309,8 @@ test_channel_service_channel (ChannelServiceFixture *fixture,
   g_autoptr (GIOStream) base_stream_out = NULL;
   g_autoptr (JsonNode) identity_out = NULL;
   g_autoptr (JsonNode) peer_identity_out = NULL;
+  g_autoptr (GTlsCertificate) certificate_out = NULL;
+  g_autoptr (GTlsCertificate) peer_certificate_out = NULL;
   g_autoptr (GFile) file = NULL;
 
   g_signal_connect (fixture->service,
@@ -325,15 +327,21 @@ test_channel_service_channel (ChannelServiceFixture *fixture,
 
   VALENT_TEST_CHECK ("GObject properties function correctly");
   g_object_get (fixture->channel,
-                "base-stream",   &base_stream_out,
-                "identity",      &identity_out,
-                "peer-identity", &peer_identity_out,
+                "base-stream",      &base_stream_out,
+                "certificate",      &certificate_out,
+                "identity",         &identity_out,
+                "peer-certificate", &peer_certificate_out,
+                "peer-identity",    &peer_identity_out,
                 NULL);
 
   g_assert_true (G_IS_IO_STREAM (base_stream_out));
+  g_assert_true (G_IS_TLS_CERTIFICATE (certificate_out));
+  g_assert_true (G_IS_TLS_CERTIFICATE (peer_certificate_out));
   g_assert_true (VALENT_IS_PACKET (identity_out));
   g_assert_true (VALENT_IS_PACKET (peer_identity_out));
 
+  g_assert_true (valent_channel_get_certificate (fixture->channel) == certificate_out);
+  g_assert_true (valent_channel_get_peer_certificate (fixture->channel) == peer_certificate_out);
   g_assert_true (json_node_equal (valent_channel_get_identity (fixture->channel), identity_out));
   g_assert_true (json_node_equal (valent_channel_get_peer_identity (fixture->channel), peer_identity_out));
 

--- a/tests/plugins/bluez/test-bluez-plugin.c
+++ b/tests/plugins/bluez/test-bluez-plugin.c
@@ -311,8 +311,6 @@ test_bluez_service_channel (BluezBackendFixture *fixture,
   JsonNode *packet;
   g_autoptr (GSocketAddress) address = NULL;
   g_autofree char *identity_str = NULL;
-  const char *channel_verification;
-  const char *endpoint_verification;
   g_autoptr (GFile) file = NULL;
 
   g_async_initable_init_async (G_ASYNC_INITABLE (fixture->service),
@@ -344,12 +342,6 @@ test_bluez_service_channel (BluezBackendFixture *fixture,
                     G_CALLBACK (on_channel),
                     fixture);
   g_main_loop_run (fixture->loop);
-
-  channel_verification = valent_channel_get_verification_key (fixture->channel);
-  endpoint_verification = valent_channel_get_verification_key (fixture->endpoint);
-  g_assert_nonnull (channel_verification);
-  g_assert_nonnull (endpoint_verification);
-  g_assert_cmpstr (channel_verification, ==, endpoint_verification);
 
   /* Transfers */
   file = g_file_new_for_uri ("resource:///tests/image.png");

--- a/tests/plugins/lan/test-lan-plugin.c
+++ b/tests/plugins/lan/test-lan-plugin.c
@@ -635,8 +635,6 @@ test_lan_service_channel (LanBackendFixture *fixture,
   JsonNode *packet;
   g_autoptr (GSocketAddress) address = NULL;
   g_autofree char *identity_str = NULL;
-  const char *channel_verification;
-  const char *endpoint_verification;
   char *host;
   GTlsCertificate *certificate = NULL;
   GTlsCertificate *peer_certificate = NULL;
@@ -690,12 +688,6 @@ test_lan_service_channel (LanBackendFixture *fixture,
   certificate = valent_channel_get_certificate (fixture->channel);
   peer_certificate = valent_channel_get_peer_certificate (fixture->endpoint);
   g_assert_true (g_tls_certificate_is_same (certificate, peer_certificate));
-
-  channel_verification = valent_channel_get_verification_key (fixture->channel);
-  endpoint_verification = valent_channel_get_verification_key (fixture->endpoint);
-  g_assert_nonnull (channel_verification);
-  g_assert_nonnull (endpoint_verification);
-  g_assert_cmpstr (channel_verification, ==, endpoint_verification);
 
   VALENT_TEST_CHECK ("Channel can transfer payloads");
   file = g_file_new_for_uri ("resource:///tests/image.png");


### PR DESCRIPTION
In preparation for protocol v8, move the verification key
generation to `ValentDevice`, where we can access the protocol
version and pairing timestamp.