### PR TITLE
fix(xdp): fix memory leak and NULL dereference

### DIFF
--- a/src/plugins/xdp/valent-xdp-input.c
+++ b/src/plugins/xdp/valent-xdp-input.c
@@ -50,6 +50,7 @@ on_session_started (XdpSession   *session,
                     gpointer      user_data)
 {
   ValentXdpInput *self = VALENT_XDP_INPUT (user_data);
+  g_autofree char *session_token = NULL;
   g_autoptr (GError) error = NULL;
 
   self->started = xdp_session_start_finish (session, res, &error);
@@ -59,9 +60,10 @@ on_session_started (XdpSession   *session,
       g_clear_object (&self->session);
     }
 
+  session_token = xdp_session_get_restore_token (session);
   g_settings_set_string (self->settings,
                          "session-token",
-                         xdp_session_get_restore_token (session));
+                         session_token ? session_token : "");
   self->session_starting = FALSE;
 }
 


### PR DESCRIPTION
`xdp_session_get_restore_token()` is nullable and transfer-full,
so catch the possible `NULL` and free the string otherwise.

cc https://github.com/andyholmes/valent/issues/869