### PR TITLE
feat(lan): identify to mDNS hosts when broadcasting

### DIFF
--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -1189,7 +1189,21 @@ valent_lan_channel_service_identify (ValentChannelService *service,
   else
     {
       g_autoptr (GSocketAddress) address = NULL;
+      unsigned int n_items;
 
+      /* Identify to each DNS-SD service
+       */
+      n_items = g_list_model_get_n_items (self->dnssd);
+      for (unsigned int i = 0; i < n_items; i++)
+        {
+          g_autoptr (GSocketConnectable) item = NULL;
+
+          service = g_list_model_get_item (self->dnssd, i);
+          valent_lan_channel_service_socket_queue_resolve (self, item);
+        }
+
+      /* Broadcast to the network
+       */
       address = g_inet_socket_address_new_from_string (self->broadcast_address,
                                                        self->port);
       valent_lan_channel_service_socket_queue (self, address);


### PR DESCRIPTION
When the `identify()` vfunc is invoked for the LAN service with
no target, identify to each discovered DNS-SD service directly
before broadcasting a general UDP packet.