### PR TITLE
fix(device): add a temporary fix for device plugins

### DIFF
--- a/src/libvalent/device/valent-device.c
+++ b/src/libvalent/device/valent-device.c
@@ -1688,7 +1688,7 @@ valent_device_generate_id (void)
 
 /**
  * valent_device_validate_id:
- * @id: (nullable) a KDE Connect device ID
+ * @id: (nullable): a KDE Connect device ID
  *
  * Validate a KDE Connect device ID.
  *


### PR DESCRIPTION
Due to the way device connections can be "hot swapped", while incoming packets resolve asynchronously, it's possible for a device to receive packets while technically disconnected.

Address this by tracking the device state and stashing incoming packets to prevent violating what should be an invariant that plugins rely on. Not handling this results in non-deterministic crashes that are likely more annoying than missing a few packets.