### PR TITLE
refactor(device): drop synchronous packet helpers

### DIFF
--- a/src/libvalent/device/valent-packet.h
+++ b/src/libvalent/device/valent-packet.h
@@ -155,7 +155,7 @@ VALENT_AVAILABLE_IN_1_0
 gboolean     valent_packet_validate           (JsonNode             *packet,
                                                GError              **error);
 VALENT_AVAILABLE_IN_1_0
-void         valent_packet_from_stream_async  (GInputStream         *stream,
+void         valent_packet_from_stream        (GInputStream         *stream,
                                                gssize                max_len,
                                                GCancellable         *cancellable,
                                                GAsyncReadyCallback   callback,
@@ -165,12 +165,7 @@ JsonNode   * valent_packet_from_stream_finish (GInputStream         *stream,
                                                GAsyncResult         *result,
                                                GError              **error);
 VALENT_AVAILABLE_IN_1_0
-JsonNode   * valent_packet_from_stream        (GInputStream         *stream,
-                                               gssize                max_len,
-                                               GCancellable         *cancellable,
-                                               GError              **error);
-VALENT_AVAILABLE_IN_1_0
-void         valent_packet_to_stream_async    (GOutputStream        *stream,
+void         valent_packet_to_stream          (GOutputStream        *stream,
                                                JsonNode             *packet,
                                                GCancellable         *cancellable,
                                                GAsyncReadyCallback   callback,
@@ -178,11 +173,6 @@ void         valent_packet_to_stream_async    (GOutputStream        *stream,
 VALENT_AVAILABLE_IN_1_0
 gboolean     valent_packet_to_stream_finish   (GOutputStream        *stream,
                                                GAsyncResult         *result,
-                                               GError              **error);
-VALENT_AVAILABLE_IN_1_0
-gboolean     valent_packet_to_stream          (GOutputStream        *stream,
-                                               JsonNode             *packet,
-                                               GCancellable         *cancellable,
                                                GError              **error);
 VALENT_AVAILABLE_IN_1_0
 char       * valent_packet_serialize          (JsonNode             *packet,

--- a/src/plugins/bluez/valent-mux-connection.c
+++ b/src/plugins/bluez/valent-mux-connection.c
@@ -1049,16 +1049,16 @@ handshake_protocol_task_cb (GObject      *object,
     }
 
   data->connection = g_object_ref (stream);
-  valent_packet_to_stream_async (g_io_stream_get_output_stream (data->connection),
-                                 data->identity,
-                                 cancellable,
-                                 (GAsyncReadyCallback)handshake_write_identity_cb,
-                                 g_object_ref (task));
-  valent_packet_from_stream_async (g_io_stream_get_input_stream (data->connection),
-                                   IDENTITY_BUFFER_MAX,
-                                   cancellable,
-                                   (GAsyncReadyCallback)handshake_read_identity_cb,
-                                   g_object_ref (task));
+  valent_packet_to_stream (g_io_stream_get_output_stream (data->connection),
+                           data->identity,
+                           cancellable,
+                           (GAsyncReadyCallback)handshake_write_identity_cb,
+                           g_object_ref (task));
+  valent_packet_from_stream (g_io_stream_get_input_stream (data->connection),
+                             IDENTITY_BUFFER_MAX,
+                             cancellable,
+                             (GAsyncReadyCallback)handshake_read_identity_cb,
+                             g_object_ref (task));
 }
 
 static void

--- a/src/plugins/lan/valent-lan-channel-service.c
+++ b/src/plugins/lan/valent-lan-channel-service.c
@@ -372,16 +372,16 @@ valent_lan_connection_handshake_cb (GSocketConnection *connection,
   if (data->protocol_version >= VALENT_NETWORK_PROTOCOL_V8)
     {
       identity = valent_channel_service_ref_identity (service);
-      valent_packet_to_stream_async (g_io_stream_get_output_stream (data->connection),
-                                     identity,
-                                     cancellable,
-                                     (GAsyncReadyCallback)handshake_write_identity_cb,
-                                     g_object_ref (task));
-      valent_packet_from_stream_async (g_io_stream_get_input_stream (data->connection),
-                                       IDENTITY_BUFFER_MAX,
-                                       cancellable,
-                                       (GAsyncReadyCallback)handshake_read_identity_cb,
-                                       g_object_ref (task));
+      valent_packet_to_stream (g_io_stream_get_output_stream (data->connection),
+                               identity,
+                               cancellable,
+                               (GAsyncReadyCallback)handshake_write_identity_cb,
+                               g_object_ref (task));
+      valent_packet_from_stream (g_io_stream_get_input_stream (data->connection),
+                                 IDENTITY_BUFFER_MAX,
+                                 cancellable,
+                                 (GAsyncReadyCallback)handshake_read_identity_cb,
+                                 g_object_ref (task));
     }
   else
     {
@@ -502,11 +502,11 @@ g_socket_client_connect_to_host_cb (GSocketClient *client,
    * so the local device must send its identity before TLS negotiation.
    */
   identity = valent_channel_service_ref_identity (service);
-  valent_packet_to_stream_async (g_io_stream_get_output_stream (data->connection),
-                                 identity,
-                                 cancellable,
-                                 (GAsyncReadyCallback)valent_packet_to_stream_cb,
-                                 g_object_ref (task));
+  valent_packet_to_stream (g_io_stream_get_output_stream (data->connection),
+                           identity,
+                           cancellable,
+                           (GAsyncReadyCallback)valent_packet_to_stream_cb,
+                           g_object_ref (task));
 }
 
 /*
@@ -540,11 +540,11 @@ on_incoming_connection (ValentChannelService *service,
   /* The incoming connection is in response to the local device's broadcast,
    * so the remote device must send its identity before TLS negotiation.
    */
-  valent_packet_from_stream_async (g_io_stream_get_input_stream (data->connection),
-                                   IDENTITY_BUFFER_MAX,
-                                   data->task_cancellable,
-                                   (GAsyncReadyCallback)valent_packet_from_stream_cb,
-                                   g_object_ref (task));
+  valent_packet_from_stream (g_io_stream_get_input_stream (data->connection),
+                             IDENTITY_BUFFER_MAX,
+                             data->task_cancellable,
+                             (GAsyncReadyCallback)valent_packet_from_stream_cb,
+                             g_object_ref (task));
 
   return TRUE;
 }

--- a/tests/plugins/lan/test-lan-plugin.c
+++ b/tests/plugins/lan/test-lan-plugin.c
@@ -260,11 +260,11 @@ test_lan_service_incoming_broadcast (LanTestFixture *fixture,
    * so we now expect the test service to write its identity packet.
    */
   VALENT_TEST_CHECK ("The service writes its identity after connecting");
-  valent_packet_from_stream_async (g_io_stream_get_input_stream (G_IO_STREAM (connection)),
-                                   IDENTITY_BUFFER_MAX,
-                                   NULL,
-                                   (GAsyncReadyCallback)valent_packet_from_stream_cb,
-                                   &peer_identity);
+  valent_packet_from_stream (g_io_stream_get_input_stream (G_IO_STREAM (connection)),
+                             IDENTITY_BUFFER_MAX,
+                             NULL,
+                             (GAsyncReadyCallback)valent_packet_from_stream_cb,
+                             &peer_identity);
   valent_test_await_pointer (&peer_identity);
 
   VALENT_TEST_CHECK ("The service uses a valid device ID");
@@ -285,16 +285,16 @@ test_lan_service_incoming_broadcast (LanTestFixture *fixture,
   if (protocol_version >= VALENT_NETWORK_PROTOCOL_V8)
     {
       VALENT_TEST_CHECK ("The service exchanges identity packets over TLS");
-      valent_packet_to_stream_async (g_io_stream_get_output_stream (tls_stream),
-                                     fixture->peer_identity,
-                                     NULL,
-                                     NULL,
-                                     NULL);
-      valent_packet_from_stream_async (g_io_stream_get_input_stream (tls_stream),
-                                       IDENTITY_BUFFER_MAX,
-                                       NULL,
-                                       NULL,
-                                       NULL);
+      valent_packet_to_stream (g_io_stream_get_output_stream (tls_stream),
+                               fixture->peer_identity,
+                               NULL,
+                               NULL,
+                               NULL);
+      valent_packet_from_stream (g_io_stream_get_input_stream (tls_stream),
+                                 IDENTITY_BUFFER_MAX,
+                                 NULL,
+                                 NULL,
+                                 NULL);
     }
 
   peer_certificate = g_tls_connection_get_peer_certificate (G_TLS_CONNECTION (tls_stream));
@@ -407,11 +407,11 @@ test_lan_service_outgoing_broadcast (LanTestFixture *fixture,
       valent_test_await_timeout (HANDSHAKE_TIMEOUT_MS);
     }
 
-  valent_packet_to_stream_async (g_io_stream_get_output_stream (G_IO_STREAM (connection)),
-                                 fixture->peer_identity,
-                                 NULL,
-                                 (GAsyncReadyCallback)valent_packet_to_stream_cb,
-                                 &done);
+  valent_packet_to_stream (g_io_stream_get_output_stream (G_IO_STREAM (connection)),
+                           fixture->peer_identity,
+                           NULL,
+                           (GAsyncReadyCallback)valent_packet_to_stream_cb,
+                           &done);
   valent_test_await_boolean (&done);
 
   VALENT_TEST_CHECK ("The service negotiates TLS connections as the client");
@@ -428,16 +428,16 @@ test_lan_service_outgoing_broadcast (LanTestFixture *fixture,
   if (protocol_version >= VALENT_NETWORK_PROTOCOL_V8)
     {
       VALENT_TEST_CHECK ("The service exchanges identity packets over TLS");
-      valent_packet_to_stream_async (g_io_stream_get_output_stream (tls_stream),
-                                     fixture->peer_identity,
-                                     NULL,
-                                     NULL,
-                                     NULL);
-      valent_packet_from_stream_async (g_io_stream_get_input_stream (tls_stream),
-                                       IDENTITY_BUFFER_MAX,
-                                       NULL,
-                                       NULL,
-                                       NULL);
+      valent_packet_to_stream (g_io_stream_get_output_stream (tls_stream),
+                               fixture->peer_identity,
+                               NULL,
+                               NULL,
+                               NULL);
+      valent_packet_from_stream (g_io_stream_get_input_stream (tls_stream),
+                                 IDENTITY_BUFFER_MAX,
+                                 NULL,
+                                 NULL,
+                                 NULL);
     }
 
   peer_certificate = g_tls_connection_get_peer_certificate (G_TLS_CONNECTION (tls_stream));


### PR DESCRIPTION
Drop the synchronous versions of `valent_packet_to_stream()` and `valent_packet_from_stream()`.