### PR TITLE
refactor(device): use GDataInputStream's async methods

### DIFF
--- a/tests/extra/tsan.supp
+++ b/tests/extra/tsan.supp
@@ -8,6 +8,9 @@
 #
 mutex:valent_extension_get_type_once
 
+# /src/libvalent/device/valent-channel.c (valent_channel_download)
+race:valent_mock_channel_class_init
+
 #
 # Uninstrumented libraries (Yes, all of these are really necessary)
 #


### PR DESCRIPTION
Use the built-in async features of GDataInputStream, rather than a bespoke task thread.