### PR TITLE
fix(sftp): handle sessions more efficiently

### DIFF
--- a/src/plugins/sftp/valent-sftp-plugin.c
+++ b/src/plugins/sftp/valent-sftp-plugin.c
@@ -831,6 +831,10 @@ valent_sftp_plugin_update_state (ValentDevicePlugin *plugin,
     {
       g_clear_pointer (&self->session, sftp_session_end);
     }
+  else if ((state & VALENT_DEVICE_STATE_CONNECTED) == 0)
+    {
+      g_clear_pointer (&self->session, sftp_session_free);
+    }
 }
 
 static void


### PR DESCRIPTION
There's no harm in attempting to register the local private key
with the ssh-agent, but it really only has to be done once.

When a device reconnects it may have acquired a new IP address,
so clear the SFTP session when it disconnects so the info is
requested again and the channel host rechecked.