### PR TITLE
fix(device): take the basename of the hostname as a default

### DIFF
--- a/src/libvalent/device/valent-channel-service.c
+++ b/src/libvalent/device/valent-channel-service.c
@@ -233,7 +233,10 @@ on_device_name_changed (GSettings            *settings,
   name = g_settings_get_string (settings, "name");
   if (name == NULL || *name == '\0')
     {
-      g_settings_set_string (settings, "name", g_get_host_name ());
+      g_auto (GStrv) hostname = NULL;
+
+      hostname = g_strsplit (g_get_host_name (), ".", 2);
+      g_settings_set_string (settings, "name", hostname[0]);
       return;
     }
 


### PR DESCRIPTION
In the case that the local device's hostname is used as a default, use the basename in case it contains invalid characters.

closes #893