### PR TITLE
build(flatpak): don't build pipewire

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -262,26 +262,6 @@
                 }
             ]
         },
-        {
-            "name": "pipewire",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts": [
-                "-Dgstreamer=disabled",
-                "-Dman=disabled",
-                "-Dsystemd=disabled",
-                "-Dudev=disabled",
-                "-Dudevrulesdir=disabled",
-                "-Dsession-managers=[]"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/PipeWire/pipewire.git",
-                    "branch": "master"
-                }
-            ]
-        },
         "ca.andyholmes.Valent.Tests.json",
         {
             "name": "valent",

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -300,33 +300,6 @@
             ]
         },
         {
-            "name": "pipewire",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts": [
-                "-Dgstreamer=disabled",
-                "-Dman=disabled",
-                "-Dsystemd=disabled",
-                "-Dudev=disabled",
-                "-Dudevrulesdir=disabled",
-                "-Dsession-managers=[]"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/PipeWire/pipewire.git",
-                    "commit": "2eb8cf5dc780ca22b94545f1254497a428c412f5",
-                    "tag": "1.4.1",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 57357,
-                        "stable-only": true,
-                        "tag-template": "$version"
-                    }
-                }
-            ]
-        },
-        {
             "name": "valent",
             "buildsystem": "meson",
             "builddir": true,


### PR DESCRIPTION
Apaprently this has been in the runtime for awhile, and we don't need anything fancy to justify building the latest.