### PR TITLE
refactor(bluez): drop client profile

### DIFF
--- a/src/plugins/bluez/valent-bluez-profile.h
+++ b/src/plugins/bluez/valent-bluez-profile.h
@@ -8,18 +8,11 @@
 G_BEGIN_DECLS
 
 /**
- * VALENT_BLUEZ_PROFILE_CLIENT_PATH: (value "/ca/andyholmes/Valent/bluez/Client")
+ * VALENT_BLUEZ_PROFILE_PATH: (value "/ca/andyholmes/Valent/bluez")
  *
  * The object path for the KDE Connect bluetooth profile.
  */
-#define VALENT_BLUEZ_PROFILE_CLIENT_PATH "/ca/andyholmes/Valent/bluez/Client"
-
-/**
- * VALENT_BLUEZ_PROFILE_SERVER_PATH: (value "/ca/andyholmes/Valent/bluez/SERVER")
- *
- * The object path for the KDE Connect bluetooth profile.
- */
-#define VALENT_BLUEZ_PROFILE_SERVER_PATH "/ca/andyholmes/Valent/bluez/Server"
+#define VALENT_BLUEZ_PROFILE_PATH "/ca/andyholmes/Valent/bluez"
 
 /**
  * VALENT_BLUEZ_PROFILE_UUID: (value "185f3df4-3268-4e3f-9fca-d4d5059915bd")
@@ -33,7 +26,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (ValentBluezProfile, valent_bluez_profile, VALENT, BLUEZ_PROFILE, GDBusInterfaceSkeleton)
 
-ValentBluezProfile * valent_bluez_profile_new             (gboolean              is_client);
+ValentBluezProfile * valent_bluez_profile_new             (void);
 void                 valent_bluez_profile_register        (ValentBluezProfile   *profile,
                                                            GDBusConnection      *connection,
                                                            GCancellable         *cancellable,

--- a/tests/plugins/bluez/test-bluez-plugin.c
+++ b/tests/plugins/bluez/test-bluez-plugin.c
@@ -215,7 +215,7 @@ dbusmock_new_connection (BluezBackendFixture *fixture)
 
   g_dbus_connection_call_with_unix_fd_list (fixture->connection,
                                             unique_name,
-                                            VALENT_BLUEZ_PROFILE_SERVER_PATH,
+                                            VALENT_BLUEZ_PROFILE_PATH,
                                             "org.bluez.Profile1",
                                             "NewConnection",
                                             g_variant_new ("(oh@a{sv})",


### PR DESCRIPTION
This is unneeded and apparently causes problems when registering with the same UUID as the service profile.