### PR TITLE
feat(sftp): add an expanded menu and actions

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2022-03-28 11:21-0700\n"
 "Last-Translator: Andy Holmes <andrew.g.r.holmes@gmail.com>\n"
 "Language-Team: English <andrew.g.r.holmes@gmail.com>\n"
@@ -368,7 +368,7 @@ msgstr ""
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr ""
 
@@ -1366,12 +1366,20 @@ msgstr ""
 msgid "Share files and directories with SFTP"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+msgid "Browse Folders"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
 msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7

--- a/po/es.po
+++ b/po/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2023-11-09 18:24+0100\n"
 "Last-Translator: HDavo <h.davoc24@gmail.com>\n"
 "Language-Team: Spanish - Spain <>\n"
@@ -380,7 +380,7 @@ msgstr "Móvil"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "Inicio"
 
@@ -1399,13 +1399,22 @@ msgstr "Archivos"
 msgid "Share files and directories with SFTP"
 msgstr "Compartir archivos y carpetas con SFTP"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "Autorización denegada"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "Examinar Archivos"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2023-03-04 17:28+0100\n"
 "Last-Translator: Valérie Roux <vxlerieuwu@unixgirl.xyz>\n"
 "Language-Team: French <vxlerieuwu@unixgirl.xyz>\n"
@@ -387,7 +387,7 @@ msgstr "Portable"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "Accueil"
 
@@ -1443,13 +1443,22 @@ msgstr "Tous les fichiers"
 msgid "Share files and directories with SFTP"
 msgstr "Parcourir les fichiers et dossiers"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "Permission non accordée"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "Parcourir les fichiers"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2024-03-21 03:05+0100\n"
 "Last-Translator: Gianni Lerro <glerro@pm.me>\n"
 "Language-Team: Italian <>\n"
@@ -378,7 +378,7 @@ msgstr "Cellulare"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "Casa"
 
@@ -1397,13 +1397,22 @@ msgstr "Salva"
 msgid "Share files and directories with SFTP"
 msgstr "Condividi file e cartelle con SFTP"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "Permesso negato"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "Sfoglia file"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2025-03-05 11:14+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -374,7 +374,7 @@ msgstr "Mobiel"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "Persoonlijke map"
 
@@ -1373,13 +1373,22 @@ msgstr "Bestanden"
 msgid "Share files and directories with SFTP"
 msgstr "Verken bestanden en mappen met sftp"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "Toegang geweigerd"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "Bestanden verkennen"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2023-10-29 00:44-0300\n"
 "Last-Translator: Victor L. Pavan <victorpavan001@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <victorpavan001@gmail.com>\n"
@@ -381,7 +381,7 @@ msgstr "Celular"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "Página Inicial"
 
@@ -1400,13 +1400,22 @@ msgstr "Arquivos"
 msgid "Share files and directories with SFTP"
 msgstr "Compartilhe arquivos e pastas com SFTP"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "Navegar pelos arquivos"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2024-09-29 08:24+0530\n"
 "Last-Translator: Aryan Karamtoth <aryankmmiv@outlook.com>\n"
 "Language-Team: Telugu l10n Translation Team <ubuntu-l10n-te@lists.launchpad."
@@ -371,7 +371,7 @@ msgstr "మొబైల్"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "హోమ్"
 
@@ -1371,13 +1371,22 @@ msgstr "ఫైళ్లు"
 msgid "Share files and directories with SFTP"
 msgstr "SFTPతో ఫైల్‌లు మరియు డైరెక్టరీలను భాగస్వామ్యం చేయండి"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "అనుమతి నిరాకరించబడింది"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "ఫైళ్లను బ్రౌజ్ చేయండి"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/po/valent.pot
+++ b/po/valent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,7 +368,7 @@ msgstr ""
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr ""
 
@@ -1366,12 +1366,20 @@ msgstr ""
 msgid "Share files and directories with SFTP"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr ""
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+msgid "Browse Folders"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
 msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/valent/issues\n"
-"POT-Creation-Date: 2025-03-18 01:09-0700\n"
+"POT-Creation-Date: 2025-03-20 11:58-0700\n"
 "PO-Revision-Date: 2023-07-03 19:05+0800\n"
 "Last-Translator: sky96111 <sky96111@outlook.com>\n"
 "Language-Team: Chinese Simplified\n"
@@ -373,7 +373,7 @@ msgstr "手机"
 
 #: src/plugins/gnome/valent-contact-page.c:316
 #: src/plugins/gnome/valent-messages-window.c:424
-#: src/plugins/sftp/valent-sftp-plugin.c:535
+#: src/plugins/sftp/valent-sftp-plugin.c:634
 msgid "Home"
 msgstr "首页"
 
@@ -1394,13 +1394,22 @@ msgstr "文件"
 msgid "Share files and directories with SFTP"
 msgstr "用 SFTP 共享文件和目录"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:541
+#: src/plugins/sftp/valent-sftp-plugin.c:640
 msgid "Permission denied"
 msgstr "权限被拒绝"
 
-#: src/plugins/sftp/valent-sftp-plugin.c:682
-msgid "Browse Files"
+#: src/plugins/sftp/valent-sftp-plugin.c:765
+#, fuzzy
+msgid "Browse Folders"
 msgstr "浏览文件"
+
+#: src/plugins/sftp/valent-sftp-plugin.c:782
+msgid "Unmount"
+msgstr ""
+
+#: src/plugins/sftp/valent-sftp-plugin.c:792
+msgid "Mount"
+msgstr ""
 
 #: src/plugins/share/share.plugin.desktop.in:7
 msgid "Sharing"

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -668,6 +668,10 @@ valent_sftp_plugin_update_state (ValentDevicePlugin *plugin,
       if (g_settings_get_boolean (settings, "auto-mount"))
         valent_sftp_plugin_sftp_request (self);
     }
+  else if ((state & VALENT_DEVICE_STATE_PAIRED) == 0)
+    {
+      g_clear_pointer (&self->session, sftp_session_end);
+    }
 }
 
 static void

--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -250,7 +250,7 @@ on_mount_removed (GVolumeMonitor   *volume_monitor,
   uri = g_file_get_uri (root);
 
   if (g_strcmp0 (self->session->uri, uri) == 0)
-    g_clear_pointer (&self->session, sftp_session_free);
+    g_clear_object (&self->session->mount);
 }
 
 /**


### PR DESCRIPTION
Add support for the full path listing, allowing the device to
be mounted, unmounted and folders browsed from the menu.

This doesn't allow mounting individual folders as discrete
paths, but does give an entry point for browsing them when a
device exposes paths outside the root folder.

closes #429 