### PR TITLE
fix(fdo): cleanups and fixes for freedesktop notifications adapter

### DIFF
--- a/src/plugins/fdo/valent-fdo-notifications.c
+++ b/src/plugins/fdo/valent-fdo-notifications.c
@@ -85,10 +85,6 @@ _g_icon_new_for_variant (GVariant *image_data)
   gboolean has_alpha;
   int32_t bits_per_sample, n_channels;
   g_autoptr (GVariant) data_variant = NULL;
-  const unsigned char *data = NULL;
-  size_t data_len = 0;
-  size_t expected_len = 0;
-
   g_autoptr (GlyCreator) creator = NULL;
   g_autoptr (GlyNewFrame) frame = NULL;
   g_autoptr (GlyEncodedImage) image = NULL;
@@ -104,23 +100,8 @@ _g_icon_new_for_variant (GVariant *image_data)
                  &bits_per_sample,
                  &n_channels,
                  &data_variant);
-
-  data = g_variant_get_data (data_variant);
-  data_len = g_variant_get_size (data_variant);
-  expected_len = (height - 1) * rowstride + width
-    * ((n_channels * bits_per_sample + 7) / 8);
-
-  if (expected_len != data_len)
-    {
-      g_warning ("Expected image data to be of length %zu not %zu",
-                 expected_len,
-                 data_len);
-      return NULL;
-    }
-
-  g_return_val_if_fail (bits_per_sample == 8, NULL);
-  g_return_val_if_fail ((has_alpha && n_channels == 4) ||
-                        (!has_alpha && n_channels == 3), NULL);
+  texture = g_bytes_new (g_variant_get_data (data_variant),
+                         g_variant_get_size (data_variant));
 
   creator = gly_creator_new ("image/png", &error);
   if (creator == NULL)
@@ -129,7 +110,6 @@ _g_icon_new_for_variant (GVariant *image_data)
       return NULL;
     }
 
-  texture = g_bytes_new (data, data_len);
   frame = gly_creator_add_frame_with_stride (creator,
                                              width,
                                              height,


### PR DESCRIPTION
- [fix(fdo): remove filter from the monitor connection, not session](https://github.com/andyholmes/valent/commit/dd010a43e489a9f081cd90df9ee8d20e72fefb74)
- [fix(fdo): complete GTask to avoid debug warning](https://github.com/andyholmes/valent/commit/7c0600ca2a1e33943d1322ffe826d24ff3f115b0)
- [fix(fdo): use g_idle_add_full() to dispatch correctly](https://github.com/andyholmes/valent/commit/680d50bc01dd013d2b75a33f9e09cf80cb3e5d6d)
- [fix(fdo): don't report adapter active until the name owner appears](https://github.com/andyholmes/valent/commit/e3d703ac3a5b853a7c53db4ba18aaee0b543626f)
- [refactor(fdo): cleanup pixbuf loading path](https://github.com/andyholmes/valent/commit/c02f86a8ccc88ee2309a90dc1a93b50911205105)