### PR TITLE
fix: use Glycin's install prefix to find loaders in tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ add_project_link_arguments(cc.get_supported_link_arguments(project_link_args),
 glib_version = '>= 2.80.0'
 gdk_pixbuf_version = '>= 2.0'
 gtk_version = '>= 4.15.2'
+glycin_version = '>= 2.0'
 gnutls_version = '>= 3.1.3'
 json_glib_version = '>= 1.6.0'
 libpeas_version = '>= 2.0.0'
@@ -167,6 +168,7 @@ libm_dep = cc.find_library('m', required: true)
 gio_dep = dependency('gio-2.0', version: glib_version)
 gio_unix_dep = dependency('gio-unix-2.0', version: glib_version)
 gdk_pixbuf_dep = dependency('gdk-pixbuf-2.0', version: gdk_pixbuf_version)
+glycin_dep = dependency('glycin-2', version: glycin_version)
 gnutls_dep = dependency('gnutls', version: gnutls_version)
 json_glib_dep = dependency('json-glib-1.0', version: json_glib_version)
 libpeas_dep = dependency('libpeas-2', version: libpeas_version)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -22,6 +22,8 @@ tests_env = [
   'GVFS_DISABLE_FUSE=true',
   # https://gnome.pages.gitlab.gnome.org/gobject-introspection/girepository/GIRepository.html
   'GI_TYPELIB_PATH=@0@:$(GI_TYPELIB_PATH)'.format(':'.join(typelib_dirs)),
+  # https://gitlab.gnome.org/GNOME/glycin/-/blob/main/CONTRIBUTING.md
+  'GLYCIN_DATA_DIR=@0@/share'.format(glycin_dep.get_variable('prefix')),
   # https://docs.gtk.org/gtk4/running.html
   'GDK_BACKEND=wayland,x11',
   'GDK_DEBUG=default-settings',
@@ -58,6 +60,8 @@ installed_tests_env = [
   'GSETTINGS_BACKEND=memory',
   'GSETTINGS_SCHEMA_DIR=@0@'.format(join_paths(datadir, 'glib-2.0', 'schemas')),
   'GVFS_DISABLE_FUSE=true',
+  # https://gitlab.gnome.org/GNOME/glycin/-/blob/main/CONTRIBUTING.md
+  'GLYCIN_DATA_DIR=@0@/share'.format(glycin_dep.get_variable('prefix')),
   # https://docs.gtk.org/gtk4/running.html
   'GDK_DEBUG=default-settings',
   'GTK_A11Y=test',


### PR DESCRIPTION
The standard call to `g_content_type_set_mime_dirs (NULL)` before `g_test_init()` doesn't work for GdkPixbuf, so pull the prefix from Glycin's dependency object and pass it via the env variable `GLYCIN_DATA_DIR`.