### PR TITLE
refactor(sftp): prefer org.freedeskop.FileManager1 for URIs

### DIFF
--- a/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.Devel.json
@@ -29,6 +29,7 @@
         "--system-talk-name=org.freedesktop.UPower",
         "--talk-name=org.a11y.Bus",
         "--talk-name=org.freedesktop.DBus",
+        "--talk-name=org.freedesktop.FileManager1",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gnome.evolution.dataserver.AddressBook10",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",

--- a/build-aux/flatpak/ca.andyholmes.Valent.json
+++ b/build-aux/flatpak/ca.andyholmes.Valent.json
@@ -27,6 +27,7 @@
         "--system-talk-name=org.freedesktop.UPower",
         "--talk-name=org.a11y.Bus",
         "--talk-name=org.freedesktop.DBus",
+        "--talk-name=org.freedesktop.FileManager1",
         "--talk-name=org.gnome.evolution.dataserver.AddressBook10",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
         "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",


### PR DESCRIPTION
Some distributions or desktop environments don't seem to handle `sftp` URIs properly, so prefer the XDG interface over GIO's `g_app_info_launch_default_for_uri_async()`.

closes #597
cc #429