### PR TITLE
fix(device): ignore invalid device IDs from state file

### DIFF
--- a/src/libvalent/device/valent-device-manager.c
+++ b/src/libvalent/device/valent-device-manager.c
@@ -475,8 +475,14 @@ valent_device_manager_ensure_device (ValentDeviceManager *self,
 
   if (!valent_packet_get_string (identity, "deviceId", &device_id))
     {
-      g_debug ("%s(): expected \"deviceId\" field holding a string",
-               G_STRFUNC);
+      g_critical ("%s(): expected \"deviceId\" field holding a string",
+                  G_STRFUNC);
+      return NULL;
+    }
+
+  if (!valent_device_validate_id (device_id))
+    {
+      g_critical ("%s(): invalid device ID \"%s\"", G_STRFUNC, device_id);
       return NULL;
     }
 


### PR DESCRIPTION
The one source of invalid device IDs left is the state file, which may contain old devices with invalid IDs.

Everywhere else we assert and crash, so check once more and log a critical instead.