### PR TITLE
fix(connectivity_report): correct values reported by modemmanager

### DIFF
--- a/src/plugins/connectivity_report/valent-telephony.c
+++ b/src/plugins/connectivity_report/valent-telephony.c
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <math.h>
+
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
 #include <valent.h>
@@ -382,7 +384,7 @@ valent_telephony_serialize_modem (GDBusProxy *proxy)
   gboolean signal_recent;
   int32_t state;
   const char *telephony_type;
-  int64_t signal_strength = -1;
+  int64_t signal_strength = 0;
 
   g_assert (G_IS_DBUS_PROXY (proxy));
 
@@ -403,7 +405,12 @@ valent_telephony_serialize_modem (GDBusProxy *proxy)
   telephony_type = get_telephony_type_string (access_technologies);
 
   if (state >= MM_MODEM_STATE_ENABLED)
-    signal_strength = (int64_t)(signal_quality / 20);
+    {
+      if (signal_quality >= 100)
+        signal_strength = 4;
+      else
+        signal_strength = (int64_t)floor (signal_quality / 20);
+    }
 
   /* Serialize to a JsonNode */
   builder = json_builder_new ();

--- a/tests/fixtures/data/plugin-connectivity_report.json
+++ b/tests/fixtures/data/plugin-connectivity_report.json
@@ -46,7 +46,7 @@
       "signalStrengths": {
         "1": {
           "networkType": "Unknown",
-          "signalStrength": -1
+          "signalStrength": 0
         }
       }
     }
@@ -118,7 +118,7 @@
       "signalStrengths": {
         "1": {
           "networkType": "HSPA",
-          "signalStrength": 5
+          "signalStrength": 4
         }
       }
     }
@@ -130,7 +130,7 @@
       "signalStrengths": {
         "1": {
           "networkType": "5G",
-          "signalStrength": 5
+          "signalStrength": 4
         }
       }
     }

--- a/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
+++ b/tests/plugins/connectivity_report/test-connectivity_report-plugin.c
@@ -120,7 +120,7 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
   g_assert_true (g_variant_lookup (signal_info, "icon-name", "&s", &icon_name));
 
   g_assert_cmpstr (network_type, ==, "Unknown");
-  g_assert_cmpint (signal_strength, ==, -1);
+  g_assert_cmpint (signal_strength, ==, 0);
   g_assert_cmpstr (icon_name, ==, "network-cellular-symbolic");
 
   g_clear_pointer (&signal_info, g_variant_unref);
@@ -257,7 +257,7 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
   g_assert_true (g_variant_lookup (signal_info, "icon-name", "&s", &icon_name));
 
   g_assert_cmpstr (network_type, ==, "HSPA");
-  g_assert_cmpint (signal_strength, ==, 5);
+  g_assert_cmpint (signal_strength, ==, 4);
   g_assert_cmpstr (icon_name, ==, "network-cellular-hspa-symbolic");
 
   g_clear_pointer (&signal_info, g_variant_unref);
@@ -280,7 +280,7 @@ test_connectivity_report_plugin_handle_update (ValentTestFixture *fixture,
   g_assert_true (g_variant_lookup (signal_info, "icon-name", "&s", &icon_name));
 
   g_assert_cmpstr (network_type, ==, "5G");
-  g_assert_cmpint (signal_strength, ==, 5);
+  g_assert_cmpint (signal_strength, ==, 4);
   g_assert_cmpstr (icon_name, ==, "network-cellular-5g-symbolic");
 
   g_clear_pointer (&signal_info, g_variant_unref);
@@ -317,7 +317,7 @@ test_connectivity_report_plugin_send_update (ValentTestFixture *fixture,
   signal_strength = json_object_get_int_member (signal_meta, "signalStrength");
 
   g_assert_cmpstr (network_type, ==, "Unknown");
-  g_assert_cmpint (signal_strength, ==, -1);
+  g_assert_cmpint (signal_strength, ==, 0);
 
   json_node_unref (packet);
 
@@ -351,7 +351,7 @@ test_connectivity_report_plugin_send_update (ValentTestFixture *fixture,
   signal_strength = json_object_get_int_member (signal_meta, "signalStrength");
 
   g_assert_cmpstr (network_type, ==, "Unknown");
-  g_assert_cmpint (signal_strength, ==, -1);
+  g_assert_cmpint (signal_strength, ==, 0);
 
   json_node_unref (packet);
 

--- a/tests/plugins/connectivity_report/test-telephony.c
+++ b/tests/plugins/connectivity_report/test-telephony.c
@@ -69,7 +69,7 @@ test_telephony_proxy (void)
   signal_meta = json_object_get_object_member (signal_obj, "0");
 
   g_assert_cmpstr (json_object_get_string_member (signal_meta, "networkType"), ==, "Unknown");
-  g_assert_cmpint (json_object_get_int_member (signal_meta, "signalStrength"), ==, -1);
+  g_assert_cmpint (json_object_get_int_member (signal_meta, "signalStrength"), ==, 0);
   g_clear_pointer (&signal_node, json_node_unref);
 
   /* Modem should be online */
@@ -93,7 +93,7 @@ test_telephony_proxy (void)
   signal_meta = json_object_get_object_member (signal_obj, "0");
 
   g_assert_cmpstr (json_object_get_string_member (signal_meta, "networkType"), ==, "Unknown");
-  g_assert_cmpint (json_object_get_int_member (signal_meta, "signalStrength"), ==, -1);
+  g_assert_cmpint (json_object_get_int_member (signal_meta, "signalStrength"), ==, 0);
   g_clear_pointer (&signal_node, json_node_unref);
 
   /* Modem should be removed */


### PR DESCRIPTION
Correct the values and tests for `ValentTelephony` used for local connectivity monitoring.