### PR TITLE
refactor(systemd): deprecate `requestSinks`

### DIFF
--- a/src/plugins/systemvolume/valent-systemvolume-device.c
+++ b/src/plugins/systemvolume/valent-systemvolume-device.c
@@ -222,26 +222,6 @@ struct _ValentSystemvolumeDevice
 
 G_DEFINE_FINAL_TYPE (ValentSystemvolumeDevice, valent_systemvolume_device, VALENT_TYPE_MIXER_ADAPTER)
 
-#if 0
-static void
-valent_systemvolume_device_request_sinks (ValentSystemvolumeDevice *self)
-{
-  g_autoptr (JsonBuilder) builder = NULL;
-  g_autoptr (JsonNode) packet = NULL;
-
-  valent_packet_init (&builder, "kdeconnect.systemvolume.request");
-  json_builder_set_member_name (builder, "requestSinks");
-  json_builder_add_boolean_value (builder, TRUE);
-  packet = valent_packet_end (&builder);
-
-  valent_device_send_packet (self->device,
-                             packet,
-                             self->cancellable,
-                             (GAsyncReadyCallback) valent_device_send_packet_cb,
-                             NULL);
-}
-#endif
-
 /*
  * ValentMixerAdapter
  */

--- a/src/plugins/systemvolume/valent-systemvolume-plugin.c
+++ b/src/plugins/systemvolume/valent-systemvolume-plugin.c
@@ -404,13 +404,15 @@ valent_systemvolume_plugin_handle_request (ValentSystemvolumePlugin *self,
 {
   g_assert (VALENT_IS_SYSTEMVOLUME_PLUGIN (self));
 
-  /* A request for a list of audio outputs */
-  if (valent_packet_check_field (packet, "requestSinks"))
-    valent_systemvolume_plugin_send_sinklist (self);
-
-  /* A request to change an audio output */
-  else if (valent_packet_check_field (packet, "name"))
+  /* A request to change an audio output
+   */
+  if (valent_packet_check_field (packet, "name"))
     valent_systemvolume_plugin_handle_sink_change (self, packet);
+
+  /* A request for a list of audio outputs (deprecated)
+   */
+  else if (valent_packet_check_field (packet, "requestSinks"))
+    valent_systemvolume_plugin_send_sinklist (self);
 
   else
     g_warn_if_reached ();


### PR DESCRIPTION
The deprecation of this hasn't propagated through clients yet, but we can deprecate the parts we don't need.